### PR TITLE
Patch relnotes.k8s.io to release v1.18.12

### DIFF
--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.18.12.json',
   'assets/release-notes-1.17.14.json',
   'assets/release-notes-1.20.0-beta.1.json',
   'assets/release-notes-1.20.0-alpha.3.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.18.12` 