### PR TITLE
WIP: Add CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,192 @@
+---
+version: 2.1
+
+executors:
+  docker:
+    docker:
+      - image: &image circleci/node:11
+  machine:
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-1604:201903-01
+
+workflows:
+  version: 2
+  pipeline:
+    jobs:
+      - build:
+          name: build-dev
+          target: dev
+          requires:
+            - install
+      - build:
+          name: build-prod
+          target: prod
+          requires:
+            - install
+      - docker:
+          name: docker-dev
+          target: dev
+          requires:
+            - build-dev
+      - docker:
+          name: docker-prod
+          target: prod
+          requires:
+            - build-prod
+      - documentation:
+          requires:
+            - install
+      - install
+      - lint:
+          requires:
+            - install
+      - prettier:
+          requires:
+            - install
+      - results:
+          requires:
+            - build-dev
+            - build-prod
+            - docker-dev
+            - docker-prod
+            - documentation
+      - test-e2e:
+          requires:
+            - install
+      - test-unit:
+          requires:
+            - install
+
+jobs:
+  build:
+    executor: docker
+    parameters:
+      target:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: npm run build:<< parameters.target >>
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist-<< parameters.target >>
+
+  docker:
+    executor: machine
+    parameters:
+      target:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: build
+          command: |
+            docker build -t $IMAGE -f Dockerfile-circleci \
+              --build-arg SOURCE=dist-<< parameters.target >> .
+            docker save -o $IMAGE.tar $IMAGE
+          environment:
+            IMAGE: relnotes-<< parameters.target >>
+      - persist_to_workspace:
+          root: .
+          paths:
+            - relnotes-<< parameters.target >>.tar
+
+  documentation:
+    executor: docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: build
+          command: npm run doc
+      - persist_to_workspace:
+          root: .
+          paths:
+            - documentation
+
+  install:
+    executor: docker
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-npm-install-{{ checksum "package.json" }}
+      - run: npm install
+      - save_cache:
+          key: v1-npm-install-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+
+  lint:
+    executor: docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: lint
+          command: npm run lint
+
+  prettier:
+    executor: docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: check
+          # TODO: fix me
+          command: npm run check-prettier || true
+
+  results:
+    executor: docker
+    steps:
+      - attach_workspace:
+          at: .
+      - store_artifacts:
+          path: dist-dev
+          destination: dist/dev
+      - store_artifacts:
+          path: dist-prod
+          destination: dist/prod
+      - store_artifacts:
+          path: relnotes-dev.tar
+          destination: images/relnotes-dev.tar
+      - store_artifacts:
+          path: relnotes-prod.tar
+          destination: images/relnotes-prod.tar
+      - store_artifacts:
+          path: documentation
+          destination: documentation
+
+  test-e2e:
+    executor: docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: test
+          # TODO: activate me
+          command: echo npm run e2e:ci
+
+  test-unit:
+    executor: docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: test
+          # TODO: coverage report and test run
+          command: echo npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
+/dist*
 /tmp
 /out-tsc
 # Only exists if Bazel was run

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+documentation

--- a/Dockerfile-circleci
+++ b/Dockerfile-circleci
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+COPY nginx-gzip.conf /etc/nginx/conf.d/
+ARG SOURCE
+COPY $SOURCE /usr/share/nginx/html/

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod --build-optimizer",
+    "build:dev": "ng build --output-path dist-dev",
+    "build:prod": "ng build --prod --build-optimizer --output-path dist-prod",
     "docker:build": "docker build -t relnotes .",
-    "docker:run": "docker run -i -t -p 80:80 --name relnotes relnotes",
+    "docker:run": "docker run -i -t -p 80:80 --rm --name relnotes relnotes",
     "docker:build:run": "npm run docker:build && npm run docker:run",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Hey :wave:, this PR adds the CircleCI test pipeline.

An example run on openSUSE/release-notes and be found here:
https://circleci.com/workflow-run/3f8c0d40-40b1-43f5-818b-3fb39d034223

The following CircleCI settings should be ensured by a repository administrator 
https://circleci.com/gh/kubernetes-sigs/release-notes/edit#advanced-settings:
- GitHub Status updates: **On**
- Free and Open Source: **On**
- Build forked pull requests: **Off**
- Pass secrets to builds from forked pull requests: **Off**
- Only build pull requests: **Off**
- Auto-cancel redundant builds: **On**
- Enable pipelines: **On**

Please ensure that the parallelism is set to the maximum (for free accounts: 4) here:
https://circleci.com/gh/kubernetes-sigs/release-notes/edit#parallel-builds

A good plan would be to run the first master build **after** this PR got merged via:
https://circleci.com/setup-project/gh/kubernetes-sigs/release-notes

---

Things to be done here:
- [ ] apply prettier fixes and make pipeline job mandatory
- [ ] enable jest unit testing (#18)
- [ ] enable cypress end-to-end testing (#20)

Relates to #1