### PR TITLE
Change site title to 'Kubernetes Release Notes'

### DIFF
--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -7,6 +7,6 @@ describe('Release Notes App', () => {
     // Given
     // When
     // Then
-    cy.title().should('include', 'Relnotes');
+    cy.title().should('include', 'Kubernetes Release Notes');
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,7 +20,7 @@ describe('AppComponent', () => {
     expect(instance).toBeTruthy();
   });
 
-  it(`should have as title 'relnotes'`, () => {
-    expect(instance.title).toEqual('relnotes');
+  it(`should have as title 'Kubernetes Release Notes'`, () => {
+    expect(instance.title).toEqual('Kubernetes Release Notes');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
   templateUrl: './app.component.html',
 })
 export class AppComponent {
-  title = 'relnotes';
+  title = 'Kubernetes Release Notes';
 
   /**
    * The main app components constructor

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Relnotes</title>
+    <title>Kubernetes Release Notes</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="shortcut icon" type=image/png href=favicon.png>


### PR DESCRIPTION
I propose to change the site title to something more verbose.