### PR TITLE
Add possibility to hide notes

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -56,8 +56,8 @@
               "assets": ["src/favicon.png", "src/assets", "src/testdata"],
               "fileReplacements": [
                 {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.test.ts"
+                  "replace": "src/environments/assets.ts",
+                  "with": "src/environments/assets.test.ts"
                 }
               ]
             }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start:prod": "ng serve --prod",
     "start:test": "ng serve --configuration=test",
     "build-dev": "ng build --output-path dist-dev",
     "build-prod": "ng build --prod --build-optimizer --output-path dist-prod",
@@ -91,7 +92,7 @@
     ],
     "moduleNameMapper": {
       "^@app(.*)$": "<rootDir>/src/app/$1",
-      "^@environment": "<rootDir>/src/environments/environment",
+      "^@env(.*)$": "<rootDir>/src/environments/$1",
       "^@shared(.*)$": "<rootDir>/src/app/shared/$1"
     },
     "preset": "jest-preset-angular",

--- a/src/app/app.reducer.ts
+++ b/src/app/app.reducer.ts
@@ -5,7 +5,6 @@ import {
   createSelector,
   MetaReducer,
 } from '@ngrx/store';
-import { environment } from '@environment';
 import { State as NotesState, notesReducer } from './notes/notes.reducer';
 
 export interface State {

--- a/src/app/notes/notes.service.ts
+++ b/src/app/notes/notes.service.ts
@@ -6,7 +6,7 @@ import { map } from 'rxjs/operators';
 
 import { Note } from './notes.model';
 import { LoggerService } from '@shared/services/logger.service';
-import { environment } from '@environment';
+import { assets } from '@env/assets';
 
 @Injectable({
   providedIn: 'root',
@@ -20,11 +20,14 @@ export class NotesService {
    * @returns The NoteList as observable
    */
   getNotes(): Observable<Note[]> {
-    this.logger.debug(`Gathering notes from ${environment.notesAssets}`);
+    this.logger.debug(`Gathering notes from ${assets.length} assets`);
 
     const observables = [];
-    for (const jsonFile of environment.notesAssets) {
-      observables.push(this.http.get(jsonFile));
+    for (const asset of assets) {
+      if (asset.hidden) {
+        continue;
+      }
+      observables.push(this.http.get(asset.path));
     }
 
     return forkJoin(observables).pipe(map(this.toNoteList));

--- a/src/app/shared/model/options.model.spec.ts
+++ b/src/app/shared/model/options.model.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, getTestBed } from '@angular/core/testing';
 import { Filter } from './options.model';
-import { environment } from '@environment';
 
 describe('OptionsModel', () => {
   let filter: Filter;

--- a/src/app/shared/services/logger.service.spec.ts
+++ b/src/app/shared/services/logger.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, getTestBed } from '@angular/core/testing';
-import { LoggerService } from './logger.service';
-import { environment } from '@environment';
+import { LoggerService, Verbosity } from './logger.service';
 
 describe('LoggerService', () => {
   let service: LoggerService;
@@ -23,6 +22,9 @@ describe('LoggerService', () => {
 
   describe('error', () => {
     it('should log', () => {
+      // Given
+      service.setVerbosity(Verbosity.Error);
+
       // When
       service.error(message);
 
@@ -34,9 +36,9 @@ describe('LoggerService', () => {
   });
 
   describe('warn', () => {
-    it('should not log when logLevel < 1', () => {
+    it('should not log when logLevel < Verbosity.Warn', () => {
       // Given
-      environment.logLevel = 0;
+      service.setVerbosity(Verbosity.Error);
 
       // When
       service.warn(message);
@@ -47,9 +49,9 @@ describe('LoggerService', () => {
       expect(console.error).not.toHaveBeenCalled();
     });
 
-    it('should log when logLevel >= 1', () => {
+    it('should log when logLevel >= Verbosity.Warn', () => {
       // Given
-      environment.logLevel = 1;
+      service.setVerbosity(Verbosity.Warn);
 
       // When
       service.warn(message);
@@ -62,9 +64,9 @@ describe('LoggerService', () => {
   });
 
   describe('info', () => {
-    it('should not log when logLevel < 2', () => {
+    it('should not log when logLevel < Verbosity.Info', () => {
       // Given
-      environment.logLevel = 1;
+      service.setVerbosity(Verbosity.Warn);
 
       // When
       service.info(message);
@@ -75,9 +77,9 @@ describe('LoggerService', () => {
       expect(console.error).not.toHaveBeenCalled();
     });
 
-    it('should log when logLevel >= 2', () => {
+    it('should log when logLevel >= Verbosity.Info', () => {
       // Given
-      environment.logLevel = 2;
+      service.setVerbosity(Verbosity.Info);
 
       // When
       service.info(message);
@@ -90,9 +92,9 @@ describe('LoggerService', () => {
   });
 
   describe('debug', () => {
-    it('should not log when logLevel < 3', () => {
+    it('should not log when logLevel < Verbosity.Debug', () => {
       // Given
-      environment.logLevel = 2;
+      service.setVerbosity(Verbosity.Info);
 
       // When
       service.debug(message);
@@ -103,9 +105,9 @@ describe('LoggerService', () => {
       expect(console.error).not.toHaveBeenCalled();
     });
 
-    it('should log when logLevel >= 3', () => {
+    it('should log when logLevel >= Verbosity.Debug', () => {
       // Given
-      environment.logLevel = 3;
+      service.setVerbosity(Verbosity.Debug);
 
       // When
       service.debug(message);

--- a/src/app/shared/services/logger.service.ts
+++ b/src/app/shared/services/logger.service.ts
@@ -1,11 +1,36 @@
 import { Injectable } from '@angular/core';
-import { environment } from '@environment';
+import { isDevMode } from '@angular/core';
+
+/**
+ * All available verbosity levels
+ */
+export enum Verbosity {
+  Error = 0,
+  Warn,
+  Info,
+  Debug,
+}
 
 /**
  * The logger service implementation
  */
 @Injectable()
 export class LoggerService {
+  /**
+   * The default verbosity in non production mode
+   */
+  private logLevel = Verbosity.Debug;
+
+  /**
+   * The loggers constructor
+   */
+  constructor() {
+    // Adapt the default verbosity in production mode
+    if (!isDevMode()) {
+      this.logLevel = Verbosity.Error;
+    }
+  }
+
   /**
    * Gets the current time as prefix
    *
@@ -17,12 +42,21 @@ export class LoggerService {
   }
 
   /**
+   * Set the verbosity to a dedicated level
+   *
+   * @param level     The verbosity level
+   */
+  public setVerbosity(level: Verbosity) {
+    this.logLevel = level;
+  }
+
+  /**
    * Logs a debug message to the console when log level >= 3
    *
    * @param msg     The log message
    */
   public debug(msg: string) {
-    if (environment.logLevel >= 3) {
+    if (this.logLevel >= Verbosity.Debug) {
       console.log(`[DEBUG]\t${this.date()}: ${msg}`);
     }
   }
@@ -33,7 +67,7 @@ export class LoggerService {
    * @param msg     The info log message
    */
   public info(msg: string) {
-    if (environment.logLevel >= 2) {
+    if (this.logLevel >= Verbosity.Info) {
       console.log(`[INFO]\t${this.date()}: ${msg}`);
     }
   }
@@ -44,7 +78,7 @@ export class LoggerService {
    * @param msg     The warning log message
    */
   public warn(msg: string) {
-    if (environment.logLevel >= 1) {
+    if (this.logLevel >= Verbosity.Warn) {
       console.warn(`[WARN]\t${this.date()}: ${msg}`);
     }
   }
@@ -55,6 +89,8 @@ export class LoggerService {
    * @param msg     The error log message
    */
   public error(msg: string) {
-    console.error(`[ERROR]\t${this.date()}: ${msg}`);
+    if (this.logLevel >= Verbosity.Error) {
+      console.error(`[ERROR]\t${this.date()}: ${msg}`);
+    }
   }
 }

--- a/src/environments/assets.test.ts
+++ b/src/environments/assets.test.ts
@@ -1,0 +1,6 @@
+export const assets = [
+  {
+    path: 'testdata/release-notes.json',
+    hidden: false,
+  },
+];

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,0 +1,14 @@
+export const assets = [
+  {
+    path: 'assets/release-notes-1.15.json',
+    hidden: false,
+  },
+  {
+    path: 'assets/release-notes-1.15.1.json',
+    hidden: false,
+  },
+  {
+    path: 'assets/release-notes-1.16.json',
+    hidden: true,
+  },
+];

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,9 +1,3 @@
 export const environment = {
   production: true,
-  logLevel: 0, // 0 - 3 verbosity
-  notesAssets: [
-    'assets/release-notes-1.15.json',
-    'assets/release-notes-1.15.1.json',
-    'assets/release-notes-1.16.json',
-  ],
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,5 +1,0 @@
-export const environment = {
-  production: false,
-  logLevel: 3, // 0 - 3 verbosity
-  notesAssets: ['testdata/release-notes.json'],
-};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,22 +1,3 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
-
 export const environment = {
   production: false,
-  logLevel: 3, // 0 - 3 verbosity
-  notesAssets: [
-    'assets/release-notes-1.15.json',
-    'assets/release-notes-1.15.1.json',
-    'assets/release-notes-1.16.json',
-  ],
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
-import { environment } from '@environment';
+import { environment } from '@env/environment';
 
 if (environment.production) {
   enableProdMode();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist/out-tsc",
     "paths": {
       "@app/*": ["./src/app/*"],
-      "@environment": ["./src/environments/environment"],
+      "@env/*": ["./src/environments/*"],
       "@shared/*": ["src/app/shared/*"]
     },
     "sourceMap": true,


### PR DESCRIPTION
This commit enables the possibility to hide notes assets from the
environment configuration. The field `hidden` now indicates if the asset
should be invisible, which is not configurable for now.

We separate the assets from the usual environment.ts to override the
assets only when it comes to testing. The logger has been made
independent from the environment and populates the level via
`isDevMode()`.

If everything works as intended can be verified by using the new target
`npm run start:prod`.

---

Later on the logging verbosity as well as the assets visibility
should be configurable.