### PR TITLE
Patch relnotes.k8s.io to release v1.19.0-rc.4

### DIFF
--- a/src/assets/release-notes-1.19.0-rc.4.json
+++ b/src/assets/release-notes-1.19.0-rc.4.json
@@ -1,0 +1,69 @@
+{
+  "93408": {
+    "commit": "c0ec2eee41794796dee230f75478602b707f2be2",
+    "text": "kube-apiserver: jsonpath expressions with consecutive recursive descent operators are no longer evaluated for custom resource printer columns",
+    "markdown": "Kube-apiserver: jsonpath expressions with consecutive recursive descent operators are no longer evaluated for custom resource printer columns ([#93408](https://github.com/kubernetes/kubernetes/pull/93408), [@joelsmith](https://github.com/joelsmith)) [SIG API Machinery]",
+    "author": "joelsmith",
+    "author_url": "https://github.com/joelsmith",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93408",
+    "pr_number": 93408,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"],
+    "release_version": "1.19.0-rc.4"
+  },
+  "93442": {
+    "commit": "9d8a87b5c76c19032d1ba0ed4d72eae429e99928",
+    "text": "EndpointSliceMirroring controller now copies labels from Endpoints to EndpointSlices.",
+    "markdown": "EndpointSliceMirroring controller now copies labels from Endpoints to EndpointSlices. ([#93442](https://github.com/kubernetes/kubernetes/pull/93442), [@robscott](https://github.com/robscott)) [SIG Apps and Network]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93442",
+    "pr_number": 93442,
+    "kinds": ["bug"],
+    "sigs": ["apps", "network"],
+    "duplicate": true,
+    "release_version": "1.19.0-rc.4"
+  },
+  "93570": {
+    "commit": "b7d44329f3514a65af9048224329a4897cf4d31d",
+    "text": "kube-apiserver: the componentstatus API is deprecated. This API provided status of etcd, kube-scheduler, and kube-controller-manager components, but only worked when those components were local to the API server, and when kube-scheduler and kube-controller-manager exposed unsecured health endpoints. Instead of this API, etcd health is included in the kube-apiserver health check and kube-scheduler/kube-controller-manager health checks can be made directly against those components' health endpoints.",
+    "markdown": "Kube-apiserver: the componentstatus API is deprecated. This API provided status of etcd, kube-scheduler, and kube-controller-manager components, but only worked when those components were local to the API server, and when kube-scheduler and kube-controller-manager exposed unsecured health endpoints. Instead of this API, etcd health is included in the kube-apiserver health check and kube-scheduler/kube-controller-manager health checks can be made directly against those components' health endpoints. ([#93570](https://github.com/kubernetes/kubernetes/pull/93570), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps and Cluster Lifecycle]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93570",
+    "pr_number": 93570,
+    "kinds": ["api-change", "deprecation"],
+    "sigs": ["api-machinery", "apps", "cluster-lifecycle"],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "release_version": "1.19.0-rc.4"
+  },
+  "93600": {
+    "commit": "ec560b9737537be8c688776461bc700e8ddedb9d",
+    "text": "A panic in the apiserver caused by the `informer-sync` health checker is now fixed.",
+    "markdown": "A panic in the apiserver caused by the `informer-sync` health checker is now fixed. ([#93600](https://github.com/kubernetes/kubernetes/pull/93600), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG API Machinery]",
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93600",
+    "pr_number": 93600,
+    "areas": ["apiserver"],
+    "kinds": ["bug", "regression"],
+    "sigs": ["api-machinery"],
+    "duplicate_kind": true,
+    "release_version": "1.19.0-rc.4"
+  },
+  "93667": {
+    "commit": "c3816157f97cc068600b0dbebdbe80733ee5c3eb",
+    "text": "build: Update to debian-base@v2.1.0 and debian-iptables@v12.1.1",
+    "markdown": "Build: Update to debian-base@v2.1.0 and debian-iptables@v12.1.1 ([#93667](https://github.com/kubernetes/kubernetes/pull/93667), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, Release and Testing]",
+    "author": "justaugustus",
+    "author_url": "https://github.com/justaugustus",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93667",
+    "pr_number": 93667,
+    "areas": ["dependency", "release-eng", "security", "test"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "release", "testing"],
+    "duplicate": true,
+    "release_version": "1.19.0-rc.4"
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.19.0-rc.4.json',
   'assets/release-notes-1.19.0-rc.3.json',
   'assets/release-notes-1.19.0-rc.2.json',
   'assets/release-notes-1.18.6.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.19.0-rc.4` 