### PR TITLE
Add options model unit tests and fix lint

### DIFF
--- a/src/app/shared/model/options.model.spec.ts
+++ b/src/app/shared/model/options.model.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed, getTestBed } from '@angular/core/testing';
+import { Filter } from './options.model';
+import { environment } from '@environment';
+
+describe('OptionsModel', () => {
+  let filter: Filter;
+
+  // Given
+  const message = 'message';
+
+  beforeEach(() => {
+    filter = new Filter();
+  });
+
+  describe('toURI()', () => {
+    it('should succeed on initial state', () => {
+      // When
+      // Then
+      expect(filter.toURI()).toEqual({});
+      expect(filter.isEmpty()).toBeTruthy();
+    });
+  });
+
+  describe('setMarkdown', () => {
+    it('should succeed with markdown', () => {
+      // Given
+      const markdown = 'some markdown';
+
+      // When
+      filter.setMarkdown(markdown);
+
+      // Then
+      expect(filter.toURI()).toEqual({ markdown });
+      expect(filter.isEmpty()).toBeFalsy();
+    });
+  });
+});

--- a/src/app/shared/model/options.model.ts
+++ b/src/app/shared/model/options.model.ts
@@ -12,7 +12,7 @@ export class Options {
  * A generic filter abstraction based on the Options type
  */
 export class Filter extends Options {
-  markdown = '';
+  private markdown = '';
 
   /**
    * Method to set the markdown attribute
@@ -44,16 +44,14 @@ export class Filter extends Options {
   public toURI(): object {
     const friendly = {};
     for (const key of Object.keys(this)) {
-      /* tslint:disable:no-string-literal */
       if (key !== 'markdown') {
         if (Object.keys(this[key]).length > 0) {
           friendly[key] = Object.keys(this[key]);
         }
       }
-      if (key === 'markdown' && this['markdown'].trim().length > 0) {
+      if (key === 'markdown' && this.markdown.trim().length > 0) {
         friendly[key] = this[key];
       }
-      /* tslint:enable:no-string-literal */
     }
 
     return friendly;


### PR DESCRIPTION
Hey, I mainly added unit tests to the options model, whereas `markdown` can now be private.