### PR TITLE
Remove unused Filter from GetNotes()

### DIFF
--- a/src/app/notes/notes.actions.spec.ts
+++ b/src/app/notes/notes.actions.spec.ts
@@ -52,12 +52,11 @@ describe('NotesActions', () => {
 
   it('should be able to create a GetNotes action', () => {
     // When
-    const action = new GetNotes(filter);
+    const action = new GetNotes();
 
     // Then
     expect({ ...action }).toEqual({
       type: ActionTypes.GetNotes,
-      filter,
     });
   });
 

--- a/src/app/notes/notes.actions.ts
+++ b/src/app/notes/notes.actions.ts
@@ -29,7 +29,7 @@ export class DoFilterSuccess implements Action {
 
 export class GetNotes implements Action {
   readonly type = ActionTypes.GetNotes;
-  constructor(public filter: Filter) {}
+  constructor() {}
 }
 
 export class GetNotesSuccess implements Action {

--- a/src/app/notes/notes.component.ts
+++ b/src/app/notes/notes.component.ts
@@ -21,7 +21,7 @@ export class NotesComponent {
   p = 1;
 
   constructor(private store: Store<State>) {
-    store.dispatch(new GetNotes(this.filter));
+    store.dispatch(new GetNotes());
 
     this.store.pipe(select(getAllNotesSelector)).subscribe(n => {
       // Initial retrieval of the notes

--- a/src/app/notes/notes.effects.spec.ts
+++ b/src/app/notes/notes.effects.spec.ts
@@ -32,7 +32,7 @@ describe('NotesEffects', () => {
 
   describe('GetNotes', () => {
     it('should succeed with empty filter', () => {
-      const action = new GetNotes(filter);
+      const action = new GetNotes();
       const completion = new GetNotesSuccess(notesMock);
 
       actions = hot('-a---', { a: action });
@@ -45,7 +45,7 @@ describe('NotesEffects', () => {
 
     it('should fail if NotesService fails', () => {
       const error = 'error';
-      const action = new GetNotes(filter);
+      const action = new GetNotes();
       const completion = new Failed(error);
 
       actions = hot('-a---', { a: action });

--- a/src/app/notes/notes.effects.ts
+++ b/src/app/notes/notes.effects.ts
@@ -20,9 +20,8 @@ export class NotesEffects {
   @Effect()
   getNotes$ = this.actions$.pipe(
     ofType(ActionTypes.GetNotes),
-    map((action: GetNotes) => action.filter),
-    exhaustMap(filter =>
-      this.notesService.getNotes(filter).pipe(
+    exhaustMap(() =>
+      this.notesService.getNotes().pipe(
         map((noteList: NoteList) => {
           const notes: Note[] = [];
           for (const k of Object.keys(noteList)) {

--- a/src/app/notes/notes.service.spec.ts
+++ b/src/app/notes/notes.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientModule } from '@angular/common/http';
 import { NotesService } from './notes.service';
 import { LoggerService } from '@shared/services/logger.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { Filter } from '@app/shared/model/options.model';
 
 describe('NotesService', () => {
   let service: NotesService;
@@ -24,6 +23,6 @@ describe('NotesService', () => {
   });
 
   it('should succeed to get notes', () => {
-    expect(service.getNotes(new Filter())).toBeTruthy();
+    expect(service.getNotes()).toBeTruthy();
   });
 });

--- a/src/app/notes/notes.service.ts
+++ b/src/app/notes/notes.service.ts
@@ -5,7 +5,6 @@ import { Observable } from 'rxjs';
 
 import { Note, NoteList } from './notes.model';
 import { LoggerService } from '@shared/services/logger.service';
-import { Filter } from '@app/shared/model/options.model';
 
 @Injectable({
   providedIn: 'root',
@@ -15,7 +14,12 @@ export class NotesService {
 
   constructor(private http: HttpClient, private logger: LoggerService) {}
 
-  getNotes(filter: Filter): Observable<NoteList> {
+  /**
+   * Retrieve the notes
+   *
+   * @returns The NoteList as observable
+   */
+  getNotes(): Observable<NoteList> {
     this.logger.debug('Gathering notes');
     return this.http.get<NoteList>(this.noteUrl).pipe();
   }


### PR DESCRIPTION
Removed the unused `Filter` parameter from the NotesService and adapted everything else. Should be future save since we use ngrx and should filter via the DoFilter effect.