### PR TITLE
Add possibility to filter additional documentation

### DIFF
--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -13,6 +13,8 @@ describe('Release Notes App', () => {
   const option1160 = `${optionID}-1-16-0`;
   const optionKubectl = `${optionID}-kubectl`;
   const optionKubelet = `${optionID}-kubelet`;
+  const optionKEP = `${optionID}-KEP`;
+  const optionExternal = `${optionID}-external`;
   const optionReleaseEng = `${optionID}-release-eng`;
   const optionsID = '#options';
   const optionsReleaseVersionsID = `${optionsID}-releaseVersions`;
@@ -198,5 +200,56 @@ describe('Release Notes App', () => {
     cy.get(v1160entry1DocumentationButton).click();
     cy.get(v1160entry1DocumentationContent).should('be.visible');
     cy.get(documentationTooltip).should('be.visible');
+  });
+
+  it(`should be possible to filter 'KEP' doc types`, () => {
+    // Given
+    cy.get(optionKEP).should('not.be.checked');
+
+    // When
+    cy.get(optionKEP).check();
+
+    // Then
+    cy.get(optionKEP).should('be.checked');
+    cy.get(v1160entry1DocumentationContent).should('be.visible');
+    cy.get(cards).should($c => {
+      expect($c).to.have.length(1);
+      expect($c).to.contain(v1160entry1);
+    });
+  });
+
+  it(`should be possible to filter 'external' doc types`, () => {
+    // Given
+    cy.get(optionExternal).should('not.be.checked');
+
+    // When
+    cy.get(optionExternal).check();
+
+    // Then
+    cy.get(optionExternal).should('be.checked');
+    cy.get(v1160entry1DocumentationContent).should('be.visible');
+    cy.get(cards).should($c => {
+      expect($c).to.have.length(1);
+      expect($c).to.contain(v1160entry1);
+    });
+  });
+
+  it(`should show double filtered documentation entries only once`, () => {
+    // Given
+    cy.get(optionExternal).should('not.be.checked');
+    cy.get(optionKEP).should('not.be.checked');
+
+    // When
+    cy.get(optionExternal).check();
+    cy.get(optionKEP).check();
+
+    // Then
+    cy.get(optionExternal).should('be.checked');
+    cy.get(optionKEP).should('be.checked');
+    cy.get(v1160entry1DocumentationContent).should('be.visible');
+    cy.get(cards).should($c => {
+      expect($c).to.have.length(1);
+      expect($c).to.contain(v1160entry1);
+    });
   });
 });

--- a/src/app/filter/filter.component.html
+++ b/src/app/filter/filter.component.html
@@ -1,17 +1,18 @@
 <p *ngFor="let data of options | keyvalue" [id]="optionsHeaderID(data.key)">
-  <b>{{ data.key }}</b
-  ><br />
-  <span *ngFor="let a of data.value | keyvalue">
-    <label>
-      <input
-        [id]="optionCheckboxID(a.value)"
-        type="checkbox"
-        name="{{ data.key }}[]"
-        [ngModel]="filter[data.key][a.value]"
-        (ngModelChange)="updateFilterObject(data.key, a.value, $event)"
-        value="{{ a.value }}"
-      />
-      {{ a.value }} </label
-    ><br />
+  <span *ngIf="data.value.length > 0">
+    <h6>{{ data.key }}</h6>
+    <div *ngFor="let a of data.value | keyvalue">
+      <label>
+        <input
+          [id]="optionCheckboxID(a.value)"
+          type="checkbox"
+          name="{{ data.key }}[]"
+          [ngModel]="filter[data.key][a.value]"
+          (ngModelChange)="updateFilterObject(data.key, a.value, $event)"
+          value="{{ a.value }}"
+        />
+        {{ a.value }}
+      </label>
+    </div>
   </span>
 </p>

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -55,6 +55,7 @@ export class MainComponent implements OnInit {
   }
 
   gotNotes(notes: Note[]): void {
+    console.log(this.options);
     for (const note of Object.values(notes)) {
       if ('areas' in note) {
         this.options.areas = [...new Set(this.options.areas.concat(note.areas))];
@@ -64,6 +65,13 @@ export class MainComponent implements OnInit {
       }
       if ('sigs' in note) {
         this.options.sigs = [...new Set(this.options.sigs.concat(note.sigs))];
+      }
+      if ('documentation' in note) {
+        this.options.documentation = [
+          ...new Set(
+            this.options.documentation.concat(note.documentation.map(x => x.type.toString())),
+          ),
+        ];
       }
       if (this.options.releaseVersions.indexOf(note.release_version) < 0) {
         this.options.releaseVersions.push(note.release_version);

--- a/src/app/notes/notes.component.html
+++ b/src/app/notes/notes.component.html
@@ -44,7 +44,7 @@
       <div [innerHTML]="note.markdown | markdown"></div>
       <div
         *ngIf="note.documentation"
-        class="collapse"
+        class="collapse {{ collapseClass() }}"
         id="documentationContent-{{ note.pr_number }}"
       >
         <h6>Additional Documentation</h6>

--- a/src/app/notes/notes.component.ts
+++ b/src/app/notes/notes.component.ts
@@ -63,4 +63,16 @@ export class NotesComponent {
     }
     return 'badge-secondary';
   }
+
+  /**
+   * Retrieve the collapse css class based on the current filter
+   *
+   * @returns The resulting class as string
+   */
+  public collapseClass(): string {
+    if (this.filter.isset('documentation')) {
+      return 'show';
+    }
+    return '';
+  }
 }

--- a/src/app/notes/notes.effects.ts
+++ b/src/app/notes/notes.effects.ts
@@ -68,7 +68,16 @@ export class NotesEffects {
               } else {
                 for (const key in data.filter) {
                   if (key in note && typeof note[key] !== 'string') {
-                    if (
+                    // Filter the documentation by its doctype
+                    if (key === 'documentation' && note[key]) {
+                      for (let i = 0, len = note[key].length; i < len; i++) {
+                        const docType = note[key][i].type.toString();
+                        if (data.filter[key][docType] === true && filteredNotes.indexOf(note) < 0) {
+                          filteredNotes.push(note);
+                        }
+                      }
+                    } else if (
+                      // Filter everything else based on a simple set manipulation
                       [...new Set(note[key])].filter(x => {
                         return data.filter[key].indexOf(x) && data.filter[key][x];
                       }).length > 0

--- a/src/app/shared/model/options.model.ts
+++ b/src/app/shared/model/options.model.ts
@@ -6,6 +6,7 @@ export class Options {
   kinds: string[] = [];
   releaseVersions: string[] = [];
   sigs: string[] = [];
+  documentation: string[] = [];
 }
 
 /**
@@ -62,7 +63,6 @@ export class Filter extends Options {
    *
    * @returns a boolean
    */
-
   public isset(key: string): boolean {
     if (Object.keys(this[key]).length > 0) {
       return true;
@@ -75,7 +75,6 @@ export class Filter extends Options {
    *
    * @returns an object or null
    */
-
   public get(key: string): object {
     return this[key];
   }
@@ -85,7 +84,6 @@ export class Filter extends Options {
    *
    * @returns void
    */
-
   public add(key: string, value: string): void {
     this[key][value] = true;
   }


### PR DESCRIPTION
It is now possible to filter additional documentation via the newly
added options `KEP`, `external` and `official`. The documentation part
of the not will be automatically expanded if one of these filters got
selected. End to end tests have been updated as well.

Test locally via:
```
> npm start -- --configuration=test
```

Or by viewing this wonderful gif:
![docs](https://user-images.githubusercontent.com/695473/62531745-529f4500-b843-11e9-8858-b5aff363a872.gif)

Closes: https://github.com/kubernetes-sigs/release-notes/issues/82
Relates to: https://github.com/kubernetes/sig-release/issues/729