### PR TITLE
Fix url modification on link click

### DIFF
--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -27,7 +27,7 @@
     </ul>
     <ul class="navbar-nav">
       <li class="nav-item">
-        <a (click)="openModal()" href="#" id="aboutLink" class="nav-link">About</a>
+        <a (click)="openModal()" id="aboutLink" class="nav-link">About</a>
       </li>
       <li class="nav-item" id="settingsButton"><app-settings></app-settings></li>
     </ul>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,4 +1,4 @@
-<a href="#" id="settingsLink" (click)="openModal(content)" class="nav-link">
+<a id="settingsLink" (click)="openModal(content)" class="nav-link">
   <fa-icon class="icon" [icon]="faCogs" size="lg"></fa-icon>
 </a>
 <ng-template #content let-modal>

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,10 @@ html {
   }
 }
 
+.nav-link {
+  cursor: pointer;
+}
+
 .sidebar .nav-link {
   font-weight: 500;
   color: #333;


### PR DESCRIPTION
We should not modify the URL when clicking on links, because this will
reset the currently applied filter.