### PR TITLE
Patch relnotes.k8s.io to release v1.20.0-alpha.3

### DIFF
--- a/src/assets/release-notes-1.20.0-alpha.3.json
+++ b/src/assets/release-notes-1.20.0-alpha.3.json
@@ -1,0 +1,438 @@
+{
+  "77398": {
+    "commit": "4dbb55fe85f504de3e28eccf7987944df82ed686",
+    "text": "Kubernetes E2E test image manifest lists now contain Windows images.",
+    "markdown": "Kubernetes E2E test image manifest lists now contain Windows images. ([#77398](https://github.com/kubernetes/kubernetes/pull/77398), [@claudiubelu](https://github.com/claudiubelu)) [SIG Testing and Windows]",
+    "author": "claudiubelu",
+    "author_url": "https://github.com/claudiubelu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/77398",
+    "pr_number": 77398,
+    "areas": ["test"],
+    "kinds": ["bug", "feature"],
+    "sigs": ["testing", "windows"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "78153": {
+    "commit": "46b5eb333850b851b44bcc11cbee06d257315fb6",
+    "text": "Adds `create ingress` command to `kubectl`",
+    "markdown": "Adds `create ingress` command to `kubectl` ([#78153](https://github.com/kubernetes/kubernetes/pull/78153), [@amimof](https://github.com/amimof)) [SIG CLI and Network]",
+    "author": "amimof",
+    "author_url": "https://github.com/amimof",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/78153",
+    "pr_number": 78153,
+    "areas": ["dependency", "kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "network"],
+    "feature": true,
+    "duplicate": true
+  },
+  "91931": {
+    "commit": "0a20321bab20a6fe3f3ef3c8e055125d705049cb",
+    "text": "fix func name NewCreateCreateDeploymentOptions",
+    "markdown": "Fix func name NewCreateCreateDeploymentOptions ([#91931](https://github.com/kubernetes/kubernetes/pull/91931), [@lixiaobing1](https://github.com/lixiaobing1)) [SIG CLI]",
+    "author": "lixiaobing1",
+    "author_url": "https://github.com/lixiaobing1",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/91931",
+    "pr_number": 91931,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "92507": {
+    "commit": "4bbf4111e2e04e61945a0cfa106f8e7ae827b901",
+    "text": "Added new k8s.io/component-helpers repository providing shared helper code for (core) components.",
+    "markdown": "Added new k8s.io/component-helpers repository providing shared helper code for (core) components. ([#92507](https://github.com/kubernetes/kubernetes/pull/92507), [@ingvagabund](https://github.com/ingvagabund)) [SIG Apps, Node, Release and Scheduling]",
+    "author": "ingvagabund",
+    "author_url": "https://github.com/ingvagabund",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92507",
+    "pr_number": 92507,
+    "areas": ["code-organization", "dependency", "kubelet", "release-eng"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "node", "release", "scheduling"],
+    "feature": true,
+    "duplicate": true
+  },
+  "93534": {
+    "commit": "c72b30b3b7760713477114bb0eb2c62a12908265",
+    "text": "Scheduling Framework: expose Run[Pre]ScorePlugins functions to PreemptionHandle which can be used in PostFilter extention point.",
+    "markdown": "Scheduling Framework: expose Run[Pre]ScorePlugins functions to PreemptionHandle which can be used in PostFilter extention point. ([#93534](https://github.com/kubernetes/kubernetes/pull/93534), [@everpeace](https://github.com/everpeace)) [SIG Scheduling and Testing]",
+    "author": "everpeace",
+    "author_url": "https://github.com/everpeace",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93534",
+    "pr_number": 93534,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "94327": {
+    "commit": "35e20f1742db382d56081b7e5d6efd1382d15401",
+    "text": "kubectl create now supports creating ingress objects.",
+    "markdown": "Kubectl create now supports creating ingress objects. ([#94327](https://github.com/kubernetes/kubernetes/pull/94327), [@rikatz](https://github.com/rikatz)) [SIG CLI and Network]",
+    "author": "rikatz",
+    "author_url": "https://github.com/rikatz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94327",
+    "pr_number": 94327,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "network"],
+    "feature": true,
+    "duplicate": true
+  },
+  "94489": {
+    "commit": "3175b59ac24782b6f4849594589675700e6ba3c0",
+    "text": "An issues preventing volume expand controller to annotate the PVC with `volume.kubernetes.io/storage-resizer` when the PVC StorageClass is already updated to the out-of-tree provisioner is now fixed.",
+    "markdown": "An issues preventing volume expand controller to annotate the PVC with `volume.kubernetes.io/storage-resizer` when the PVC StorageClass is already updated to the out-of-tree provisioner is now fixed. ([#94489](https://github.com/kubernetes/kubernetes/pull/94489), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG API Machinery, Apps and Storage]",
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94489",
+    "pr_number": 94489,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "apps", "storage"],
+    "duplicate": true
+  },
+  "94916": {
+    "commit": "4ca119f521bf6e3bf2af2d8ca7e0010c72b39e83",
+    "text": "Change the mount way from systemd to normal mount except ceph and glusterfs intree-volume.",
+    "markdown": "Change the mount way from systemd to normal mount except ceph and glusterfs intree-volume. ([#94916](https://github.com/kubernetes/kubernetes/pull/94916), [@smileusd](https://github.com/smileusd)) [SIG Apps, Cloud Provider, Network, Node, Storage and Testing]",
+    "author": "smileusd",
+    "author_url": "https://github.com/smileusd",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94916",
+    "pr_number": 94916,
+    "areas": ["cloudprovider", "kubelet", "test"],
+    "kinds": ["bug"],
+    "sigs": ["apps", "cloud-provider", "network", "node", "storage", "testing"],
+    "duplicate": true
+  },
+  "94985": {
+    "commit": "2318a13228dfaadd2de4669c8ce3ffb126ed3958",
+    "text": "Fixed a bug causing incorrect formatting of `kubectl describe ingress`.",
+    "markdown": "Fixed a bug causing incorrect formatting of `kubectl describe ingress`. ([#94985](https://github.com/kubernetes/kubernetes/pull/94985), [@howardjohn](https://github.com/howardjohn)) [SIG CLI and Network]",
+    "author": "howardjohn",
+    "author_url": "https://github.com/howardjohn",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94985",
+    "pr_number": 94985,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli", "network"],
+    "duplicate": true
+  },
+  "95048": {
+    "commit": "78ece5411a83029ae32bb877c05dfb93c532b24a",
+    "text": "New parameter `defaultingType` for `PodTopologySpread` plugin allows to use k8s defined or user provided default constraints",
+    "markdown": "New parameter `defaultingType` for `PodTopologySpread` plugin allows to use k8s defined or user provided default constraints ([#95048](https://github.com/kubernetes/kubernetes/pull/95048), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://git.k8s.io/enhancements/keps/sig-scheduling/1258-default-pod-topology-spread",
+        "type": "external"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#cluster-level-default-constraints",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95048",
+    "pr_number": 95048,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "95069": {
+    "commit": "6268e6f990522289a6a2c25db5d9cacc0988171b",
+    "text": "Scheduler framework interface moved from pkg/scheduler/framework/v1alpha to pkg/scheduler/framework",
+    "markdown": "Scheduler framework interface moved from pkg/scheduler/framework/v1alpha to pkg/scheduler/framework ([#95069](https://github.com/kubernetes/kubernetes/pull/95069), [@farah](https://github.com/farah)) [SIG Scheduling, Storage and Testing]",
+    "author": "farah",
+    "author_url": "https://github.com/farah",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95069",
+    "pr_number": 95069,
+    "areas": ["e2e-test-framework", "test"],
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "storage", "testing"],
+    "duplicate": true
+  },
+  "95252": {
+    "commit": "477b14b3c4545d121d68a98e41b1256760f92c82",
+    "text": "Reorganized iptables rules to fix a performance issue",
+    "markdown": "Reorganized iptables rules to fix a performance issue ([#95252](https://github.com/kubernetes/kubernetes/pull/95252), [@tssurya](https://github.com/tssurya)) [SIG Network]",
+    "author": "tssurya",
+    "author_url": "https://github.com/tssurya",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95252",
+    "pr_number": 95252,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "95260": {
+    "commit": "86a208edc8dab91064513884175c3314b051a0d6",
+    "text": "Fixes high CPU usage in kubectl drain",
+    "markdown": "Fixes high CPU usage in kubectl drain ([#95260](https://github.com/kubernetes/kubernetes/pull/95260), [@amandahla](https://github.com/amandahla)) [SIG CLI]",
+    "author": "amandahla",
+    "author_url": "https://github.com/amandahla",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95260",
+    "pr_number": 95260,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "95267": {
+    "commit": "c71519e53da7a79b9f5748d40d3b68aae172a18d",
+    "text": "SetHostnameAsFQDN has been graduated to Beta and therefore it is enabled by default.",
+    "markdown": "SetHostnameAsFQDN has been graduated to Beta and therefore it is enabled by default. ([#95267](https://github.com/kubernetes/kubernetes/pull/95267), [@javidiaz](https://github.com/javidiaz)) [SIG Node]",
+    "author": "javidiaz",
+    "author_url": "https://github.com/javidiaz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95267",
+    "pr_number": 95267,
+    "kinds": ["feature"],
+    "sigs": ["node"],
+    "feature": true
+  },
+  "95412": {
+    "commit": "dee62a726772678f490c4b0fe7e214c79b563f67",
+    "text": "No",
+    "markdown": "No ([#95412](https://github.com/kubernetes/kubernetes/pull/95412), [@saikat-royc](https://github.com/saikat-royc)) [SIG Cloud Provider]",
+    "author": "saikat-royc",
+    "author_url": "https://github.com/saikat-royc",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95412",
+    "pr_number": 95412,
+    "areas": ["provider/gcp"],
+    "kinds": ["cleanup"],
+    "sigs": ["cloud-provider"]
+  },
+  "95419": {
+    "commit": "acb3beaae4e52ff2f06ebfd3664e348821231cca",
+    "text": "kubeadm: update the default pause image version to 1.4.0 on Windows. With this update the image supports Windows versions 1809 (2019LTS), 1903, 1909, 2004",
+    "markdown": "Kubeadm: update the default pause image version to 1.4.0 on Windows. With this update the image supports Windows versions 1809 (2019LTS), 1903, 1909, 2004 ([#95419](https://github.com/kubernetes/kubernetes/pull/95419), [@jsturtevant](https://github.com/jsturtevant)) [SIG Cluster Lifecycle and Windows]",
+    "author": "jsturtevant",
+    "author_url": "https://github.com/jsturtevant",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95419",
+    "pr_number": 95419,
+    "areas": ["kubeadm"],
+    "kinds": ["cleanup"],
+    "sigs": ["cluster-lifecycle", "windows"],
+    "duplicate": true
+  },
+  "95427": {
+    "commit": "36a6a6493621d3b0796478bc6c08b80b82282601",
+    "text": "Fixed a bug in client-go where new clients with customized `Dial`, `Proxy`, `GetCert` config may get stale HTTP transports.",
+    "markdown": "Fixed a bug in client-go where new clients with customized `Dial`, `Proxy`, `GetCert` config may get stale HTTP transports. ([#95427](https://github.com/kubernetes/kubernetes/pull/95427), [@roycaihw](https://github.com/roycaihw)) [SIG API Machinery]",
+    "author": "roycaihw",
+    "author_url": "https://github.com/roycaihw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95427",
+    "pr_number": 95427,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "95447": {
+    "commit": "e799c852fb337be414fa2dae982fed69a67806fe",
+    "text": "Fix vsphere detach failure for static PVs",
+    "markdown": "Fix vsphere detach failure for static PVs ([#95447](https://github.com/kubernetes/kubernetes/pull/95447), [@gnufied](https://github.com/gnufied)) [SIG Cloud Provider and Storage]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95447",
+    "pr_number": 95447,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider", "storage"],
+    "duplicate": true
+  },
+  "95448": {
+    "commit": "fbe806ef9e07f88d631f922062a7b18070922f42",
+    "text": "SelectorSpreadPriority maps to PodTopologySpread plugin when DefaultPodTopologySpread feature is enabled",
+    "markdown": "SelectorSpreadPriority maps to PodTopologySpread plugin when DefaultPodTopologySpread feature is enabled ([#95448](https://github.com/kubernetes/kubernetes/pull/95448), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://git.k8s.io/enhancements/keps/sig-scheduling/1258-default-pod-topology-spread",
+        "type": "external"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95448",
+    "pr_number": 95448,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "95456": {
+    "commit": "fa15799f7409b8644221c2b43a494c74aac0c5ee",
+    "text": "fix azure disk data loss issue on Windows when unmount disk",
+    "markdown": "Fix azure disk data loss issue on Windows when unmount disk ([#95456](https://github.com/kubernetes/kubernetes/pull/95456), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95456",
+    "pr_number": 95456,
+    "areas": ["provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider", "storage"],
+    "duplicate": true
+  },
+  "95463": {
+    "commit": "53d9bed6e0e140eb9913eb853ac57950841eed66",
+    "text": "fix azure disk attach failure for disk size bigger than 4TB",
+    "markdown": "Fix azure disk attach failure for disk size bigger than 4TB ([#95463](https://github.com/kubernetes/kubernetes/pull/95463), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95463",
+    "pr_number": 95463,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "95505": {
+    "commit": "e7f319870ab15cd2b491b39a77af2aca0c2810d4",
+    "text": "Windows hyper-v container featuregate is deprecated in 1.20 and will be removed in 1.21",
+    "markdown": "Windows hyper-v container featuregate is deprecated in 1.20 and will be removed in 1.21 ([#95505](https://github.com/kubernetes/kubernetes/pull/95505), [@wawa0210](https://github.com/wawa0210)) [SIG Node and Windows]",
+    "author": "wawa0210",
+    "author_url": "https://github.com/wawa0210",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95505",
+    "pr_number": 95505,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "windows"],
+    "duplicate": true,
+    "action_required": true
+  },
+  "95539": {
+    "commit": "b2de4a6159e5e6836b34f12cd172e44f31042126",
+    "text": "New default scheduling plugins order reduces scheduling and preemption latency when taints and node affinity are used",
+    "markdown": "New default scheduling plugins order reduces scheduling and preemption latency when taints and node affinity are used ([#95539](https://github.com/kubernetes/kubernetes/pull/95539), [@soulxu](https://github.com/soulxu)) [SIG Scheduling]",
+    "author": "soulxu",
+    "author_url": "https://github.com/soulxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95539",
+    "pr_number": 95539,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "95542": {
+    "commit": "d7e0cb0e35dba826ca97ef4c29f2cf80a59b052c",
+    "text": "Support the node label `node.kubernetes.io/exclude-from-external-load-balancers`",
+    "markdown": "Support the node label `node.kubernetes.io/exclude-from-external-load-balancers` ([#95542](https://github.com/kubernetes/kubernetes/pull/95542), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95542",
+    "pr_number": 95542,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "95543": {
+    "commit": "722be6647a64cf55b46d785add7790a10e8aa8f3",
+    "text": "Remove the dependency of csi-translation-lib module on apiserver/cloud-provider/controller-manager",
+    "markdown": "Remove the dependency of csi-translation-lib module on apiserver/cloud-provider/controller-manager ([#95543](https://github.com/kubernetes/kubernetes/pull/95543), [@wawa0210](https://github.com/wawa0210)) [SIG Release]",
+    "author": "wawa0210",
+    "author_url": "https://github.com/wawa0210",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95543",
+    "pr_number": 95543,
+    "areas": ["code-organization", "dependency", "release-eng"],
+    "kinds": ["cleanup"],
+    "sigs": ["release"]
+  },
+  "95562": {
+    "commit": "cd8b87f25a25a647eb5818dc42af4ac64448646b",
+    "text": "Fix verb \u0026 scope reporting for kube-apiserver metrics (LIST reported instead of GET)",
+    "markdown": "Fix verb \u0026 scope reporting for kube-apiserver metrics (LIST reported instead of GET) ([#95562](https://github.com/kubernetes/kubernetes/pull/95562), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Testing]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95562",
+    "pr_number": 95562,
+    "areas": ["apiserver", "test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "testing"],
+    "duplicate": true
+  },
+  "95566": {
+    "commit": "78828078ca213379b304485801a862ec76314e36",
+    "text": "SCTP support in API objects (Pod, Service, NetworkPolicy) is now GA.\nNote that this has no effect on whether SCTP is enabled on nodes at the kernel level,\nand note that some cloud platforms and network plugins do not support SCTP traffic.",
+    "markdown": "SCTP support in API objects (Pod, Service, NetworkPolicy) is now GA.\n  Note that this has no effect on whether SCTP is enabled on nodes at the kernel level,\n  and note that some cloud platforms and network plugins do not support SCTP traffic. ([#95566](https://github.com/kubernetes/kubernetes/pull/95566), [@danwinship](https://github.com/danwinship)) [SIG Apps and Network]",
+    "documentation": [
+      {
+        "description": "[Enhancement]",
+        "url": "https://github.com/kubernetes/enhancements/issues/614",
+        "type": "KEP"
+      },
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/ee5e90d5/keps/sig-network/614-SCTP-support",
+        "type": "KEP"
+      }
+    ],
+    "author": "danwinship",
+    "author_url": "https://github.com/danwinship",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95566",
+    "pr_number": 95566,
+    "kinds": ["feature"],
+    "sigs": ["apps", "network"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95583": {
+    "commit": "9af86e8db8e965d2aec5b8d1762fc7cbab323daa",
+    "text": "fix: smb valid path error",
+    "markdown": "Fix: smb valid path error ([#95583](https://github.com/kubernetes/kubernetes/pull/95583), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95583",
+    "pr_number": 95583,
+    "kinds": ["bug"],
+    "sigs": ["storage"]
+  },
+  "95631": {
+    "commit": "87c8349bdc24cd0f984b025c18605483e7e0c57c",
+    "text": "DefaultPodTopologySpread graduated to Beta. The feature gate is enabled by default.",
+    "markdown": "DefaultPodTopologySpread graduated to Beta. The feature gate is enabled by default. ([#95631](https://github.com/kubernetes/kubernetes/pull/95631), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://git.k8s.io/enhancements/keps/sig-scheduling/1258-default-pod-topology-spread",
+        "type": "external"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#cluster-level-default-constraints",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95631",
+    "pr_number": 95631,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95690": {
+    "commit": "e76e057439fd18c4ff64cc2a5ba853cfacc47fc1",
+    "text": "NO",
+    "markdown": "NO ([#95690](https://github.com/kubernetes/kubernetes/pull/95690), [@nikhita](https://github.com/nikhita)) [SIG Release]",
+    "author": "nikhita",
+    "author_url": "https://github.com/nikhita",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95690",
+    "pr_number": 95690,
+    "areas": ["code-organization", "release-eng"],
+    "kinds": ["cleanup"],
+    "sigs": ["release"]
+  },
+  "95694": {
+    "commit": "5f2ebe4bbc7c4c40a69b51babd12dc23cc89bafe",
+    "text": "UDP and SCTP protocols can left stale connections that need to be cleared to avoid services disruption, but they can cause problems that are hard to debug.\nKubernetes components using a loglevel greater or equal than 4 will log the conntrack operations and its output, to show the entries that were deleted.",
+    "markdown": "UDP and SCTP protocols can left stale connections that need to be cleared to avoid services disruption, but they can cause problems that are hard to debug.\n  Kubernetes components using a loglevel greater or equal than 4 will log the conntrack operations and its output, to show the entries that were deleted. ([#95694](https://github.com/kubernetes/kubernetes/pull/95694), [@aojea](https://github.com/aojea)) [SIG Network]",
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95694",
+    "pr_number": 95694,
+    "kinds": ["cleanup", "flake"],
+    "sigs": ["network"],
+    "duplicate_kind": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.20.0-alpha.3.json',
   'assets/release-notes-1.19.3.json',
   'assets/release-notes-1.20.0-alpha.2.json',
   'assets/release-notes-1.18.10.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.20.0-alpha.3` 