### PR TITLE
Throw error if assets paths have wrong format

### DIFF
--- a/src/app/notes/notes.service.ts
+++ b/src/app/notes/notes.service.ts
@@ -65,6 +65,11 @@ export class NotesService {
    * @returns The release version
    */
   private releaseVersionFromPath(path: string): string {
-    return path.replace(/^.*release-notes-/, '').replace(/.json$/, '');
+    // Enforce asset path syntax
+    const regex = /^.*release-notes-[0-9]\.[0-9]+\.[0-9]+.*\.json$/;
+    if (!path.match(regex)) {
+      throw new Error(`Asset path "${path}" does not match regex ${regex}`);
+    }
+    return path.replace(/^.*release-notes-/, '').replace(/\.json$/, '');
   }
 }


### PR DESCRIPTION
We now display an information to the user if assets have the wrong path
format. This should prevent us from merging wrong formatted assets.

Relates to https://github.com/kubernetes-sigs/release-notes/issues/193

How it looks like:
![screenshot](https://user-images.githubusercontent.com/695473/92277422-3ad93b00-eef3-11ea-8e67-629c545d5e12.png)
