### PR TITLE
Patch relnotes.k8s.io with release v1.18.0-rc.1

### DIFF
--- a/src/assets/release-notes-1.18.0-rc.1.json
+++ b/src/assets/release-notes-1.18.0-rc.1.json
@@ -1,0 +1,111 @@
+{
+  "88786": {
+    "commit": "0d85d1629c1c98b48677e66e20bec42fd6d90fd6",
+    "text": "Fix a bug where ExternalTrafficPolicy is not applied to service ExternalIPs.",
+    "markdown": "Fix a bug where ExternalTrafficPolicy is not applied to service ExternalIPs. ([#88786](https://github.com/kubernetes/kubernetes/pull/88786), [@freehan](https://github.com/freehan)) [SIG Network]",
+    "author": "freehan",
+    "author_url": "https://github.com/freehan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88786",
+    "pr_number": 88786,
+    "areas": ["ipvs", "kube-proxy"],
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "88915": {
+    "commit": "562a420d86cbe3845835e89bcda77c1f4c35904d",
+    "text": "Fixed a data race in kubelet image manager that can cause static pod workers to silently stop working.",
+    "markdown": "Fixed a data race in kubelet image manager that can cause static pod workers to silently stop working. ([#88915](https://github.com/kubernetes/kubernetes/pull/88915), [@roycaihw](https://github.com/roycaihw)) [SIG Node]",
+    "author": "roycaihw",
+    "author_url": "https://github.com/roycaihw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88915",
+    "pr_number": 88915,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "88934": {
+    "commit": "0ec85a146708492bb62b8d797e5d28770250c155",
+    "text": "kube-proxy: on dual-stack mode, if it is not able to get the IP Family of an endpoint, logs it with level InfoV(4) instead of Warning, avoiding flooding the logs for endpoints without addresses",
+    "markdown": "Kube-proxy: on dual-stack mode, if it is not able to get the IP Family of an endpoint, logs it with level InfoV(4) instead of Warning, avoiding flooding the logs for endpoints without addresses ([#88934](https://github.com/kubernetes/kubernetes/pull/88934), [@aojea](https://github.com/aojea)) [SIG Network]",
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88934",
+    "pr_number": 88934,
+    "kinds": ["bug", "cleanup"],
+    "sigs": ["network"],
+    "duplicate_kind": true
+  },
+  "89002": {
+    "commit": "cb3856042212fcc85ea12c95e5d17ab7f6c286c8",
+    "text": "Fix invalid VMSS updates due to incorrect cache",
+    "markdown": "Fix invalid VMSS updates due to incorrect cache ([#89002](https://github.com/kubernetes/kubernetes/pull/89002), [@ArchangelSDY](https://github.com/ArchangelSDY)) [SIG Cloud Provider]",
+    "author": "ArchangelSDY",
+    "author_url": "https://github.com/ArchangelSDY",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89002",
+    "pr_number": 89002,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "89055": {
+    "commit": "2b63c09d2e00b76b5a5d40cd5bdb7789b3614ed6",
+    "text": "Fixed an issue that could cause the kubelet to incorrectly run concurrent pod reconciliation loops and crash.",
+    "markdown": "Fixed an issue that could cause the kubelet to incorrectly run concurrent pod reconciliation loops and crash. ([#89055](https://github.com/kubernetes/kubernetes/pull/89055), [@tedyu](https://github.com/tedyu)) [SIG Node]",
+    "author": "tedyu",
+    "author_url": "https://github.com/tedyu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89055",
+    "pr_number": 89055,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "89056": {
+    "commit": "3491129d348eb6fb5e4274112df5a946ded740af",
+    "text": "EndpointSlice should not contain endpoints for terminating pods",
+    "markdown": "EndpointSlice should not contain endpoints for terminating pods ([#89056](https://github.com/kubernetes/kubernetes/pull/89056), [@andrewsykim](https://github.com/andrewsykim)) [SIG Apps and Network]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89056",
+    "pr_number": 89056,
+    "kinds": ["bug"],
+    "sigs": ["apps", "network"],
+    "duplicate": true
+  },
+  "89093": {
+    "commit": "bce16df824cc48b96282c7f7fa60487eccef2233",
+    "text": "Removes ConfigMap as suggestion for IngressClass parameters",
+    "markdown": "Removes ConfigMap as suggestion for IngressClass parameters ([#89093](https://github.com/kubernetes/kubernetes/pull/89093), [@robscott](https://github.com/robscott)) [SIG Network]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89093",
+    "pr_number": 89093,
+    "kinds": ["api-change", "documentation"],
+    "sigs": ["network"],
+    "duplicate_kind": true
+  },
+  "89095": {
+    "commit": "ff21f4568040dfc36e76386d2be153079e3f170f",
+    "text": "Update Cluster Autoscaler to 1.18.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.18.0",
+    "markdown": "Update Cluster Autoscaler to 1.18.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.18.0 ([#89095](https://github.com/kubernetes/kubernetes/pull/89095), [@losipiuk](https://github.com/losipiuk)) [SIG Autoscaling and Cluster Lifecycle]",
+    "author": "losipiuk",
+    "author_url": "https://github.com/losipiuk",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89095",
+    "pr_number": 89095,
+    "areas": ["release-eng"],
+    "kinds": ["bug"],
+    "sigs": ["autoscaling", "cluster-lifecycle"],
+    "duplicate": true
+  },
+  "89138": {
+    "commit": "adf4ccab61d4fecd4af3ba12d5e4f1fb3ae58c96",
+    "text": "Fix isCurrentInstance for Windows by removing the dependency of hostname.",
+    "markdown": "Fix isCurrentInstance for Windows by removing the dependency of hostname. ([#89138](https://github.com/kubernetes/kubernetes/pull/89138), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]",
+    "author": "feiskyer",
+    "author_url": "https://github.com/feiskyer",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89138",
+    "pr_number": 89138,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.18.0-rc.1.json',
   'assets/release-notes-1.18.0-beta.2.json',
   'assets/release-notes-1.18.0-beta.1.json',
   'assets/release-notes-1.18.0-beta.0.json',


### PR DESCRIPTION
First patch to relnotes.k8s.io to be generated with krel!!

```bash
krel \
   release-notes \
   --tag v1.18.0-rc.1 \
   --website-org=puerco \
   --website-repo=release-notes  \
   --create-website-pr 
```
Please take a look at the output in case there are any errors. The files seem fine to me

cc/ @saschagrunert @evillgenius75 @reylejano-rxm  @JamesLaverack 

Signed-off-by: Puerco <adolfo.garcia@uservers.net>