### PR TITLE
Fix unit-tests for new filter model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5572,14 +5572,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5594,20 +5592,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5724,8 +5719,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5737,7 +5731,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5752,7 +5745,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5760,14 +5752,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5786,7 +5776,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5867,8 +5856,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5880,7 +5868,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6002,7 +5989,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/app/notes/notes.actions.spec.ts
+++ b/src/app/notes/notes.actions.spec.ts
@@ -7,10 +7,11 @@ import {
   GetNotesSuccess,
 } from './notes.actions';
 import { notesMock } from './notes.model.mock';
+import { Filter } from '@app/shared/model/options.model';
 
 describe('NotesActions', () => {
   // Given
-  const filter = { key: 'value' };
+  const filter = new Filter();
 
   it('should be able to create a Failed action', () => {
     // Given

--- a/src/app/notes/notes.component.spec.ts
+++ b/src/app/notes/notes.component.spec.ts
@@ -7,8 +7,11 @@ import { State } from '@app/app.reducer';
 import { NotesComponent } from './notes.component';
 import { notesReducer } from './notes.reducer';
 import { DoFilter } from './notes.actions';
+import { Filter } from '@app/shared/model/options.model';
 
 describe('NotesComponent', () => {
+  const filter = new Filter();
+
   let fixture: ComponentFixture<NotesComponent>;
   let component: NotesComponent;
   let store: Store<State>;
@@ -51,10 +54,10 @@ describe('NotesComponent', () => {
 
   it('should succeed to update', () => {
     // Given
-    const action = new DoFilter(undefined, {});
+    const action = new DoFilter(undefined, filter);
 
     // When
-    component.update({});
+    component.update(filter);
 
     // Then
     expect(store.dispatch).toHaveBeenCalledWith(action);

--- a/src/app/notes/notes.effects.spec.ts
+++ b/src/app/notes/notes.effects.spec.ts
@@ -9,8 +9,11 @@ import { NotesEffects } from './notes.effects';
 import { DoFilter, DoFilterSuccess, Failed, GetNotes, GetNotesSuccess } from './notes.actions';
 import { notesMock } from './notes.model.mock';
 import { LoggerService } from '@shared/services/logger.service';
+import { Filter } from '@app/shared/model/options.model';
 
 describe('NotesEffects', () => {
+  const filter = new Filter();
+
   let effects: NotesEffects;
   let actions: Observable<any>;
   let httpMock: HttpTestingController;
@@ -29,7 +32,7 @@ describe('NotesEffects', () => {
 
   describe('GetNotes', () => {
     it('should succeed with empty filter', () => {
-      const action = new GetNotes({});
+      const action = new GetNotes(filter);
       const completion = new GetNotesSuccess(notesMock);
 
       actions = hot('-a---', { a: action });
@@ -42,7 +45,7 @@ describe('NotesEffects', () => {
 
     it('should fail if NotesService fails', () => {
       const error = 'error';
-      const action = new GetNotes({});
+      const action = new GetNotes(filter);
       const completion = new Failed(error);
 
       actions = hot('-a---', { a: action });
@@ -56,7 +59,7 @@ describe('NotesEffects', () => {
 
   describe('DoFilter', () => {
     it('should succeed with empty filter', () => {
-      const action = new DoFilter(notesMock, {});
+      const action = new DoFilter(notesMock, filter);
       const completion = new DoFilterSuccess(notesMock);
 
       actions = hot('--a-', { a: action });
@@ -66,7 +69,9 @@ describe('NotesEffects', () => {
     });
 
     it('should succeed with non matching filter', () => {
-      const action = new DoFilter(notesMock, { key: 'value' });
+      const testFilter = new Filter();
+      testFilter.areas = ['area'];
+      const action = new DoFilter(notesMock, testFilter);
       const completion = new DoFilterSuccess([]);
 
       actions = hot('--a-', { a: action });

--- a/src/app/notes/notes.service.spec.ts
+++ b/src/app/notes/notes.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { NotesService } from './notes.service';
 import { LoggerService } from '@shared/services/logger.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { Filter } from '@app/shared/model/options.model';
 
 describe('NotesService', () => {
   let service: NotesService;
@@ -23,6 +24,6 @@ describe('NotesService', () => {
   });
 
   it('should succeed to get notes', () => {
-    expect(service.getNotes({})).toBeTruthy();
+    expect(service.getNotes(new Filter())).toBeTruthy();
   });
 });

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -91,7 +91,7 @@ describe('OptionsComponent', () => {
     expect(component.options.areas.length).toEqual(1);
     expect(component.options.kinds.length).toEqual(1);
     expect(component.options.sigs.length).toEqual(1);
-    expect(component.options.release_versions.length).toEqual(1);
+    expect(component.options.releaseVersions.length).toEqual(1);
   });
 
   it('should succeed to update options on empty/invalid notes', () => {
@@ -99,6 +99,6 @@ describe('OptionsComponent', () => {
     expect(component.options.areas.length).toEqual(0);
     expect(component.options.kinds.length).toEqual(0);
     expect(component.options.sigs.length).toEqual(0);
-    expect(component.options.release_versions.length).toEqual(1);
+    expect(component.options.releaseVersions.length).toEqual(1);
   });
 });


### PR DESCRIPTION
The latest merge of the `Filter()` model breaks up the unit tests, which is now fixed.