### PR TITLE
Update version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 [![Build](https://img.shields.io/badge/master-view%20online-brightgreen.svg)](https://relnotes.k8s.io)
+[![Version](https://img.shields.io/badge/package-1.0.0-blue.svg)]()
 
 A lightweight release notes UI to help users keep track of the ever-changing
 codebase for Kubernetes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relnotes",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
We should bump the version to 1.0.0, tag a release and update the development version to 1.0.1 afterwards. Before that, everything should be green for 1.0.0, whereas I would see #52 and #53 as mandatory. WDYT?