### PR TITLE
 Split `options` component in `main` and `filter` component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,2 @@
-<app-options></app-options>
+<app-main></app-main>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,12 +3,14 @@ import { NgModule } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { AppRoutingModule } from './app-routing.module';
+
 import { AppComponent } from './app.component';
+import { FilterComponent } from './filter/filter.component';
+import { MainComponent } from './main/main.component';
+import { ModalComponent } from './modal/modal.component';
+import { NotesComponent } from './notes/notes.component';
 
 import { HttpClientModule } from '@angular/common/http';
-import { NotesComponent } from './notes/notes.component';
-import { OptionsComponent } from './options/options.component';
-import { ModalComponent } from './modal/modal.component';
 import { FormsModule } from '@angular/forms';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { LoggerService } from '@shared/services/logger.service';
@@ -24,7 +26,7 @@ import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 @NgModule({
-  declarations: [AppComponent, NotesComponent, OptionsComponent, ModalComponent],
+  declarations: [AppComponent, FilterComponent, MainComponent, ModalComponent, NotesComponent],
   imports: [
     HttpClientModule,
     BrowserModule,

--- a/src/app/filter/filter.component.html
+++ b/src/app/filter/filter.component.html
@@ -1,0 +1,17 @@
+<p *ngFor="let data of options | keyvalue" [id]="optionsHeaderID(data.key)">
+  <b>{{ data.key }}</b
+  ><br />
+  <span *ngFor="let a of data.value | keyvalue">
+    <label>
+      <input
+        [id]="optionCheckboxID(a.value)"
+        type="checkbox"
+        name="{{ data.key }}[]"
+        [ngModel]="filter[data.key][a.value]"
+        (ngModelChange)="updateFilterObject(data.key, a.value, $event)"
+        value="{{ a.value }}"
+      />
+      {{ a.value }} </label
+    ><br />
+  </span>
+</p>

--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -1,0 +1,46 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { FilterComponent } from '@app/filter/filter.component';
+import { notesMock } from '@app/notes/notes.model.mock';
+
+describe('FilterComponent', () => {
+  let component: FilterComponent;
+  let fixture: ComponentFixture<FilterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [FilterComponent],
+      imports: [FormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilterComponent);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  }));
+
+  const areas = 'areas';
+  const b = 'b';
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should succeed to update filter object', () => {
+    component.updateFilterObject(areas, b, true);
+    expect(component.filter[areas][b]).toEqual(true);
+  });
+
+  it('should succeed to delete filter object', () => {
+    component.updateFilterObject(areas, b, false);
+  });
+
+  it('should succeed to retrieve the options header ID', () => {
+    expect(component.optionsHeaderID('value')).toEqual('options-value');
+  });
+
+  it('should succeed to retrieve the options checkbox ID', () => {
+    expect(component.optionCheckboxID('value')).toEqual('option-value');
+    expect(component.optionCheckboxID('1.2.3')).toEqual('option-1-2-3');
+  });
+});

--- a/src/app/filter/filter.component.ts
+++ b/src/app/filter/filter.component.ts
@@ -1,0 +1,50 @@
+import { Component, ElementRef, EventEmitter, Input, Output } from '@angular/core';
+import { Note } from '@app/notes/notes.model';
+import { Filter, Options } from '@app/shared/model/options.model';
+
+@Component({
+  selector: 'app-filter',
+  templateUrl: './filter.component.html',
+})
+export class FilterComponent {
+  @Input() options: Options = new Options();
+  @Input() filter: Filter = new Filter();
+  @Output() filterUpdate = new EventEmitter<Filter>();
+
+  /**
+   * Update the filter object based on the given parameters
+   */
+  updateFilterObject(a: string, b: string, val: any): void {
+    if (val) {
+      this.filter.add(a, b);
+    } else {
+      delete this.filter[a][b];
+    }
+    this.filterUpdate.emit(this.filter);
+  }
+
+  /**
+   * Create the options header ID from the given input string
+   *
+   * @param input   The provided input string
+   *
+   * @returns The prefixed output string
+   */
+  optionsHeaderID(input: string): string {
+    return `options-${input}`;
+  }
+
+  /**
+   * Create the options checkbox ID from the given input string. This method
+   * also stripps invalid dot (.) characters from the input.
+   *
+   * @param input   The provided input string
+   *
+   * @returns The prefixed output string
+   */
+  optionCheckboxID(input: string): string {
+    // Strip the dots from the release versions
+    const stripped = input.replace(/\./g, '-');
+    return `option-${stripped}`;
+  }
+}

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -37,23 +37,12 @@
   <div class="row">
     <nav class="col-md-2 d-none d-md-block bg-light sidebar">
       <div class="sidebar-sticky">
-        <p *ngFor="let data of options | keyvalue" [id]="optionsHeaderID(data.key)">
-          <b>{{ data.key }}</b
-          ><br />
-          <span *ngFor="let a of data.value | keyvalue">
-            <label>
-              <input
-                [id]="optionCheckboxID(a.value)"
-                type="checkbox"
-                name="{{ data.key }}[]"
-                [ngModel]="filter[data.key][a.value]"
-                (ngModelChange)="updateFilterObject(data.key, a.value, $event)"
-                value="{{ a.value }}"
-              />
-              {{ a.value }} </label
-            ><br />
-          </span>
-        </p>
+        <app-filter
+          id="filterComponent"
+          [options]="options"
+          [filter]="filter"
+          (filterUpdate)="onUpdateFromFilterComponent($event)"
+        ></app-filter>
       </div>
     </nav>
 
@@ -63,7 +52,7 @@
       >
         <app-notes
           id="notesComponent"
-          (filterUpdate)="toggleFilter($event)"
+          (filterUpdate)="onUpdateFromNotesComponent($event)"
           (gotNotes)="gotNotes($event)"
           [filter]="filter"
         ></app-notes>

--- a/src/app/main/main.component.spec.ts
+++ b/src/app/main/main.component.spec.ts
@@ -3,8 +3,9 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import { FormsModule } from '@angular/forms';
 import { StoreModule, combineReducers } from '@ngrx/store';
 import { NgxPaginationModule } from 'ngx-pagination';
-import { OptionsComponent } from './options.component';
+import { MainComponent } from './main.component';
 import { NotesComponent } from '@app/notes/notes.component';
+import { FilterComponent } from '@app/filter/filter.component';
 import { ModalComponent } from '@app/modal/modal.component';
 import { notesMock } from '@app/notes/notes.model.mock';
 import { Note } from '@app/notes/notes.model';
@@ -14,13 +15,13 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
-describe('OptionsComponent', () => {
-  let component: OptionsComponent;
-  let fixture: ComponentFixture<OptionsComponent>;
+describe('MainComponent', () => {
+  let component: MainComponent;
+  let fixture: ComponentFixture<MainComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [NotesComponent, ModalComponent, OptionsComponent],
+      declarations: [NotesComponent, FilterComponent, ModalComponent, MainComponent],
       imports: [
         FontAwesomeModule,
         FormsModule,
@@ -53,7 +54,7 @@ describe('OptionsComponent', () => {
       })
       .compileComponents();
 
-    fixture = TestBed.createComponent(OptionsComponent);
+    fixture = TestBed.createComponent(MainComponent);
     fixture.detectChanges();
     component = fixture.componentInstance;
   }));
@@ -75,30 +76,6 @@ describe('OptionsComponent', () => {
     expect(component.filter.areas).toBe('');
   });
 
-  it('should succeed to update filter object', () => {
-    component.updateFilterObject(areas, b, true);
-    expect(component.filter[areas][b]).toEqual(true);
-  });
-
-  it('should succeed to delete filter object', () => {
-    component.updateFilterObject(areas, b, false);
-  });
-
-  it('should succeed to toggle filter to true', () => {
-    const event = { key: areas, value: b };
-    component.toggleFilter(event);
-    expect(component.filter[areas][b]).toBeTruthy();
-  });
-
-  it('should succeed to toggle filter to false', () => {
-    const event = { key: areas, value: b };
-    component.toggleFilter(event);
-    expect(component.filter[areas][b]).toBeTruthy();
-
-    component.toggleFilter(event);
-    expect(component.filter[areas][b]).toBeFalsy();
-  });
-
   it('should succeed to update options on gotNotes', () => {
     component.gotNotes(notesMock);
     expect(component.options.areas.length).toEqual(1);
@@ -115,16 +92,22 @@ describe('OptionsComponent', () => {
     expect(component.options.releaseVersions.length).toEqual(1);
   });
 
+  it('should succeed to toggle filter to true', () => {
+    const event = { key: areas, value: b };
+    component.onUpdateFromNotesComponent(event);
+    expect(component.filter[areas][b]).toBeTruthy();
+  });
+
+  it('should succeed to toggle filter to false', () => {
+    const event = { key: areas, value: b };
+    component.onUpdateFromNotesComponent(event);
+    expect(component.filter[areas][b]).toBeTruthy();
+
+    component.onUpdateFromNotesComponent(event);
+    expect(component.filter[areas][b]).toBeFalsy();
+  });
+
   it('should succeed to open the modal view', () => {
     component.openModal();
-  });
-
-  it('should succeed to retrieve the options header ID', () => {
-    expect(component.optionsHeaderID('value')).toEqual('options-value');
-  });
-
-  it('should succeed to retrieve the options checkbox ID', () => {
-    expect(component.optionCheckboxID('value')).toEqual('option-value');
-    expect(component.optionCheckboxID('1.2.3')).toEqual('option-1-2-3');
   });
 });

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -2,18 +2,21 @@ import { Component, ViewChild, ElementRef, OnInit } from '@angular/core';
 import { Note } from '@app/notes/notes.model';
 import { Filter, Options } from '@app/shared/model/options.model';
 import { NotesComponent } from '@app/notes/notes.component';
+import { FilterComponent } from '@app/filter/filter.component';
 import { ModalComponent } from '@app/modal/modal.component';
 import { Router, ActivatedRoute } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
-  selector: 'app-options',
-  templateUrl: './options.component.html',
+  selector: 'app-main',
+  templateUrl: './main.component.html',
 })
-export class OptionsComponent implements OnInit {
+export class MainComponent implements OnInit {
   options: Options = new Options();
   filter: Filter = new Filter();
+
   @ViewChild(NotesComponent, { static: true }) noteChild;
+  @ViewChild(FilterComponent, { static: true }) filterChild;
 
   constructor(
     private router: Router,
@@ -51,17 +54,6 @@ export class OptionsComponent implements OnInit {
     this.updateURI();
   }
 
-  updateFilterObject(a, b, val): void {
-    if (val) {
-      this.filter.add(a, b);
-    } else {
-      delete this.filter[a][b];
-    }
-    this.noteChild.update(this.filter);
-
-    this.updateURI();
-  }
-
   gotNotes(notes: Note[]): void {
     for (const note of Object.values(notes)) {
       if ('areas' in note) {
@@ -79,7 +71,13 @@ export class OptionsComponent implements OnInit {
     }
   }
 
-  toggleFilter(event): void {
+  onUpdateFromFilterComponent(filter: Filter): void {
+    this.filter = filter;
+    this.noteChild.update(this.filter);
+    this.updateURI();
+  }
+
+  onUpdateFromNotesComponent(event: any): void {
     if (typeof this.filter[event.key][event.value] === 'boolean') {
       delete this.filter[event.key][event.value];
     } else {
@@ -142,30 +140,5 @@ export class OptionsComponent implements OnInit {
                target="_blank">Kubernetes Slack #sig-release channel</a>.
         </p>
     `;
-  }
-
-  /**
-   * Create the options header ID from the given input string
-   *
-   * @param input   The provided input string
-   *
-   * @returns The prefixed output string
-   */
-  optionsHeaderID(input: string): string {
-    return `options-${input}`;
-  }
-
-  /**
-   * Create the options checkbox ID from the given input string. This method
-   * also stripps invalid dot (.) characters from the input.
-   *
-   * @param input   The provided input string
-   *
-   * @returns The prefixed output string
-   */
-  optionCheckboxID(input: string): string {
-    // Strip the dots from the release versions
-    const stripped = input.replace(/\./g, '-');
-    return `option-${stripped}`;
   }
 }


### PR DESCRIPTION
Attention, this needs https://github.com/kubernetes-sigs/release-notes/pull/86 merged before.

We now split up the components to have a better hierarchical view from a source code level. After this we should exchange the event driven Input and Output decorators to use the redux store.