### PR TITLE
Add support for new JSON format

### DIFF
--- a/src/app/notes/notes.effects.ts
+++ b/src/app/notes/notes.effects.ts
@@ -11,7 +11,7 @@ import {
   GetNotesSuccess,
 } from './notes.actions';
 import { NotesService } from './notes.service';
-import { Note } from './notes.model';
+import { Note, NoteList } from './notes.model';
 import { Filter } from '@app/shared/model/options.model';
 import { LoggerService } from '@shared/services/logger.service';
 
@@ -23,7 +23,12 @@ export class NotesEffects {
     map((action: GetNotes) => action.filter),
     exhaustMap(filter =>
       this.notesService.getNotes(filter).pipe(
-        map((notes: Note[]) => {
+        map((noteList: NoteList) => {
+          const notes: Note[] = [];
+          for (const k of noteList.keys()) {
+            console.log('keys', k);
+            notes.push(noteList[k]);
+          }
           this.logger.debug('[Notes Effects:GetNotes] SUCCESS');
           return new GetNotesSuccess(notes);
         }),

--- a/src/app/notes/notes.effects.ts
+++ b/src/app/notes/notes.effects.ts
@@ -26,7 +26,6 @@ export class NotesEffects {
         map((noteList: NoteList) => {
           const notes: Note[] = [];
           for (const k of noteList.keys()) {
-            console.log('keys', k);
             notes.push(noteList[k]);
           }
           this.logger.debug('[Notes Effects:GetNotes] SUCCESS');

--- a/src/app/notes/notes.model.ts
+++ b/src/app/notes/notes.model.ts
@@ -14,3 +14,5 @@ export interface Note {
   action_required: boolean;
   release_version: string;
 }
+
+export type NoteList = Map<number, Note>;

--- a/src/app/notes/notes.service.ts
+++ b/src/app/notes/notes.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 
 import { Observable } from 'rxjs';
 
-import { Note } from './notes.model';
+import { Note, NoteList } from './notes.model';
 import { LoggerService } from '@shared/services/logger.service';
 import { Filter } from '@app/shared/model/options.model';
 
@@ -15,8 +15,8 @@ export class NotesService {
 
   constructor(private http: HttpClient, private logger: LoggerService) {}
 
-  getNotes(filter: Filter): Observable<Note[]> {
+  getNotes(filter: Filter): Observable<NoteList> {
     this.logger.debug('Gathering notes');
-    return this.http.get<Note[]>(this.noteUrl).pipe();
+    return this.http.get<NoteList>(this.noteUrl).pipe();
   }
 }


### PR DESCRIPTION
Cleaner version of #44 because I suck at `git` today

The release-notes tool generates a different JSON format. This supports it. 🎉

The format is different so it can (more efficiently) read in an existing JSON file, and merge new PRs with existing ones. It should be backwards compatible (from my testing) but we'll find out based on this PR. :)

A separate PR with an updated JSON file will be coming.