### PR TITLE
Show error message of notes parsing/retrieval fails

### DIFF
--- a/src/app/notes/notes.component.html
+++ b/src/app/notes/notes.component.html
@@ -1,3 +1,6 @@
+<div *ngIf="errorMessage" class="alert alert-danger" role="alert">
+  {{ errorMessage }}
+</div>
 <ng-container *ngFor="let note of filteredNotes | paginate: { itemsPerPage: 10, currentPage: p }">
   <div class="card">
     <div class="card-header">

--- a/src/app/notes/notes.component.ts
+++ b/src/app/notes/notes.component.ts
@@ -3,7 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { Note } from '@app/shared/model/notes.model';
 import { DoFilter, GetNotes } from './notes.actions';
 import { State } from '@app/app.reducer';
-import { getAllNotesSelector, getFilteredNotesSelector } from './notes.reducer';
+import { getErrorSelector, getAllNotesSelector, getFilteredNotesSelector } from './notes.reducer';
 import { Filter } from '@app/shared/model/filter.model';
 import { OptionType } from '@app/shared/model/options.model';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
@@ -22,6 +22,7 @@ export class NotesComponent {
   filteredNotes: Note[] = [];
   p = 1;
   faBook = faBook;
+  errorMessage = '';
 
   constructor(private store: Store<State>) {
     this.store.dispatch(new GetNotes());
@@ -33,6 +34,12 @@ export class NotesComponent {
         this.filteredNotes = notes;
 
         this.store.dispatch(new DoFilter(this.allNotes, this.filter));
+      }
+    });
+
+    store.pipe(select(getErrorSelector, getAllNotesSelector)).subscribe(err => {
+      if (err) {
+        this.errorMessage = `Unable to display notes: ${err}`;
       }
     });
 

--- a/src/app/notes/notes.effects.ts
+++ b/src/app/notes/notes.effects.ts
@@ -20,7 +20,10 @@ export class NotesEffects {
           return new GetNotesSuccess(notes);
         }),
         catchError(error => {
-          this.logger.debug(`[Notes Effects:GetNotes] FAILED: ${error}`);
+          this.logger.debug(`[Notes Effects:GetNotes] FAILED: ${error.message}`);
+          if (error && error.message) {
+            return of(new Failed(error.message));
+          }
           return of(new Failed(error));
         }),
       ),

--- a/src/app/notes/notes.reducer.ts
+++ b/src/app/notes/notes.reducer.ts
@@ -52,3 +52,7 @@ export const getFilteredNotesSelector = createSelector(
   selectNotes,
   (state: State) => state.filteredNotes,
 );
+export const getErrorSelector = createSelector(
+  selectNotes,
+  (state: State) => state.error,
+);


### PR DESCRIPTION
If any error occurs during parsing of the notes, the website shows now an error message like this:

![screenshot](https://user-images.githubusercontent.com/695473/66898142-ce163300-eff8-11e9-89d9-b2ba0278cc03.png)

