### PR TITLE
Sanitize doc descriptions

### DIFF
--- a/src/app/notes/notes.component.html
+++ b/src/app/notes/notes.component.html
@@ -52,7 +52,7 @@
           <li *ngFor="let doc of note.documentation">
             <a href="{{ doc.url }}" target="_blank">
               <span *ngIf="doc.description; else elseBlock">
-                {{ doc.description }}
+                {{ saneKEPDescription(doc) }}
               </span>
               <ng-template #elseBlock>{{ doc.url }}</ng-template>
               <span class="badge doc-badge {{ badgeClass(doc.type) }}">{{ doc.type }}</span>

--- a/src/app/notes/notes.component.spec.ts
+++ b/src/app/notes/notes.component.spec.ts
@@ -9,6 +9,7 @@ import { notesReducer } from './notes.reducer';
 import { filterReducer } from '@app/filter/filter.reducer';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { OptionType } from '@app/shared/model/options.model';
+import { documentationMock } from '@app/shared/model/notes.model.mock';
 
 describe('NotesComponent', () => {
   let fixture: ComponentFixture<NotesComponent>;
@@ -74,5 +75,41 @@ describe('NotesComponent', () => {
     expect(kep).toEqual('badge-primary');
     expect(official).toEqual('badge-success');
     expect(external).toEqual('badge-secondary');
+  });
+
+  it('should succeed sanitize the document description with [KEP]', () => {
+    // Given
+    const doc = documentationMock;
+    doc.description = '[KEP]';
+
+    // When
+    const description = component.saneKEPDescription(doc);
+
+    // Then
+    expect(description).toEqual('Kubernetes Enhancement Proposal');
+  });
+
+  it('should succeed sanitize the document description with [KEP Some docs]', () => {
+    // Given
+    const doc = documentationMock;
+    doc.description = '[KEP Some docs]';
+
+    // When
+    const description = component.saneKEPDescription(doc);
+
+    // Then
+    expect(description).toEqual('Some docs');
+  });
+
+  it('should succeed sanitize the document description', () => {
+    // Given
+    const doc = documentationMock;
+    doc.description = ' some documentation ';
+
+    // When
+    const description = component.saneKEPDescription(doc);
+
+    // Then
+    expect(description).toEqual('some documentation');
   });
 });

--- a/src/app/notes/notes.component.ts
+++ b/src/app/notes/notes.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { Note } from '@app/shared/model/notes.model';
+import { Note, Documentation } from '@app/shared/model/notes.model';
 import { DoFilter, GetNotes } from './notes.actions';
 import { State } from '@app/app.reducer';
 import { getAllNotesSelector, getFilteredNotesSelector } from './notes.reducer';
@@ -22,6 +22,8 @@ export class NotesComponent {
   filteredNotes: Note[] = [];
   p = 1;
   faBook = faBook;
+
+  readonly kep = 'KEP';
 
   constructor(private store: Store<State>) {
     this.store.dispatch(new GetNotes());
@@ -70,12 +72,34 @@ export class NotesComponent {
    * @returns The resulting class as string
    */
   public badgeClass(t: string): string {
-    if (t === 'KEP') {
+    if (t === this.kep) {
       return 'badge-primary';
     } else if (t === 'official') {
       return 'badge-success';
     }
     return 'badge-secondary';
+  }
+
+  /**
+   * Sanitize the documentation description
+   *
+   * @param doc The documentation to be processed
+   *
+   * @returns The resulting description as string
+   */
+  public saneKEPDescription(doc: Documentation): string {
+    const stripped = doc.description
+      .replace(/[\[\]]/g, '') // remove brackets
+      .replace(this.kep, '') // remove 'KEP'
+      .trim();
+
+    if (stripped === '') {
+      // write out KEP
+      return 'Kubernetes Enhancement Proposal';
+    }
+
+    // all other sort of descriptions
+    return stripped;
   }
 
   /**


### PR DESCRIPTION
Saw issues in https://github.com/kubernetes-sigs/release-notes/pull/97, like: https://deploy-preview-97--kubernetes-sigs-release-notes.netlify.com/?releaseVersions=1.16.0&documentation=external&documentation=KEP&documentation=official

This should be fixed with this commit, where we sanitize the description before actually printing them out.