### PR TITLE
Fix adding notes multiple times if already filtered

### DIFF
--- a/src/app/notes/notes.effects.ts
+++ b/src/app/notes/notes.effects.ts
@@ -80,7 +80,8 @@ export class NotesEffects {
                       // Filter everything else based on a simple set manipulation
                       [...new Set(note[key])].filter(x => {
                         return data.filter[key].indexOf(x) && data.filter[key][x];
-                      }).length > 0
+                      }).length > 0 &&
+                      filteredNotes.indexOf(note) < 0
                     ) {
                       filteredNotes.push(note);
                     }
@@ -94,7 +95,8 @@ export class NotesEffects {
                         note[key]
                           .toUpperCase()
                           .trim()
-                          .includes(data.filter[key].toUpperCase().trim())
+                          .includes(data.filter[key].toUpperCase().trim()) &&
+                        filteredNotes.indexOf(note) < 0
                       ) {
                         filteredNotes.push(note);
                       }


### PR DESCRIPTION
Before: #66928 is listed twice:
https://relnotes.k8s.io/?areas=kubelet&kinds=feature&markdown=XFS

Afterwards, it's gone:
https://deploy-preview-92--kubernetes-sigs-release-notes.netlify.com/?areas=kubelet&kinds=feature&markdown=XFS

I guess we have to rework the whole filtering logic a bit. :)