### PR TITLE
Sort release versions by semver

### DIFF
--- a/src/app/shared/model/options.model.ts
+++ b/src/app/shared/model/options.model.ts
@@ -85,7 +85,18 @@ export class Options {
     [OptionType.areas, OptionType.kinds, OptionType.sigs, OptionType.documentation].forEach(x =>
       this.sort_set(x),
     );
-    this.sort_set(OptionType.releaseVersions, (a, b) => (a < b ? 1 : -1));
+    this.sort_set(OptionType.releaseVersions, (a, b) =>
+      a
+        .split('.')
+        .map(n => +n + 100000)
+        .join('.') <
+      b
+        .split('.')
+        .map(n => +n + 100000)
+        .join('.')
+        ? 1
+        : -1,
+    );
   }
 
   /**


### PR DESCRIPTION
This fixes an issue that the release versions are not sorted correctly
by their semver logical order.

Before:
![screenshot](https://user-images.githubusercontent.com/695473/92224547-3b95b100-eea2-11ea-838e-04bf157ea70e.png)

After: 
![screenshot](https://user-images.githubusercontent.com/695473/92224570-47817300-eea2-11ea-8aba-290e59f663f6.png)

