### PR TITLE
Sort filter options regarding its logic

### DIFF
--- a/src/app/shared/model/options.model.spec.ts
+++ b/src/app/shared/model/options.model.spec.ts
@@ -31,4 +31,30 @@ describe('OptionsModel', () => {
     // Then
     expect(res).toEqual(new Set(['a', 'b']));
   });
+
+  it('should succeed to add data and re-sort it alphabetically', () => {
+    // Given
+    options.add(OptionType.areas, ['c', 'a', 'b']);
+
+    // When
+    const res = Array.from(options.get(OptionType.areas));
+
+    // Then
+    expect(res[0]).toEqual('a');
+    expect(res[1]).toEqual('b');
+    expect(res[2]).toEqual('c');
+  });
+
+  it('should succeed to add data and re-sort it reverse alphabetically', () => {
+    // Given
+    options.add(OptionType.releaseVersions, ['v1.14.0', 'v1.16.0', 'v1.14.2']);
+
+    // When
+    const res = Array.from(options.get(OptionType.releaseVersions));
+
+    // Then
+    expect(res[0]).toEqual('v1.16.0');
+    expect(res[1]).toEqual('v1.14.2');
+    expect(res[2]).toEqual('v1.14.0');
+  });
 });

--- a/src/app/shared/model/options.model.ts
+++ b/src/app/shared/model/options.model.ts
@@ -63,6 +63,7 @@ export class Options {
    */
   public add(optionType: OptionType, input: string[]) {
     this.data.set(optionType, this.merge(this.data.get(optionType), input));
+    this.sort();
   }
 
   /**
@@ -75,5 +76,27 @@ export class Options {
    */
   private merge(input: OptionSet, arr: string[]): OptionSet {
     return new Set([...input, ...new Set(arr)]);
+  }
+
+  /**
+   * Sort the internal data structures by its defined logical order
+   */
+  private sort() {
+    [OptionType.areas, OptionType.kinds, OptionType.sigs, OptionType.documentation].forEach(x =>
+      this.sort_set(x),
+    );
+    this.sort_set(OptionType.releaseVersions, (a, b) => (a < b ? 1 : -1));
+  }
+
+  /**
+   * Sort a set by converting it to a sorted array and conerting it back again
+   *
+   * @param optionType The OptionType to be used
+   * @param compareFn The name of the function used to determine the order of
+   *                  the elements. If omitted, the elements are sorted in
+   *                  ascending, ASCII character order.
+   */
+  private sort_set(optionType: OptionType, compareFn?: (a: string, b: string) => number) {
+    this.store.set(optionType, new Set([...this.store.get(optionType)].sort(compareFn)));
   }
 }


### PR DESCRIPTION
We now sort everything in alphabetical order except the release
versions, where the latest one will always be displayed on top. Testing
has been adapted as well.

The result looks like this now:

![screenshot](https://user-images.githubusercontent.com/695473/66210494-4821f000-e6ba-11e9-9708-60000a5e7d4c.png)
