### PR TITLE
Fix last v1.19.0 release note

### DIFF
--- a/src/assets/release-notes-1.19.0.json
+++ b/src/assets/release-notes-1.19.0.json
@@ -5705,6 +5705,7 @@
     "kinds": ["cleanup", "deprecation"],
     "sigs": ["api-machinery", "auth", "cluster-lifecycle", "scalability", "scheduling", "testing"],
     "duplicate": true,
-    "action_required": true
+    "action_required": true,
+    "release_version": "1.19.0"
   }
 }


### PR DESCRIPTION
The release version was not set correctly for this release note.

Fixes the issue with the empty release version on the master branch:
![screenshot](https://user-images.githubusercontent.com/695473/92225398-71876500-eea3-11ea-8fb4-207cfaa07260.png)
