### PR TITLE
Patch relnotes.k8s.io with release v1.18.0-beta.2

### DIFF
--- a/src/assets/release-notes-1.18.0-beta.2.json
+++ b/src/assets/release-notes-1.18.0-beta.2.json
@@ -1,0 +1,1614 @@
+{
+  "79083": {
+    "commit": "4b1ee392c180233c085ba0a17949bc9197535c11",
+    "text": "When client certificate files are provided, reload files for new connections, and close connections when a certificate changes.",
+    "markdown": "When client certificate files are provided, reload files for new connections, and close connections when a certificate changes. ([#79083](https://github.com/kubernetes/kubernetes/pull/79083), [@jackkleeman](https://github.com/jackkleeman)) [SIG API Machinery, Auth, Node and Testing]",
+    "author": "jackkleeman",
+    "author_url": "https://github.com/jackkleeman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/79083",
+    "pr_number": 79083,
+    "areas": [
+      "kubelet",
+      "test"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "auth",
+      "node",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "83446": {
+    "commit": "6b13befdfb3e30862dc86fd1c7739f58901f0bae",
+    "text": "Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used.",
+    "markdown": "Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used. ([#83446](https://github.com/kubernetes/kubernetes/pull/83446), [@Elias481](https://github.com/Elias481)) [SIG Cloud Provider]",
+    "author": "Elias481",
+    "author_url": "https://github.com/Elias481",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/83446",
+    "pr_number": 83446,
+    "areas": [
+      "cloudprovider",
+      "provider/aws"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "cloud-provider"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "83572": {
+    "commit": "e4e3d72f1ca143ce7261620deb61dff3284bd428",
+    "text": "fix a bug where kubenet fails to parse the tc output.",
+    "markdown": "Fix a bug where kubenet fails to parse the tc output. ([#83572](https://github.com/kubernetes/kubernetes/pull/83572), [@chendotjs](https://github.com/chendotjs)) [SIG Network]",
+    "author": "chendotjs",
+    "author_url": "https://github.com/chendotjs",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/83572",
+    "pr_number": 83572,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "network"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "84814": {
+    "commit": "61847eab61788fb0543b4cf147773c9da646ed2f",
+    "text": "The storage.k8s.io/CSIDriver has moved to GA, and is now available for use.",
+    "markdown": "The storage.k8s.io/CSIDriver has moved to GA, and is now available for use. ([#84814](https://github.com/kubernetes/kubernetes/pull/84814), [@huffmanca](https://github.com/huffmanca)) [SIG API Machinery, Apps, Auth, Node, Scheduling, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/768",
+        "type": "KEP"
+      }
+    ],
+    "author": "huffmanca",
+    "author_url": "https://github.com/huffmanca",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/84814",
+    "pr_number": 84814,
+    "areas": [
+      "kubelet",
+      "test"
+    ],
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "auth",
+      "node",
+      "scheduling",
+      "storage",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "85870": {
+    "commit": "268d0a1d3a2c79f14d4c7aad98783f2cff919af0",
+    "text": "webhooks will have alpha support for network proxy",
+    "markdown": "Webhooks will have alpha support for network proxy ([#85870](https://github.com/kubernetes/kubernetes/pull/85870), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Auth and Testing]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/85870",
+    "pr_number": 85870,
+    "areas": [
+      "apiserver",
+      "test"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "auth",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "86173": {
+    "commit": "b5b675491b69b5d48bf112a896bc739e500c7275",
+    "text": "`kubectl` no longer defaults to `http://localhost:8080`.  If you own one of these legacy clusters, you are *strongly- encouraged to secure your server.   If you cannot secure your server, you can set `KUBERNETES_MASTER` if you were relying on that behavior and you're client-go user. Set `--server`, `--kubeconfig` or `KUBECONFIG` to make it work in `kubectl`.",
+    "markdown": "`kubectl` no longer defaults to `http://localhost:8080`.  If you own one of these legacy clusters, you are *strongly- encouraged to secure your server.   If you cannot secure your server, you can set `KUBERNETES_MASTER` if you were relying on that behavior and you're client-go user. Set `--server`, `--kubeconfig` or `KUBECONFIG` to make it work in `kubectl`. ([#86173](https://github.com/kubernetes/kubernetes/pull/86173), [@soltysh](https://github.com/soltysh)) [SIG API Machinery, CLI and Testing]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/86173",
+    "pr_number": 86173,
+    "areas": [
+      "test"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "api-machinery",
+      "cli",
+      "testing"
+    ],
+    "duplicate": true,
+    "action_required": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "86636": {
+    "commit": "c7d7cf72e020f7f8e1c07350958b3755e236440e",
+    "text": "fix kubectl create deployment image name",
+    "markdown": "Fix kubectl create deployment image name ([#86636](https://github.com/kubernetes/kubernetes/pull/86636), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]",
+    "author": "zhouya0",
+    "author_url": "https://github.com/zhouya0",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/86636",
+    "pr_number": 86636,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "86837": {
+    "commit": "e1a69aee418c6cda10bf2c8959b2ac32f092ed00",
+    "text": "Update Japanese translation for kubectl help",
+    "markdown": "Update Japanese translation for kubectl help ([#86837](https://github.com/kubernetes/kubernetes/pull/86837), [@inductor](https://github.com/inductor)) [SIG CLI and Docs]",
+    "author": "inductor",
+    "author_url": "https://github.com/inductor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/86837",
+    "pr_number": 86837,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "documentation"
+    ],
+    "sigs": [
+      "cli",
+      "docs"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "87487": {
+    "commit": "0bb125e731c70c0a4a6a022694629d8fef868e8d",
+    "text": "Move TaintBasedEvictions feature gates to GA",
+    "markdown": "Move TaintBasedEvictions feature gates to GA ([#87487](https://github.com/kubernetes/kubernetes/pull/87487), [@skilxn-go](https://github.com/skilxn-go)) [SIG API Machinery, Apps, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/74e610bb0f7e40862688e8a434c77bfafc53cb9e/keps/sig-scheduling/20200114-taint-based-evictions.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "skilxn-go",
+    "author_url": "https://github.com/skilxn-go",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/87487",
+    "pr_number": 87487,
+    "areas": [
+      "test"
+    ],
+    "kinds": [
+      "api-change",
+      "cleanup"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "node",
+      "scheduling",
+      "testing"
+    ],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "87537": {
+    "commit": "4d19c6f2ad3549578090aea75c4d127c57f36ae1",
+    "text": "fix missing \"apiVersion\" for \"involvedObject\" in Events for Nodes.",
+    "markdown": "Fix missing \"apiVersion\" for \"involvedObject\" in Events for Nodes. ([#87537](https://github.com/kubernetes/kubernetes/pull/87537), [@uthark](https://github.com/uthark)) [SIG Apps and Node]",
+    "author": "uthark",
+    "author_url": "https://github.com/uthark",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/87537",
+    "pr_number": 87537,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "apps",
+      "node"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "87648": {
+    "commit": "13beb9b3ce4f360ee1a29613a1c686f6bb8d4ac4",
+    "text": "Update to use golang 1.13.8",
+    "markdown": "Update to use golang 1.13.8 ([#87648](https://github.com/kubernetes/kubernetes/pull/87648), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Release and Testing]",
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/87648",
+    "pr_number": 87648,
+    "areas": [
+      "dependency",
+      "release-eng",
+      "test"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "release",
+      "testing"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "87759": {
+    "commit": "ac32644d6e712af0747f39a945c8df29d6a9cfc4",
+    "text": "Fixed a bug in the TopologyManager. Previously, the TopologyManager would only guarantee alignment if container creation was serialized in some way. Alignment is now guaranteed under all scenarios of container creation.",
+    "markdown": "Fixed a bug in the TopologyManager. Previously, the TopologyManager would only guarantee alignment if container creation was serialized in some way. Alignment is now guaranteed under all scenarios of container creation. ([#87759](https://github.com/kubernetes/kubernetes/pull/87759), [@klueska](https://github.com/klueska)) [SIG Node]",
+    "author": "klueska",
+    "author_url": "https://github.com/klueska",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/87759",
+    "pr_number": 87759,
+    "areas": [
+      "kubelet"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "node"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "87776": {
+    "commit": "882b6f8440ac073e678c48a2ef782f9f018717ea",
+    "text": "When deleting objects using kubectl with the --force flag, you are no longer required to also specify --grace-period=0.",
+    "markdown": "When deleting objects using kubectl with the --force flag, you are no longer required to also specify --grace-period=0. ([#87776](https://github.com/kubernetes/kubernetes/pull/87776), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]",
+    "author": "brianpursley",
+    "author_url": "https://github.com/brianpursley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/87776",
+    "pr_number": 87776,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "87999": {
+    "commit": "09edbcdeb5d5e5ab6dbcffa652446c6b23594242",
+    "text": "AlgorithmSource is removed from v1alpha2 Scheduler ComponentConfig",
+    "markdown": "AlgorithmSource is removed from v1alpha2 Scheduler ComponentConfig ([#87999](https://github.com/kubernetes/kubernetes/pull/87999), [@damemi](https://github.com/damemi)) [SIG Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/785",
+        "type": "KEP"
+      },
+      {
+        "description": "[Other doc]",
+        "url": "https://github.com/kubernetes/kubernetes/issues/87617",
+        "type": "external"
+      }
+    ],
+    "author": "damemi",
+    "author_url": "https://github.com/damemi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/87999",
+    "pr_number": 87999,
+    "kinds": [
+      "api-change",
+      "deprecation"
+    ],
+    "sigs": [
+      "scheduling"
+    ],
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88004": {
+    "commit": "55bfdc6024246dbe56f4cb2d4cc08f6daca5a5ad",
+    "text": "`kubectl` now contains a `kubectl alpha debug` command. This command allows attaching an ephemeral container to a running pod for the purposes of debugging.",
+    "markdown": "`kubectl` now contains a `kubectl alpha debug` command. This command allows attaching an ephemeral container to a running pod for the purposes of debugging. ([#88004](https://github.com/kubernetes/kubernetes/pull/88004), [@verb](https://github.com/verb)) [SIG CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190805-kubectl-debug.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "verb",
+    "author_url": "https://github.com/verb",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88004",
+    "pr_number": 88004,
+    "areas": [
+      "dependency",
+      "kubectl"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88076": {
+    "commit": "a9c7529f990159ef327716e7c61984d5b7197115",
+    "text": "CustomResourceDefinition schemas that use `x-kubernetes-list-map-keys` to specify properties that uniquely identify list items must make those properties required or have a default value, to ensure those properties are present for all list items. See https://kubernetes.io/docs/reference/using-api/api-concepts/\u0026#35;merge-strategy for details.",
+    "markdown": "CustomResourceDefinition schemas that use `x-kubernetes-list-map-keys` to specify properties that uniquely identify list items must make those properties required or have a default value, to ensure those properties are present for all list items. See https://kubernetes.io/docs/reference/using-api/api-concepts/\u0026#35;merge-strategy for details. ([#88076](https://github.com/kubernetes/kubernetes/pull/88076), [@eloyekunle](https://github.com/eloyekunle)) [SIG API Machinery and Testing]",
+    "author": "eloyekunle",
+    "author_url": "https://github.com/eloyekunle",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88076",
+    "pr_number": 88076,
+    "areas": [
+      "test"
+    ],
+    "kinds": [
+      "api-change",
+      "bug",
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88134": {
+    "commit": "650220fa64544c6de308df0d8820896bf0b56194",
+    "text": "Add `rest_client_rate_limiter_duration_seconds` metric to component-base to track client side rate limiter latency in seconds. Broken down by verb and URL.",
+    "markdown": "Add `rest_client_rate_limiter_duration_seconds` metric to component-base to track client side rate limiter latency in seconds. Broken down by verb and URL. ([#88134](https://github.com/kubernetes/kubernetes/pull/88134), [@jennybuckley](https://github.com/jennybuckley)) [SIG API Machinery, Cluster Lifecycle and Instrumentation]",
+    "author": "jennybuckley",
+    "author_url": "https://github.com/jennybuckley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88134",
+    "pr_number": 88134,
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "cluster-lifecycle",
+      "instrumentation"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88141": {
+    "commit": "e90c908f64dd0839a4a55c640d601278935ccae7",
+    "text": "Fix that prevents repeated fetching of PVC/PV objects by kubelet when processing of pod volumes fails. While this prevents hammering API server in these error scenarios, it means that some errors in processing volume(s) for a pod could now take up to 2-3 minutes before retry.",
+    "markdown": "Fix that prevents repeated fetching of PVC/PV objects by kubelet when processing of pod volumes fails. While this prevents hammering API server in these error scenarios, it means that some errors in processing volume(s) for a pod could now take up to 2-3 minutes before retry. ([#88141](https://github.com/kubernetes/kubernetes/pull/88141), [@tedyu](https://github.com/tedyu)) [SIG Node and Storage]",
+    "author": "tedyu",
+    "author_url": "https://github.com/tedyu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88141",
+    "pr_number": 88141,
+    "areas": [
+      "kubelet"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "node",
+      "storage"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88240": {
+    "commit": "bfb3fb54b441b9945bf15a2d26c6a670172e03d4",
+    "text": "Print NotReady when pod is not ready based on its conditions.",
+    "markdown": "Print NotReady when pod is not ready based on its conditions. ([#88240](https://github.com/kubernetes/kubernetes/pull/88240), [@soltysh](https://github.com/soltysh)) [SIG CLI]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88240",
+    "pr_number": 88240,
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88246": {
+    "commit": "03b7f272c8287fdaafa67b82f1c577a96c5a238a",
+    "text": "consumers of the 'certificatesigningrequests/approval' API must now grant permission to 'approve' CSRs for the 'signerName' specified on the CSR. More information on the new signerName field can be found at https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190607-certificates-api.md\u0026#35;signers",
+    "markdown": "Consumers of the 'certificatesigningrequests/approval' API must now grant permission to 'approve' CSRs for the 'signerName' specified on the CSR. More information on the new signerName field can be found at https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190607-certificates-api.md\u0026#35;signers ([#88246](https://github.com/kubernetes/kubernetes/pull/88246), [@munnerz](https://github.com/munnerz)) [SIG API Machinery, Apps, Auth, CLI, Node and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/1400",
+        "type": "KEP"
+      }
+    ],
+    "author": "munnerz",
+    "author_url": "https://github.com/munnerz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88246",
+    "pr_number": 88246,
+    "areas": [
+      "apiserver",
+      "kubectl",
+      "kubelet",
+      "test"
+    ],
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "auth",
+      "cli",
+      "node",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "action_required": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88287": {
+    "commit": "5c5faed39b2541785218268dd62ca26e2a4939a3",
+    "text": "kubeadm: support Windows specific kubelet flags in kubeadm-flags.env",
+    "markdown": "Kubeadm: support Windows specific kubelet flags in kubeadm-flags.env ([#88287](https://github.com/kubernetes/kubernetes/pull/88287), [@gab-satchi](https://github.com/gab-satchi)) [SIG Cluster Lifecycle and Windows]",
+    "author": "gab-satchi",
+    "author_url": "https://github.com/gab-satchi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88287",
+    "pr_number": 88287,
+    "areas": [
+      "kubeadm"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cluster-lifecycle",
+      "windows"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88394": {
+    "commit": "4b83d0b2fd69c10c7c0455de824cd37cda3ab85e",
+    "text": "Fix describe ingress annotations not sorted.",
+    "markdown": "Fix describe ingress annotations not sorted. ([#88394](https://github.com/kubernetes/kubernetes/pull/88394), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]",
+    "author": "zhouya0",
+    "author_url": "https://github.com/zhouya0",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88394",
+    "pr_number": 88394,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88440": {
+    "commit": "7a513b575ab2efc1879c1589a29cfddf23b1a27d",
+    "text": "Terminating a restartPolicy=Never pod no longer has a chance to report the pod succeeded when it actually failed.",
+    "markdown": "Terminating a restartPolicy=Never pod no longer has a chance to report the pod succeeded when it actually failed. ([#88440](https://github.com/kubernetes/kubernetes/pull/88440), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Testing]",
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88440",
+    "pr_number": 88440,
+    "areas": [
+      "kubelet",
+      "test"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "node",
+      "testing"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88448": {
+    "commit": "a54e1a8a04739d79fc5cf856e86ee042c12defc7",
+    "text": "azure: add support for single stack IPv6",
+    "markdown": "Azure: add support for single stack IPv6 ([#88448](https://github.com/kubernetes/kubernetes/pull/88448), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]",
+    "author": "aramase",
+    "author_url": "https://github.com/aramase",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88448",
+    "pr_number": 88448,
+    "areas": [
+      "cloudprovider",
+      "provider/azure"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cloud-provider"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88460": {
+    "commit": "71cfd2a3db825683ef15fc3354f497a6d71589cd",
+    "text": "Allow user to specify resource using --filename flag when invoking kubectl exec",
+    "markdown": "Allow user to specify resource using --filename flag when invoking kubectl exec ([#88460](https://github.com/kubernetes/kubernetes/pull/88460), [@soltysh](https://github.com/soltysh)) [SIG CLI and Testing]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88460",
+    "pr_number": 88460,
+    "areas": [
+      "kubectl",
+      "test"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cli",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88487": {
+    "commit": "481b04cf7c82b1fc6fe8d3d13c526c24d6c8a5f6",
+    "text": "In GKE alpha clusters it will be possible to use the service annotation `cloud.google.com/network-tier: Standard`",
+    "markdown": "In GKE alpha clusters it will be possible to use the service annotation `cloud.google.com/network-tier: Standard` ([#88487](https://github.com/kubernetes/kubernetes/pull/88487), [@zioproto](https://github.com/zioproto)) [SIG Cloud Provider]",
+    "author": "zioproto",
+    "author_url": "https://github.com/zioproto",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88487",
+    "pr_number": 88487,
+    "areas": [
+      "cloudprovider"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "cloud-provider"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88488": {
+    "commit": "264e2f1744417dbf851c3c5740c4fc57c7308aef",
+    "text": "Allow user to specify fsgroup permission change policy for pods",
+    "markdown": "Allow user to specify fsgroup permission change policy for pods ([#88488](https://github.com/kubernetes/kubernetes/pull/88488), [@gnufied](https://github.com/gnufied)) [SIG Apps and Storage]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88488",
+    "pr_number": 88488,
+    "areas": [
+      "dependency"
+    ],
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "apps",
+      "storage"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88502": {
+    "commit": "f605ab0b088ca109ecb1496d4ecf8347a2a3335c",
+    "text": "The apiserver/v1alph1\u0026#35;EgressSelectorConfiguration API is now beta.",
+    "markdown": "The apiserver/v1alph1\u0026#35;EgressSelectorConfiguration API is now beta. ([#88502](https://github.com/kubernetes/kubernetes/pull/88502), [@caesarxuchao](https://github.com/caesarxuchao)) [SIG API Machinery]",
+    "author": "caesarxuchao",
+    "author_url": "https://github.com/caesarxuchao",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88502",
+    "pr_number": 88502,
+    "areas": [
+      "apiserver"
+    ],
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery"
+    ],
+    "feature": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88505": {
+    "commit": "f221dbb91bde0d447226a7f15b7c4301ddd161c6",
+    "text": "Fixes a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against \u003e= 1.16 API servers",
+    "markdown": "Fixes a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against \u003e= 1.16 API servers ([#88505](https://github.com/kubernetes/kubernetes/pull/88505), [@liggitt](https://github.com/liggitt)) [SIG Apps and Network]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88505",
+    "pr_number": 88505,
+    "kinds": [
+      "api-change",
+      "bug"
+    ],
+    "sigs": [
+      "apps",
+      "network"
+    ],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88509": {
+    "commit": "fdb2cb4c8832da1499069bda918c014762d8ac05",
+    "text": "A new IngressClass resource has been added to enable better Ingress configuration.",
+    "markdown": "A new IngressClass resource has been added to enable better Ingress configuration. ([#88509](https://github.com/kubernetes/kubernetes/pull/88509), [@robscott](https://github.com/robscott)) [SIG API Machinery, Apps, CLI, Network, Node and Testing]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88509",
+    "pr_number": 88509,
+    "areas": [
+      "apiserver",
+      "kubectl",
+      "kubelet",
+      "test"
+    ],
+    "kinds": [
+      "api-change"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "cli",
+      "network",
+      "node",
+      "testing"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88512": {
+    "commit": "90a622bbdbd2265ad9c447a6159746ad88765be7",
+    "text": "kube-proxy: deprecate `--healthz-port` and `--metrics-port` flag, please use `--healthz-bind-address` and `--metrics-bind-address` instead",
+    "markdown": "Kube-proxy: deprecate `--healthz-port` and `--metrics-port` flag, please use `--healthz-bind-address` and `--metrics-bind-address` instead ([#88512](https://github.com/kubernetes/kubernetes/pull/88512), [@SataQiu](https://github.com/SataQiu)) [SIG Network]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88512",
+    "pr_number": 88512,
+    "kinds": [
+      "bug",
+      "cleanup",
+      "deprecation"
+    ],
+    "sigs": [
+      "network"
+    ],
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88540": {
+    "commit": "e25ff53a6f3b75332b13d90acd4487c0468b6602",
+    "text": "Scheduler Extender API is now located under k8s.io/kube-scheduler/extender",
+    "markdown": "Scheduler Extender API is now located under k8s.io/kube-scheduler/extender ([#88540](https://github.com/kubernetes/kubernetes/pull/88540), [@damemi](https://github.com/damemi)) [SIG Release, Scheduling and Testing]",
+    "author": "damemi",
+    "author_url": "https://github.com/damemi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88540",
+    "pr_number": 88540,
+    "areas": [
+      "dependency",
+      "release-eng",
+      "test"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "release",
+      "scheduling",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88562": {
+    "commit": "6e35a13815adf221bc2b65eadcdb326de2283521",
+    "text": "build: Enable kube-cross image-building on K8s Infra",
+    "markdown": "Build: Enable kube-cross image-building on K8s Infra ([#88562](https://github.com/kubernetes/kubernetes/pull/88562), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]",
+    "author": "justaugustus",
+    "author_url": "https://github.com/justaugustus",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88562",
+    "pr_number": 88562,
+    "areas": [
+      "dependency",
+      "release-eng",
+      "test"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "release",
+      "testing"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88567": {
+    "commit": "48676adba97681027bb4223cb5b5b14aa1abb7d4",
+    "text": "Apiserver add a new flag --goaway-chance which is the fraction of requests that will be closed gracefully(GOAWAY) to prevent HTTP/2 clients from getting stuck on a single apiserver. \nAfter the connection closed(received GOAWAY), the client's other in-flight requests won't be affected, and the client will reconnect. \nThe flag min value is 0 (off), max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.\nClusters with single apiservers, or which don't use a load balancer, should NOT enable this.",
+    "markdown": "Apiserver add a new flag --goaway-chance which is the fraction of requests that will be closed gracefully(GOAWAY) to prevent HTTP/2 clients from getting stuck on a single apiserver. \n  After the connection closed(received GOAWAY), the client's other in-flight requests won't be affected, and the client will reconnect. \n  The flag min value is 0 (off), max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.\n  Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. ([#88567](https://github.com/kubernetes/kubernetes/pull/88567), [@answer1991](https://github.com/answer1991)) [SIG API Machinery]",
+    "author": "answer1991",
+    "author_url": "https://github.com/answer1991",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88567",
+    "pr_number": 88567,
+    "areas": [
+      "apiserver"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88569": {
+    "commit": "39ed64ec4c3cae32ac1e707a03017f5986efc168",
+    "text": "fix: corrupted mount point in csi driver",
+    "markdown": "Fix: corrupted mount point in csi driver ([#88569](https://github.com/kubernetes/kubernetes/pull/88569), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88569",
+    "pr_number": 88569,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "storage"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88577": {
+    "commit": "5ceddce53947ede00466f29d4ab66e88ffbd4fbd",
+    "text": "`kubectl plugin` now prints a note how to install krew",
+    "markdown": "`kubectl plugin` now prints a note how to install krew ([#88577](https://github.com/kubernetes/kubernetes/pull/88577), [@corneliusweig](https://github.com/corneliusweig)) [SIG CLI]",
+    "author": "corneliusweig",
+    "author_url": "https://github.com/corneliusweig",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88577",
+    "pr_number": 88577,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "documentation"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88587": {
+    "commit": "aeb88b6ecd898bbb788a4629d5e0163172c6c85f",
+    "text": "ingress: Add Exact and Prefix maching to Ingress PathTypes",
+    "markdown": "Ingress: Add Exact and Prefix maching to Ingress PathTypes ([#88587](https://github.com/kubernetes/kubernetes/pull/88587), [@cmluciano](https://github.com/cmluciano)) [SIG Apps, Cluster Lifecycle and Network]",
+    "author": "cmluciano",
+    "author_url": "https://github.com/cmluciano",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88587",
+    "pr_number": 88587,
+    "kinds": [
+      "api-change"
+    ],
+    "sigs": [
+      "apps",
+      "cluster-lifecycle",
+      "network"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88591": {
+    "commit": "06b798781a5aeb8368363caf35c7bcdab3cd0b2a",
+    "text": "Kubelets perform fewer unnecessary pod status update operations on the API server.",
+    "markdown": "Kubelets perform fewer unnecessary pod status update operations on the API server. ([#88591](https://github.com/kubernetes/kubernetes/pull/88591), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Scalability]",
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88591",
+    "pr_number": 88591,
+    "areas": [
+      "kubelet"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "node",
+      "scalability"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88599": {
+    "commit": "179fe40d06bc07b0e6602b203a8fb8e722c4e2a4",
+    "text": "Signatures on scale client methods have been modified to accept `context.Context` as a first argument. Signatures of Get, Update, and Patch methods have been updated to accept GetOptions, UpdateOptions and PatchOptions respectively.",
+    "markdown": "Signatures on scale client methods have been modified to accept `context.Context` as a first argument. Signatures of Get, Update, and Patch methods have been updated to accept GetOptions, UpdateOptions and PatchOptions respectively. ([#88599](https://github.com/kubernetes/kubernetes/pull/88599), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG API Machinery, Apps, Autoscaling and CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "julianvmodesto",
+    "author_url": "https://github.com/julianvmodesto",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88599",
+    "pr_number": 88599,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "autoscaling",
+      "cli"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88602": {
+    "commit": "a555825ab4473fbb42a32e3257be673e89076eec",
+    "text": "Fixes issue where you can't attach more than 15 GCE Persistent Disks to c2, n2, m1, m2 machine types.",
+    "markdown": "Fixes issue where you can't attach more than 15 GCE Persistent Disks to c2, n2, m1, m2 machine types. ([#88602](https://github.com/kubernetes/kubernetes/pull/88602), [@yuga711](https://github.com/yuga711)) [SIG Storage]",
+    "author": "yuga711",
+    "author_url": "https://github.com/yuga711",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88602",
+    "pr_number": 88602,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "storage"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88610": {
+    "commit": "c73532c4f71f7f1ede8a5ad95e07adde375196b1",
+    "text": "fix: azure file mount timeout issue",
+    "markdown": "Fix: azure file mount timeout issue ([#88610](https://github.com/kubernetes/kubernetes/pull/88610), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88610",
+    "pr_number": 88610,
+    "areas": [
+      "provider/azure"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "cloud-provider",
+      "storage"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88636": {
+    "commit": "59c6d339cdfc3759963ff30312b469256fb399b7",
+    "text": "Added GenericPVCDataSource feature gate to enable using arbitrary custom resources as the data source for a PVC.",
+    "markdown": "Added GenericPVCDataSource feature gate to enable using arbitrary custom resources as the data source for a PVC. ([#88636](https://github.com/kubernetes/kubernetes/pull/88636), [@bswartz](https://github.com/bswartz)) [SIG Apps and Storage]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/commit/933a044fa4efc137cd6a6479c96cbf627a4e92cc",
+        "type": "KEP"
+      }
+    ],
+    "author": "bswartz",
+    "author_url": "https://github.com/bswartz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88636",
+    "pr_number": 88636,
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "apps",
+      "storage"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88655": {
+    "commit": "b9696133ffe5a2ae0c7869753a5096419cd3b62c",
+    "text": "Deprecate --generator flag from kubectl create commands",
+    "markdown": "Deprecate --generator flag from kubectl create commands ([#88655](https://github.com/kubernetes/kubernetes/pull/88655), [@soltysh](https://github.com/soltysh)) [SIG CLI]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88655",
+    "pr_number": 88655,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88657": {
+    "commit": "01593144e663c2a7721eb19bf55e53e784a64fbb",
+    "text": "validate kube-proxy flags --ipvs-tcp-timeout, --ipvs-tcpfin-timeout, --ipvs-udp-timeout",
+    "markdown": "Validate kube-proxy flags --ipvs-tcp-timeout, --ipvs-tcpfin-timeout, --ipvs-udp-timeout ([#88657](https://github.com/kubernetes/kubernetes/pull/88657), [@chendotjs](https://github.com/chendotjs)) [SIG Network]",
+    "author": "chendotjs",
+    "author_url": "https://github.com/chendotjs",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88657",
+    "pr_number": 88657,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "network"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88660": {
+    "commit": "7e2394cbb0061d44c6562a908436ef7571ef3230",
+    "text": "Fixed block CSI volume cleanup after timeouts.",
+    "markdown": "Fixed block CSI volume cleanup after timeouts. ([#88660](https://github.com/kubernetes/kubernetes/pull/88660), [@jsafrane](https://github.com/jsafrane)) [SIG Node and Storage]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190130-csi-raw-block-support.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88660",
+    "pr_number": 88660,
+    "areas": [
+      "kubelet"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "node",
+      "storage"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88663": {
+    "commit": "e9d502e4fc2d41dfe3dbf9f901882da55287ea5d",
+    "text": "kube-controller-manager and kube-scheduler expose profiling by default to match the kube-apiserver.  Use `--enable-profiling=false` to disable.",
+    "markdown": "Kube-controller-manager and kube-scheduler expose profiling by default to match the kube-apiserver.  Use `--enable-profiling=false` to disable. ([#88663](https://github.com/kubernetes/kubernetes/pull/88663), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Cloud Provider and Scheduling]",
+    "author": "deads2k",
+    "author_url": "https://github.com/deads2k",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88663",
+    "pr_number": 88663,
+    "kinds": [
+      "api-change",
+      "bug",
+      "cleanup"
+    ],
+    "sigs": [
+      "api-machinery",
+      "cloud-provider",
+      "scheduling"
+    ],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88671": {
+    "commit": "1b4b1553328892e1e5486b5151f423ef78668b52",
+    "text": "DefaultConstraints can be specified for the PodTopologySpread plugin in the component config",
+    "markdown": "DefaultConstraints can be specified for the PodTopologySpread plugin in the component config ([#88671](https://github.com/kubernetes/kubernetes/pull/88671), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20190926-default-even-pod-spreading.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88671",
+    "pr_number": 88671,
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "scheduling"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88673": {
+    "commit": "9d0cbb7503b7070817b3ec08e76f3f3addf3675b",
+    "text": "BlockVolume and CSIBlockVolume features are now GA.",
+    "markdown": "BlockVolume and CSIBlockVolume features are now GA. ([#88673](https://github.com/kubernetes/kubernetes/pull/88673), [@jsafrane](https://github.com/jsafrane)) [SIG Apps, Node and Storage]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190130-csi-raw-block-support.md",
+        "type": "KEP"
+      },
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20191008-raw-block-support.md",
+        "type": "KEP"
+      },
+      {
+        "description": "[Other doc]",
+        "url": "https://github.com/kubernetes/website/pull/19338",
+        "type": "external"
+      }
+    ],
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88673",
+    "pr_number": 88673,
+    "areas": [
+      "kubelet"
+    ],
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "apps",
+      "node",
+      "storage"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88678": {
+    "commit": "ef672c1c2de542e22e95c26994a2652696647502",
+    "text": "For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel.",
+    "markdown": "For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel. ([#88678](https://github.com/kubernetes/kubernetes/pull/88678), [@verult](https://github.com/verult)) [SIG Apps, Node and Storage]",
+    "author": "verult",
+    "author_url": "https://github.com/verult",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88678",
+    "pr_number": 88678,
+    "areas": [
+      "kubelet"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "apps",
+      "node",
+      "storage"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88684": {
+    "commit": "cd23e78c3dc1a4161abb11523a8614b56b9c0928",
+    "text": "AzureFile and CephFS use new Mount library that prevents logging of sensitive mount options.",
+    "markdown": "AzureFile and CephFS use new Mount library that prevents logging of sensitive mount options. ([#88684](https://github.com/kubernetes/kubernetes/pull/88684), [@saad-ali](https://github.com/saad-ali)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation and Storage]",
+    "author": "saad-ali",
+    "author_url": "https://github.com/saad-ali",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88684",
+    "pr_number": 88684,
+    "areas": [
+      "apiserver",
+      "cloudprovider",
+      "dependency",
+      "kubectl"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery",
+      "cli",
+      "cloud-provider",
+      "cluster-lifecycle",
+      "instrumentation",
+      "storage"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88686": {
+    "commit": "e865c0b21945ca1ad0792e89c13bf9ed074a3806",
+    "text": "VolumePVCDataSource moves to GA in 1.18 release",
+    "markdown": "VolumePVCDataSource moves to GA in 1.18 release ([#88686](https://github.com/kubernetes/kubernetes/pull/88686), [@j-griffith](https://github.com/j-griffith)) [SIG Apps, CLI and Cluster Lifecycle]",
+    "documentation": [
+      {
+        "url": "https://github.com/kubernetes/website/pull/19318",
+        "type": "external"
+      }
+    ],
+    "author": "j-griffith",
+    "author_url": "https://github.com/j-griffith",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88686",
+    "pr_number": 88686,
+    "areas": [
+      "kubectl",
+      "release-eng"
+    ],
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "apps",
+      "cli",
+      "cluster-lifecycle"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88699": {
+    "commit": "1d407216e7fdc1411b2a3179a976adbc54f608d8",
+    "text": "Azure VMSS LoadBalancerBackendAddressPools updating has been improved with squential-sync + concurrent-async requests.",
+    "markdown": "Azure VMSS LoadBalancerBackendAddressPools updating has been improved with squential-sync + concurrent-async requests. ([#88699](https://github.com/kubernetes/kubernetes/pull/88699), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]",
+    "author": "feiskyer",
+    "author_url": "https://github.com/feiskyer",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88699",
+    "pr_number": 88699,
+    "areas": [
+      "cloudprovider",
+      "provider/azure"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "cloud-provider"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88702": {
+    "commit": "d04219bc8e11fce36ccd5d019dccc5e42094c50b",
+    "text": "conformance image now depends on stretch-slim instead of debian-hyperkube-base as that image is being deprecated and removed.",
+    "markdown": "Conformance image now depends on stretch-slim instead of debian-hyperkube-base as that image is being deprecated and removed. ([#88702](https://github.com/kubernetes/kubernetes/pull/88702), [@dims](https://github.com/dims)) [SIG Cluster Lifecycle, Release and Testing]",
+    "author": "dims",
+    "author_url": "https://github.com/dims",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88702",
+    "pr_number": 88702,
+    "areas": [
+      "conformance",
+      "release-eng"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "cluster-lifecycle",
+      "release",
+      "testing"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88744": {
+    "commit": "79e1ad2f4bbd05b1e56b7b57b63b2c1d67b90156",
+    "text": "client-go certificate manager rotation gained the ability to preserve optional intermediate chains accompanying issued certificates",
+    "markdown": "Client-go certificate manager rotation gained the ability to preserve optional intermediate chains accompanying issued certificates ([#88744](https://github.com/kubernetes/kubernetes/pull/88744), [@jackkleeman](https://github.com/jackkleeman)) [SIG API Machinery and Auth]",
+    "author": "jackkleeman",
+    "author_url": "https://github.com/jackkleeman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88744",
+    "pr_number": 88744,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery",
+      "auth"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88745": {
+    "commit": "c86aec0564e92175c76258825496bc109e77db5f",
+    "text": "New flag --endpointslice-updates-batch-period in kube-controller-manager can be used to reduce number of endpointslice updates generated by pod changes.",
+    "markdown": "New flag --endpointslice-updates-batch-period in kube-controller-manager can be used to reduce number of endpointslice updates generated by pod changes. ([#88745](https://github.com/kubernetes/kubernetes/pull/88745), [@mborsz](https://github.com/mborsz)) [SIG API Machinery, Apps and Network]",
+    "author": "mborsz",
+    "author_url": "https://github.com/mborsz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88745",
+    "pr_number": 88745,
+    "kinds": [
+      "api-change",
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "network"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88758": {
+    "commit": "0535520f6ea655ec05e1bde04c2c45c5c536cde5",
+    "text": "Hide kubectl.kubernetes.io/last-applied-configuration in describe command",
+    "markdown": "Hide kubectl.kubernetes.io/last-applied-configuration in describe command ([#88758](https://github.com/kubernetes/kubernetes/pull/88758), [@soltysh](https://github.com/soltysh)) [SIG Auth and CLI]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88758",
+    "pr_number": 88758,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "auth",
+      "cli"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88765": {
+    "commit": "d682c8389087e55835bbd02ce20cb6110c81731f",
+    "text": "kubectl cluster-info dump changed to only display a message telling you the location where the output was written when the output is not standard output.",
+    "markdown": "Kubectl cluster-info dump changed to only display a message telling you the location where the output was written when the output is not standard output. ([#88765](https://github.com/kubernetes/kubernetes/pull/88765), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]",
+    "author": "brianpursley",
+    "author_url": "https://github.com/brianpursley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88765",
+    "pr_number": 88765,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "cli"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88768": {
+    "commit": "8b8dd79d53ef32994488d8b3c4570093b66f7f34",
+    "text": "Scheduler Extenders can now be configured in the v1alpha2 component config",
+    "markdown": "Scheduler Extenders can now be configured in the v1alpha2 component config ([#88768](https://github.com/kubernetes/kubernetes/pull/88768), [@damemi](https://github.com/damemi)) [SIG Release, Scheduling and Testing]",
+    "author": "damemi",
+    "author_url": "https://github.com/damemi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88768",
+    "pr_number": 88768,
+    "areas": [
+      "release-eng",
+      "test"
+    ],
+    "kinds": [
+      "api-change",
+      "bug"
+    ],
+    "sigs": [
+      "release",
+      "scheduling",
+      "testing"
+    ],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88769": {
+    "commit": "bd6640a8e003059ee98f84e7378d97f8337c5e0b",
+    "text": "Support TLS Server Name overrides in kubeconfig file and via --tls-server-name in kubectl",
+    "markdown": "Support TLS Server Name overrides in kubeconfig file and via --tls-server-name in kubectl ([#88769](https://github.com/kubernetes/kubernetes/pull/88769), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Auth and CLI]",
+    "author": "deads2k",
+    "author_url": "https://github.com/deads2k",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88769",
+    "pr_number": 88769,
+    "areas": [
+      "kubectl"
+    ],
+    "kinds": [
+      "cleanup"
+    ],
+    "sigs": [
+      "api-machinery",
+      "auth",
+      "cli"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88775": {
+    "commit": "edf460bc0f50822e3cb123457445aa63ae87cf10",
+    "text": "ingress: Add alternate backends via TypedLocalObjectReference",
+    "markdown": "Ingress: Add alternate backends via TypedLocalObjectReference ([#88775](https://github.com/kubernetes/kubernetes/pull/88775), [@cmluciano](https://github.com/cmluciano)) [SIG Apps and Network]",
+    "author": "cmluciano",
+    "author_url": "https://github.com/cmluciano",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88775",
+    "pr_number": 88775,
+    "kinds": [
+      "api-change"
+    ],
+    "sigs": [
+      "apps",
+      "network"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88815": {
+    "commit": "45ac57fb67a841a21a689745aa812109fee84b8c",
+    "text": "The EventRecorder from k8s.io/client-go/tools/events will now create events in the default namespace (instead of kube-system) when the related object does not have it set.",
+    "markdown": "The EventRecorder from k8s.io/client-go/tools/events will now create events in the default namespace (instead of kube-system) when the related object does not have it set. ([#88815](https://github.com/kubernetes/kubernetes/pull/88815), [@enj](https://github.com/enj)) [SIG API Machinery]",
+    "author": "enj",
+    "author_url": "https://github.com/enj",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88815",
+    "pr_number": 88815,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88827": {
+    "commit": "a5f7151a15cbf33120ccc0e46eac41002990be84",
+    "text": "kubeadm: deprecate the usage of the experimental flag '--use-api' under the 'kubeadm alpha certs renew' command.",
+    "markdown": "Kubeadm: deprecate the usage of the experimental flag '--use-api' under the 'kubeadm alpha certs renew' command. ([#88827](https://github.com/kubernetes/kubernetes/pull/88827), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]",
+    "author": "neolit123",
+    "author_url": "https://github.com/neolit123",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88827",
+    "pr_number": 88827,
+    "areas": [
+      "kubeadm"
+    ],
+    "kinds": [
+      "deprecation"
+    ],
+    "sigs": [
+      "cluster-lifecycle"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88858": {
+    "commit": "8508875e4d400c1454561aa6d879860984bcdf59",
+    "text": "ingress: allow wildcard hosts in IngressRule",
+    "markdown": "Ingress: allow wildcard hosts in IngressRule ([#88858](https://github.com/kubernetes/kubernetes/pull/88858), [@cmluciano](https://github.com/cmluciano)) [SIG Network]",
+    "author": "cmluciano",
+    "author_url": "https://github.com/cmluciano",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88858",
+    "pr_number": 88858,
+    "kinds": [
+      "api-change"
+    ],
+    "sigs": [
+      "network"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88864": {
+    "commit": "1302f343b1e7bddb39b88b1c1be7fff7595c53ce",
+    "text": "Plugin/PluginConfig and Policy APIs are mutually exclusive when running the scheduler",
+    "markdown": "Plugin/PluginConfig and Policy APIs are mutually exclusive when running the scheduler ([#88864](https://github.com/kubernetes/kubernetes/pull/88864), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88864",
+    "pr_number": 88864,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "scheduling"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88870": {
+    "commit": "b0f793a94c3be0f81806ec2f652c55b467090b0d",
+    "text": "Specifying PluginConfig for the same plugin more than once fails scheduler startup.\n\nSpecifying extenders and configuring .ignoredResources for the NodeResourcesFit plugin fails",
+    "markdown": "Specifying PluginConfig for the same plugin more than once fails scheduler startup.\n  \n  Specifying extenders and configuring .ignoredResources for the NodeResourcesFit plugin fails ([#88870](https://github.com/kubernetes/kubernetes/pull/88870), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88870",
+    "pr_number": 88870,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "scheduling"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88879": {
+    "commit": "381a3724556634f8884765d2789fcb9d86ccbec9",
+    "text": "FIX: prevent apiserver from panicking when failing to load audit webhook config file",
+    "markdown": "FIX: prevent apiserver from panicking when failing to load audit webhook config file ([#88879](https://github.com/kubernetes/kubernetes/pull/88879), [@JoshVanL](https://github.com/JoshVanL)) [SIG API Machinery and Auth]",
+    "author": "JoshVanL",
+    "author_url": "https://github.com/JoshVanL",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88879",
+    "pr_number": 88879,
+    "areas": [
+      "apiserver"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery",
+      "auth"
+    ],
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88906": {
+    "commit": "cf4d797b5dddef1b1e06a50ebda8a0738e04b66c",
+    "text": "Signatures on the dynamic client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference.",
+    "markdown": "Signatures on the dynamic client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference. ([#88906](https://github.com/kubernetes/kubernetes/pull/88906), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps, CLI, Cluster Lifecycle, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88906",
+    "pr_number": 88906,
+    "areas": [
+      "apiserver",
+      "e2e-test-framework",
+      "kubeadm",
+      "kubectl",
+      "test"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "cli",
+      "cluster-lifecycle",
+      "storage",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88910": {
+    "commit": "f52cbea102bb6ba9fe951cbf81e7dd4b48f95d9e",
+    "text": "Signatures on the metadata client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference.",
+    "markdown": "Signatures on the metadata client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference. ([#88910](https://github.com/kubernetes/kubernetes/pull/88910), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88910",
+    "pr_number": 88910,
+    "areas": [
+      "test"
+    ],
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88911": {
+    "commit": "ab40772439f5b474929c74a90ba462bbe6999f1f",
+    "text": "Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed.",
+    "markdown": "Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed. ([#88911](https://github.com/kubernetes/kubernetes/pull/88911), [@tkashem](https://github.com/tkashem)) [SIG API Machinery]",
+    "author": "tkashem",
+    "author_url": "https://github.com/tkashem",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88911",
+    "pr_number": 88911,
+    "areas": [
+      "apiserver"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery"
+    ],
+    "release_version": "1.18.0-beta.2"
+  },
+  "88935": {
+    "commit": "900143c6d490616604d2f91e979d591eb78c20ae",
+    "text": "Adds support for NodeCIDR as an argument to --detect-local-mode",
+    "markdown": "Adds support for NodeCIDR as an argument to --detect-local-mode ([#88935](https://github.com/kubernetes/kubernetes/pull/88935), [@satyasm](https://github.com/satyasm)) [SIG Network]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20191104-iptables-no-cluster-cidr.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "satyasm",
+    "author_url": "https://github.com/satyasm",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88935",
+    "pr_number": 88935,
+    "kinds": [
+      "feature"
+    ],
+    "sigs": [
+      "network"
+    ],
+    "feature": true,
+    "release_version": "1.18.0-beta.2"
+  },
+  "88995": {
+    "commit": "307bafb86035690a1135b421a55219e857703361",
+    "text": "Fixes conversion error in multi-version custom resources that could cause metadata.generation to increment on no-op patches or updates of a custom resource.",
+    "markdown": "Fixes conversion error in multi-version custom resources that could cause metadata.generation to increment on no-op patches or updates of a custom resource. ([#88995](https://github.com/kubernetes/kubernetes/pull/88995), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88995",
+    "pr_number": 88995,
+    "areas": [
+      "apiserver",
+      "custom-resources"
+    ],
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery"
+    ],
+    "release_version": "1.18.0-beta.2"
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.18.0-beta.2.json',
   'assets/release-notes-1.18.0-beta.1.json',
   'assets/release-notes-1.18.0-beta.0.json',
   'assets/release-notes-1.18.0-alpha.5.json',


### PR DESCRIPTION
release-notes \
  --branch=master \
  --repo-path  /var/folders/35/m9zql4dj7t3_bq6qsq567vqc0000gn/T/k8s \
  --release-version 1.18.0-beta.2 \
  --format json \
  --output src/assets/release-notes-1.18.0-beta.2.json  \
  --start-rev v1.18.0-beta.1 \
  --end-rev v1.18.0-beta.2

cc/ @saschagrunert @evillgenius75 @puerco @JamesLaverack