### PR TITLE
Patch relnotes.k8s.io to release v1.20.0-beta.2

### DIFF
--- a/src/assets/release-notes-1.20.0-beta.2.json
+++ b/src/assets/release-notes-1.20.0-beta.2.json
@@ -1,0 +1,1469 @@
+{
+  "71573": {
+    "commit": "fdee7b2faade14cebb5156033f7d0e00ff6f1277",
+    "text": "Clear UDP conntrack entry on endpoint changes when using nodeport",
+    "markdown": "Clear UDP conntrack entry on endpoint changes when using nodeport ([#71573](https://github.com/kubernetes/kubernetes/pull/71573), [@JacobTanenbaum](https://github.com/JacobTanenbaum)) [SIG Network]",
+    "author": "JacobTanenbaum",
+    "author_url": "https://github.com/JacobTanenbaum",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/71573",
+    "pr_number": 71573,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "74363": {
+    "commit": "c039b02fa7281fc061455e23b6530ed8b4d19645",
+    "text": "Fix client-go prometheus metrics to correctly present the API path accessed in some environments.",
+    "markdown": "Fix client-go prometheus metrics to correctly present the API path accessed in some environments. ([#74363](https://github.com/kubernetes/kubernetes/pull/74363), [@aanm](https://github.com/aanm)) [SIG API Machinery]",
+    "author": "aanm",
+    "author_url": "https://github.com/aanm",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/74363",
+    "pr_number": 74363,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "86102": {
+    "commit": "a27a357ba1b01b82986566da79ced2df54cc56eb",
+    "text": "Add support for hugepages to downward API",
+    "markdown": "Add support for hugepages to downward API ([#86102](https://github.com/kubernetes/kubernetes/pull/86102), [@derekwaynecarr](https://github.com/derekwaynecarr)) [SIG API Machinery, Apps, CLI, Network, Node, Scheduling and Testing]",
+    "author": "derekwaynecarr",
+    "author_url": "https://github.com/derekwaynecarr",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/86102",
+    "pr_number": 86102,
+    "areas": ["kubectl", "kubelet", "test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps", "cli", "network", "node", "scheduling", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "88412": {
+    "commit": "72a7f94bddc4618be4840a928f7075df2da524d7",
+    "text": "Adds a headless service on node-local-cache addon.",
+    "markdown": "Adds a headless service on node-local-cache addon. ([#88412](https://github.com/kubernetes/kubernetes/pull/88412), [@stafot](https://github.com/stafot)) [SIG Cloud Provider and Network]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190424-NodeLocalDNS-beta-proposal.md",
+        "type": "KEP"
+      },
+      {
+        "description": "For whom it might needed: We also created a public Grafana dashboard that can be found [here](",
+        "url": "https://grafana.com/grafana/dashboards/11759) and is based on the previous [dashboard](https://grafana.com/grafana/dashboards/7279) that didn't support NodeLocalDNSCache separated monitoring.",
+        "type": "external"
+      }
+    ],
+    "author": "stafot",
+    "author_url": "https://github.com/stafot",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88412",
+    "pr_number": 88412,
+    "areas": ["provider/gcp", "release-eng"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider", "network"],
+    "feature": true,
+    "duplicate": true
+  },
+  "88759": {
+    "commit": "2b4be7bb5fdf99e17829af16c1804b61adb7bcf5",
+    "text": "For CSI drivers, kubelet no longer creates the target_path for NodePublishVolume in accordance with the CSI spec. Kubelet also no longer checks if staging and target paths are mounts or corrupted. CSI drivers need to be idempotent and do any necessary mount verification.",
+    "markdown": "For CSI drivers, kubelet no longer creates the target_path for NodePublishVolume in accordance with the CSI spec. Kubelet also no longer checks if staging and target paths are mounts or corrupted. CSI drivers need to be idempotent and do any necessary mount verification. ([#88759](https://github.com/kubernetes/kubernetes/pull/88759), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/88759",
+    "pr_number": 88759,
+    "kinds": ["feature"],
+    "sigs": ["storage"],
+    "feature": true,
+    "action_required": true
+  },
+  "90333": {
+    "commit": "1485d462efcfc27047790639543d2cc515a27d7a",
+    "text": "[kubectl] Fail when local source file doesn't exist",
+    "markdown": "[kubectl] Fail when local source file doesn't exist ([#90333](https://github.com/kubernetes/kubernetes/pull/90333), [@bamarni](https://github.com/bamarni)) [SIG CLI]",
+    "author": "bamarni",
+    "author_url": "https://github.com/bamarni",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/90333",
+    "pr_number": 90333,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "92165": {
+    "commit": "6e95025994a571a96da17cb219b8cac21c51c362",
+    "text": "Gradudate the Pod Resources API to G.A\nIntroduces the pod_resources_endpoint_requests_total metric which tracks the total number of requests to the pod resources API",
+    "markdown": "Gradudate the Pod Resources API to G.A\n  Introduces the pod_resources_endpoint_requests_total metric which tracks the total number of requests to the pod resources API ([#92165](https://github.com/kubernetes/kubernetes/pull/92165), [@RenaudWasTaken](https://github.com/RenaudWasTaken)) [SIG Instrumentation, Node and Testing]",
+    "author": "RenaudWasTaken",
+    "author_url": "https://github.com/RenaudWasTaken",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92165",
+    "pr_number": 92165,
+    "areas": ["kubelet", "test"],
+    "kinds": ["feature"],
+    "sigs": ["instrumentation", "node", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "92312": {
+    "commit": "ef16faf409b7aec6b2171ec3e4a39c3f3f68c030",
+    "text": "Add LoadBalancerIPMode feature gate",
+    "markdown": "Add LoadBalancerIPMode feature gate ([#92312](https://github.com/kubernetes/kubernetes/pull/92312), [@Sh4d1](https://github.com/Sh4d1)) [SIG Apps, CLI, Cloud Provider and Network]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/1392",
+        "type": "KEP"
+      }
+    ],
+    "author": "Sh4d1",
+    "author_url": "https://github.com/Sh4d1",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92312",
+    "pr_number": 92312,
+    "areas": ["cloudprovider", "code-generation", "ipvs", "kubectl"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "cli", "cloud-provider", "network"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "92466": {
+    "commit": "4628c605aadb9b3bdf82b3d9e1a2d77580eefcaf",
+    "text": "Add node_authorizer_actions_duration_seconds metric that can be used to estimate load to node authorizer.",
+    "markdown": "Add node_authorizer_actions_duration_seconds metric that can be used to estimate load to node authorizer. ([#92466](https://github.com/kubernetes/kubernetes/pull/92466), [@mborsz](https://github.com/mborsz)) [SIG API Machinery, Auth and Instrumentation]",
+    "author": "mborsz",
+    "author_url": "https://github.com/mborsz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92466",
+    "pr_number": 92466,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "92608": {
+    "commit": "0469db9fe792784368e113ba6578faafb116665d",
+    "text": "For vSphere Cloud Provider, If VM of worker node is deleted, the node will also be deleted by node controller",
+    "markdown": "For vSphere Cloud Provider, If VM of worker node is deleted, the node will also be deleted by node controller ([#92608](https://github.com/kubernetes/kubernetes/pull/92608), [@lubronzhan](https://github.com/lubronzhan)) [SIG Cloud Provider]",
+    "author": "lubronzhan",
+    "author_url": "https://github.com/lubronzhan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92608",
+    "pr_number": 92608,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "92743": {
+    "commit": "e1ab99e0d662f3d9bf89ccf48f71444dbabce37e",
+    "text": "Resolves non-deterministic behavior of the garbage collection controller when ownerReferences with incorrect data are encountered. Events with a reason of `OwnerRefInvalidNamespace` are recorded when namespace mismatches between child and owner objects are detected.\n- A namespaced object with an ownerReference referencing a uid of a namespaced kind which does not exist in the same namespace is now consistently treated as though that owner does not exist, and the child object is deleted.\n- A cluster-scoped object with an ownerReference referencing a uid of a namespaced kind is now consistently treated as though that owner is not resolvable, and the child object is ignored by the garbage collector.",
+    "markdown": "Resolves non-deterministic behavior of the garbage collection controller when ownerReferences with incorrect data are encountered. Events with a reason of `OwnerRefInvalidNamespace` are recorded when namespace mismatches between child and owner objects are detected.\n  - A namespaced object with an ownerReference referencing a uid of a namespaced kind which does not exist in the same namespace is now consistently treated as though that owner does not exist, and the child object is deleted.\n  - A cluster-scoped object with an ownerReference referencing a uid of a namespaced kind is now consistently treated as though that owner is not resolvable, and the child object is ignored by the garbage collector. ([#92743](https://github.com/kubernetes/kubernetes/pull/92743), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps and Testing]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92743",
+    "pr_number": 92743,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "apps", "testing"],
+    "duplicate": true
+  },
+  "92744": {
+    "commit": "f98d3842c2621fb693953c4d1ee78805d3d945a5",
+    "text": "Automatic allocation of NodePorts for services with type LoadBalancer can now be disabled by setting the (new) parameter\nService.spec.allocateLoadBalancerNodePorts=false. The default is to allocate NodePorts for services with type LoadBalancer which is the existing behavior.",
+    "markdown": "Automatic allocation of NodePorts for services with type LoadBalancer can now be disabled by setting the (new) parameter\n  Service.spec.allocateLoadBalancerNodePorts=false. The default is to allocate NodePorts for services with type LoadBalancer which is the existing behavior. ([#92744](https://github.com/kubernetes/kubernetes/pull/92744), [@uablrek](https://github.com/uablrek)) [SIG Apps and Network]",
+    "author": "uablrek",
+    "author_url": "https://github.com/uablrek",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92744",
+    "pr_number": 92744,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "network"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "92967": {
+    "commit": "16c7bf4db45a28803266c4614eaf4e4865d5d951",
+    "text": "New flag is introduced, i.e. --topology-manager-scope=container|pod. \nThe default value is the \"container\" scope.",
+    "markdown": "New flag is introduced, i.e. --topology-manager-scope=container|pod. \n  The default value is the \"container\" scope. ([#92967](https://github.com/kubernetes/kubernetes/pull/92967), [@cezaryzukowski](https://github.com/cezaryzukowski)) [SIG Instrumentation, Node and Testing]",
+    "author": "cezaryzukowski",
+    "author_url": "https://github.com/cezaryzukowski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92967",
+    "pr_number": 92967,
+    "areas": ["apiserver", "code-generation", "e2e-test-framework", "kubelet", "test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["instrumentation", "node", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "92968": {
+    "commit": "cccd77bd3a88643bade3da407065f5fc8312f511",
+    "text": "Add a 'serving' and `terminating` condition to the EndpointSlice API.\n\n`serving` tracks the readiness of endpoints regardless of their terminating state. This is distinct from `ready` since `ready` is only true when pods are not terminating. \n`terminating` is true when an endpoint is terminating. For pods this is any endpoint with a deletion timestamp.",
+    "markdown": "Add a 'serving' and `terminating` condition to the EndpointSlice API.\n  \n  `serving` tracks the readiness of endpoints regardless of their terminating state. This is distinct from `ready` since `ready` is only true when pods are not terminating. \n  `terminating` is true when an endpoint is terminating. For pods this is any endpoint with a deletion timestamp. ([#92968](https://github.com/kubernetes/kubernetes/pull/92968), [@andrewsykim](https://github.com/andrewsykim)) [SIG Apps and Network]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92968",
+    "pr_number": 92968,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "network"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "93130": {
+    "commit": "55856ed727ee4a5d6b71b7e47ee964d82d33539b",
+    "text": "this PR will introduce a feature gate CSIServiceAccountToken with two additional fields in `CSIDriverSpec`.",
+    "markdown": "This PR will introduce a feature gate CSIServiceAccountToken with two additional fields in `CSIDriverSpec`. ([#93130](https://github.com/kubernetes/kubernetes/pull/93130), [@zshihang](https://github.com/zshihang)) [SIG API Machinery, Apps, Auth, CLI, Network, Node, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/1855",
+        "type": "KEP"
+      }
+    ],
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93130",
+    "pr_number": 93130,
+    "areas": [
+      "apiserver",
+      "e2e-test-framework",
+      "ipvs",
+      "kubectl",
+      "kubelet",
+      "release-eng",
+      "test"
+    ],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery", "apps", "auth", "cli", "network", "node", "storage", "testing"],
+    "duplicate": true
+  },
+  "93244": {
+    "commit": "e0a51c9e6b4881df78e046d9c6daf4e6f2a11f78",
+    "text": "kube-apiserver: The timeout used when making health check calls to etcd can now be configured with `--etcd-healthcheck-timeout`. The default timeout is 2 seconds, matching the previous behavior.",
+    "markdown": "Kube-apiserver: The timeout used when making health check calls to etcd can now be configured with `--etcd-healthcheck-timeout`. The default timeout is 2 seconds, matching the previous behavior. ([#93244](https://github.com/kubernetes/kubernetes/pull/93244), [@Sh4d1](https://github.com/Sh4d1)) [SIG API Machinery]",
+    "author": "Sh4d1",
+    "author_url": "https://github.com/Sh4d1",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93244",
+    "pr_number": 93244,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "93370": {
+    "commit": "667d1c2c3fe7f6cece4f74dfd28983d5bdbf4208",
+    "text": "Users can try the cronjob controller v2 using the feature gate. This will be the default controller in future releases.",
+    "markdown": "Users can try the cronjob controller v2 using the feature gate. This will be the default controller in future releases. ([#93370](https://github.com/kubernetes/kubernetes/pull/93370), [@alaypatel07](https://github.com/alaypatel07)) [SIG API Machinery, Apps, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/19-Graduate-CronJob-to-Stable/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "alaypatel07",
+    "author_url": "https://github.com/alaypatel07",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93370",
+    "pr_number": 93370,
+    "areas": ["apiserver", "code-generation", "test"],
+    "kinds": ["api-change", "cleanup"],
+    "sigs": ["api-machinery", "apps", "auth", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "93873": {
+    "commit": "4261200724cd0541b4ff02cc56be866b98142823",
+    "text": "Add a StorageVersionAPI feature gate that makes API server update storageversions before serving certain write requests. \nThis feature allows the storage migrator to manage storage migration for built-in resources. \nEnabling internal.apiserver.k8s.io/v1alpha1 API and APIServerIdentity feature gate are required to use this feature.",
+    "markdown": "Add a StorageVersionAPI feature gate that makes API server update storageversions before serving certain write requests. \n  This feature allows the storage migrator to manage storage migration for built-in resources. \n  Enabling internal.apiserver.k8s.io/v1alpha1 API and APIServerIdentity feature gate are required to use this feature. ([#93873](https://github.com/kubernetes/kubernetes/pull/93873), [@roycaihw](https://github.com/roycaihw)) [SIG API Machinery, Auth and Testing]",
+    "author": "roycaihw",
+    "author_url": "https://github.com/roycaihw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/93873",
+    "pr_number": 93873,
+    "areas": ["apiserver", "test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "94028": {
+    "commit": "c970a46bc1bcc100bbbfabd5c12bd4c5d87f8aea",
+    "text": "The usage of mixed protocol values in the same LoadBalancer Service is possible if the new feature gate MixedProtocolLBSVC is enabled.\n\"action required\"\nThe feature gate is disabled by default. The user has to enable it for the API Server.",
+    "markdown": "The usage of mixed protocol values in the same LoadBalancer Service is possible if the new feature gate MixedProtocolLBSVC is enabled.\n  \"action required\"\n  The feature gate is disabled by default. The user has to enable it for the API Server. ([#94028](https://github.com/kubernetes/kubernetes/pull/94028), [@janosi](https://github.com/janosi)) [SIG API Machinery and Apps]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/commit/4ccf8f53d9ffa4ffdb98afecfc5eb0ed4f5550f3",
+        "type": "KEP"
+      }
+    ],
+    "author": "janosi",
+    "author_url": "https://github.com/janosi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94028",
+    "pr_number": 94028,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "94115": {
+    "commit": "fe3779832963d00388f6e93ac58be966f8f83868",
+    "text": "a bug was fixed in kubelet where exec probe timeouts were not respected. Ensure that pods relying on this behavior are updated to correctly handle probe timeouts.\n\nThis change in behavior may be unexpected for some clusters and can be disabled by turning off the ExecProbeTimeout feature gate. This gate will be locked and removed in future releases so that exec probe timeouts are always respected.",
+    "markdown": "A bug was fixed in kubelet where exec probe timeouts were not respected. Ensure that pods relying on this behavior are updated to correctly handle probe timeouts.\n  \n  This change in behavior may be unexpected for some clusters and can be disabled by turning off the ExecProbeTimeout feature gate. This gate will be locked and removed in future releases so that exec probe timeouts are always respected. ([#94115](https://github.com/kubernetes/kubernetes/pull/94115), [@andrewsykim](https://github.com/andrewsykim)) [SIG Node and Testing]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94115",
+    "pr_number": 94115,
+    "areas": ["kubelet", "test"],
+    "kinds": ["bug"],
+    "sigs": ["node", "testing"],
+    "duplicate": true,
+    "action_required": true
+  },
+  "94196": {
+    "commit": "d233111f5b46acdc521f7f0757b93938ac0b2db0",
+    "text": "Introduce alpha support for exec-based container registry credential provider plugins in the kubelet.",
+    "markdown": "Introduce alpha support for exec-based container registry credential provider plugins in the kubelet. ([#94196](https://github.com/kubernetes/kubernetes/pull/94196), [@andrewsykim](https://github.com/andrewsykim)) [SIG Node and Release]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94196",
+    "pr_number": 94196,
+    "areas": ["kubelet", "release-eng"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "release"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "94444": {
+    "commit": "e3185f2cc0c81956fef3cdb36b4cae85fd4a7563",
+    "text": "Add feature to size memory backed volumes",
+    "markdown": "Add feature to size memory backed volumes ([#94444](https://github.com/kubernetes/kubernetes/pull/94444), [@derekwaynecarr](https://github.com/derekwaynecarr)) [SIG Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/1968",
+        "type": "KEP"
+      }
+    ],
+    "author": "derekwaynecarr",
+    "author_url": "https://github.com/derekwaynecarr",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94444",
+    "pr_number": 94444,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "94526": {
+    "commit": "0f6d1ed59cf39ed8d908abb376455dcd11734aee",
+    "text": "Add a new `vSphere` metric: `cloudprovider_vsphere_vcenter_versions`. It's content show `vCenter` hostnames with the associated server version.",
+    "markdown": "Add a new `vSphere` metric: `cloudprovider_vsphere_vcenter_versions`. It's content show `vCenter` hostnames with the associated server version. ([#94526](https://github.com/kubernetes/kubernetes/pull/94526), [@Danil-Grigorev](https://github.com/Danil-Grigorev)) [SIG Cloud Provider and Instrumentation]",
+    "author": "Danil-Grigorev",
+    "author_url": "https://github.com/Danil-Grigorev",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94526",
+    "pr_number": 94526,
+    "areas": ["cloudprovider"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "94624": {
+    "commit": "f653e6cf92a2dc875c5c3437679340be76d25734",
+    "text": "Docker support in the kubelet is now deprecated and will be removed in a future release. The kubelet uses a module called \"dockershim\" which implements CRI support for Docker and it has seen maintenance issues in the Kubernetes community. We encourage you to evaluate moving to a container runtime that is a full-fledged implementation of CRI (v1alpha1 or v1 compliant) as they become available.",
+    "markdown": "Docker support in the kubelet is now deprecated and will be removed in a future release. The kubelet uses a module called \"dockershim\" which implements CRI support for Docker and it has seen maintenance issues in the Kubernetes community. We encourage you to evaluate moving to a container runtime that is a full-fledged implementation of CRI (v1alpha1 or v1 compliant) as they become available. ([#94624](https://github.com/kubernetes/kubernetes/pull/94624), [@dims](https://github.com/dims)) [SIG Node]",
+    "author": "dims",
+    "author_url": "https://github.com/dims",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94624",
+    "pr_number": 94624,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup", "deprecation"],
+    "sigs": ["node"],
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "94663": {
+    "commit": "1cd2ed816a5c22a621c5ea59b906834c7f145301",
+    "text": "Print go stack traces at -v=4 and not -v=2",
+    "markdown": "Print go stack traces at -v=4 and not -v=2 ([#94663](https://github.com/kubernetes/kubernetes/pull/94663), [@soltysh](https://github.com/soltysh)) [SIG CLI]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94663",
+    "pr_number": 94663,
+    "areas": ["kubectl"],
+    "kinds": ["bug", "cleanup", "regression"],
+    "sigs": ["cli"],
+    "duplicate_kind": true
+  },
+  "94814": {
+    "commit": "a3d94b53ca43e0f1087a7b9c2e5809e6430c6b53",
+    "text": "Fewer candidates are enumerated for preemption to improve performance in large clusters.",
+    "markdown": "Fewer candidates are enumerated for preemption to improve performance in large clusters. ([#94814](https://github.com/kubernetes/kubernetes/pull/94814), [@adtac](https://github.com/adtac))",
+    "author": "adtac",
+    "author_url": "https://github.com/adtac",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94814",
+    "pr_number": 94814,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "94866": {
+    "commit": "cd21a1240a5f07e9b6c5f48e72cfd354b5183d34",
+    "text": "A new set of alpha metrics are reported by the Kubernetes scheduler under the `/metrics/resources` endpoint that allow administrators to easily see the resource consumption (requests and limits for all resources on the pods) and compare it to actual pod usage or node capacity.",
+    "markdown": "A new set of alpha metrics are reported by the Kubernetes scheduler under the `/metrics/resources` endpoint that allow administrators to easily see the resource consumption (requests and limits for all resources on the pods) and compare it to actual pod usage or node capacity. ([#94866](https://github.com/kubernetes/kubernetes/pull/94866), [@smarterclayton](https://github.com/smarterclayton)) [SIG API Machinery, Instrumentation, Node and Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/1916",
+        "type": "KEP"
+      }
+    ],
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94866",
+    "pr_number": 94866,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "instrumentation", "node", "scheduling"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95002": {
+    "commit": "057986e32c1bb7284b0edbc161f0380f1548492f",
+    "text": "A new metric `requestAbortsTotal` has been introduced that counts aborted requests for each `group`, `version`, `verb`, `resource`, `subresource` and `scope`.",
+    "markdown": "A new metric `requestAbortsTotal` has been introduced that counts aborted requests for each `group`, `version`, `verb`, `resource`, `subresource` and `scope`. ([#95002](https://github.com/kubernetes/kubernetes/pull/95002), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery, Cloud Provider, Instrumentation and Scheduling]",
+    "author": "p0lyn0mial",
+    "author_url": "https://github.com/p0lyn0mial",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95002",
+    "pr_number": 95002,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "cloud-provider", "instrumentation", "scheduling"],
+    "duplicate": true
+  },
+  "95076": {
+    "commit": "f7cfe3ba0f0434f82208cc940c0770984e5758f5",
+    "text": "kubectl: deprecate --delete-local-data",
+    "markdown": "Kubectl: deprecate --delete-local-data ([#95076](https://github.com/kubernetes/kubernetes/pull/95076), [@dougsland](https://github.com/dougsland)) [SIG CLI, Cloud Provider and Scalability]",
+    "author": "dougsland",
+    "author_url": "https://github.com/dougsland",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95076",
+    "pr_number": 95076,
+    "areas": ["kubectl", "provider/gcp"],
+    "kinds": ["deprecation", "feature"],
+    "sigs": ["cli", "cloud-provider", "scalability"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "95206": {
+    "commit": "0923b9abce7382888a077860da28a635975a0f40",
+    "text": "Fix CVE-2020-8555 for Quobyte client connections.",
+    "markdown": "Fix CVE-2020-8555 for Quobyte client connections. ([#95206](https://github.com/kubernetes/kubernetes/pull/95206), [@misterikkit](https://github.com/misterikkit)) [SIG Storage]",
+    "author": "misterikkit",
+    "author_url": "https://github.com/misterikkit",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95206",
+    "pr_number": 95206,
+    "areas": ["dependency"],
+    "kinds": ["bug"],
+    "sigs": ["storage"]
+  },
+  "95247": {
+    "commit": "d2a85502dfcfd057776b9fe385d154f91415ff54",
+    "text": "The AWS network load balancer attributes can now be specified during service creation",
+    "markdown": "The AWS network load balancer attributes can now be specified during service creation ([#95247](https://github.com/kubernetes/kubernetes/pull/95247), [@kishorj](https://github.com/kishorj)) [SIG Cloud Provider]",
+    "author": "kishorj",
+    "author_url": "https://github.com/kishorj",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95247",
+    "pr_number": 95247,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "95256": {
+    "commit": "8d226790c261f6f862a37982350b2f92fde3ba2e",
+    "text": "Generators for services are removed from kubectl",
+    "markdown": "Generators for services are removed from kubectl ([#95256](https://github.com/kubernetes/kubernetes/pull/95256), [@Git-Jiro](https://github.com/Git-Jiro)) [SIG CLI]",
+    "author": "Git-Jiro",
+    "author_url": "https://github.com/Git-Jiro",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95256",
+    "pr_number": 95256,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "95282": {
+    "commit": "bffdc87241411f7359d1bf55e6389c1b7c017148",
+    "text": "VolumeSnapshotDataSource moves to GA in 1.20 release",
+    "markdown": "VolumeSnapshotDataSource moves to GA in 1.20 release ([#95282](https://github.com/kubernetes/kubernetes/pull/95282), [@xing-yang](https://github.com/xing-yang)) [SIG Apps]",
+    "documentation": [
+      {
+        "description": "-[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/177-volume-snapshot",
+        "type": "KEP"
+      }
+    ],
+    "author": "xing-yang",
+    "author_url": "https://github.com/xing-yang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95282",
+    "pr_number": 95282,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "95292": {
+    "commit": "93aeff4ef0678e9b746ed60862907a617005506d",
+    "text": "kubectl: Previously users cannot provide arguments to a external diff tool via KUBECTL_EXTERNAL_DIFF env. This release now allow users to specify args to KUBECTL_EXTERNAL_DIFF env.",
+    "markdown": "Kubectl: Previously users cannot provide arguments to a external diff tool via KUBECTL_EXTERNAL_DIFF env. This release now allow users to specify args to KUBECTL_EXTERNAL_DIFF env. ([#95292](https://github.com/kubernetes/kubernetes/pull/95292), [@dougsland](https://github.com/dougsland)) [SIG CLI]",
+    "author": "dougsland",
+    "author_url": "https://github.com/dougsland",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95292",
+    "pr_number": 95292,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "95382": {
+    "commit": "6b24a5796c47519c1b96f93b5516e46c9bcf7218",
+    "text": "kubeadm:\n- The label applied to control-plane nodes \"node-role.kubernetes.io/master\" is now deprecated and will be removed in a future release after a GA deprecation period.\n- Introduce a new label \"node-role.kubernetes.io/control-plane\" that will be applied in parallel to \"node-role.kubernetes.io/master\" until the removal of the \"node-role.kubernetes.io/master\" label.\n- Make \"kubeadm upgrade apply\" add the \"node-role.kubernetes.io/control-plane\" label on existing nodes that only have the \"node-role.kubernetes.io/master\" label during upgrade.\n- Please adapt your tooling built on top of kubeadm to use the \"node-role.kubernetes.io/control-plane\" label.\n\n- The taint applied to control-plane nodes \"node-role.kubernetes.io/master:NoSchedule\" is now deprecated and will be removed in a future release after a GA deprecation period.\n- Apply toleration for a new, future taint \"node-role.kubernetes.io/control-plane:NoSchedule\" to the kubeadm CoreDNS / kube-dns managed manifests. Note that this taint is not yet applied to kubeadm control-plane nodes.\n- Please adapt your workloads to tolerate the same future taint preemptively.\n\nFor more details see: http://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md",
+    "markdown": "Kubeadm:\n  - The label applied to control-plane nodes \"node-role.kubernetes.io/master\" is now deprecated and will be removed in a future release after a GA deprecation period.\n  - Introduce a new label \"node-role.kubernetes.io/control-plane\" that will be applied in parallel to \"node-role.kubernetes.io/master\" until the removal of the \"node-role.kubernetes.io/master\" label.\n  - Make \"kubeadm upgrade apply\" add the \"node-role.kubernetes.io/control-plane\" label on existing nodes that only have the \"node-role.kubernetes.io/master\" label during upgrade.\n  - Please adapt your tooling built on top of kubeadm to use the \"node-role.kubernetes.io/control-plane\" label.\n  \n  - The taint applied to control-plane nodes \"node-role.kubernetes.io/master:NoSchedule\" is now deprecated and will be removed in a future release after a GA deprecation period.\n  - Apply toleration for a new, future taint \"node-role.kubernetes.io/control-plane:NoSchedule\" to the kubeadm CoreDNS / kube-dns managed manifests. Note that this taint is not yet applied to kubeadm control-plane nodes.\n  - Please adapt your workloads to tolerate the same future taint preemptively.\n  \n  For more details see: http://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md ([#95382](https://github.com/kubernetes/kubernetes/pull/95382), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "http://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md",
+        "type": "external"
+      }
+    ],
+    "author": "neolit123",
+    "author_url": "https://github.com/neolit123",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95382",
+    "pr_number": 95382,
+    "areas": ["kubeadm"],
+    "kinds": ["deprecation"],
+    "sigs": ["cluster-lifecycle"],
+    "action_required": true
+  },
+  "95423": {
+    "commit": "9253aa93098f2b17d3c0ff65aa6b03863e970371",
+    "text": "CRDs: For structural schemas, non-nullable null map fields will now be dropped and defaulted if a default is available. null items in list will continue being preserved, and fail validation if not nullable.",
+    "markdown": "CRDs: For structural schemas, non-nullable null map fields will now be dropped and defaulted if a default is available. null items in list will continue being preserved, and fail validation if not nullable. ([#95423](https://github.com/kubernetes/kubernetes/pull/95423), [@apelisse](https://github.com/apelisse)) [SIG API Machinery]",
+    "author": "apelisse",
+    "author_url": "https://github.com/apelisse",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95423",
+    "pr_number": 95423,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "95439": {
+    "commit": "cc8428566ea7160c5b20410a1bee53ca7ddb998e",
+    "text": "applies translations on all command descriptions",
+    "markdown": "Applies translations on all command descriptions ([#95439](https://github.com/kubernetes/kubernetes/pull/95439), [@HerrNaN](https://github.com/HerrNaN)) [SIG CLI]",
+    "author": "HerrNaN",
+    "author_url": "https://github.com/HerrNaN",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95439",
+    "pr_number": 95439,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "95533": {
+    "commit": "281866b35c0645e9bffc00d5e6d2f97b64680fd9",
+    "text": "kube-apiserver now maintains a Lease object to identify itself: \n- The feature is under feature gate `APIServerIdentity`. \n- Two flags are added to kube-apiserver: `identity-lease-duration-seconds`, `identity-lease-renew-interval-seconds`",
+    "markdown": "Kube-apiserver now maintains a Lease object to identify itself: \n  - The feature is under feature gate `APIServerIdentity`. \n  - Two flags are added to kube-apiserver: `identity-lease-duration-seconds`, `identity-lease-renew-interval-seconds` ([#95533](https://github.com/kubernetes/kubernetes/pull/95533), [@roycaihw](https://github.com/roycaihw)) [SIG API Machinery]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1965-kube-apiserver-identity/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "roycaihw",
+    "author_url": "https://github.com/roycaihw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95533",
+    "pr_number": 95533,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "95541": {
+    "commit": "0961891a7afc54d07ce0d02c9127f67d541de33c",
+    "text": "volume binding: report UnschedulableAndUnresolvable status instead of an error when bound PVs not found",
+    "markdown": "Volume binding: report UnschedulableAndUnresolvable status instead of an error when bound PVs not found ([#95541](https://github.com/kubernetes/kubernetes/pull/95541), [@cofyc](https://github.com/cofyc)) [SIG Apps, Scheduling and Storage]",
+    "author": "cofyc",
+    "author_url": "https://github.com/cofyc",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95541",
+    "pr_number": 95541,
+    "kinds": ["bug"],
+    "sigs": ["apps", "scheduling", "storage"],
+    "duplicate": true
+  },
+  "95544": {
+    "commit": "374989e4617aa99ea260fd11e5a037738468863f",
+    "text": "Warns user when executing kubectl apply/diff to resource currently being deleted.",
+    "markdown": "Warns user when executing kubectl apply/diff to resource currently being deleted. ([#95544](https://github.com/kubernetes/kubernetes/pull/95544), [@SaiHarshaK](https://github.com/SaiHarshaK)) [SIG CLI]",
+    "author": "SaiHarshaK",
+    "author_url": "https://github.com/SaiHarshaK",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95544",
+    "pr_number": 95544,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "95603": {
+    "commit": "56c1be8317cb79d7465163674cc6561cc464367f",
+    "text": "Introduce api-extensions category which will return: mutating admission configs, validating admission configs, CRDs and APIServices when used in kubectl get, for example.",
+    "markdown": "Introduce api-extensions category which will return: mutating admission configs, validating admission configs, CRDs and APIServices when used in kubectl get, for example. ([#95603](https://github.com/kubernetes/kubernetes/pull/95603), [@soltysh](https://github.com/soltysh)) [SIG API Machinery]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95603",
+    "pr_number": 95603,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "95718": {
+    "commit": "12d9183da03d86c65f9f17e3e28be3c7c18ed22a",
+    "text": "Promote RuntimeClass feature to GA.\nPromote node.k8s.io API groups from v1beta1 to v1.",
+    "markdown": "Promote RuntimeClass feature to GA.\n  Promote node.k8s.io API groups from v1beta1 to v1. ([#95718](https://github.com/kubernetes/kubernetes/pull/95718), [@SergeyKanzhelev](https://github.com/SergeyKanzhelev)) [SIG Apps, Auth, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/585",
+        "type": "KEP"
+      }
+    ],
+    "author": "SergeyKanzhelev",
+    "author_url": "https://github.com/SergeyKanzhelev",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95718",
+    "pr_number": 95718,
+    "areas": ["apiserver", "kubelet", "test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "auth", "node", "scheduling", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "95719": {
+    "commit": "423f8731ef231298675473196100557c69165c74",
+    "text": "There is a new pv_collector_total_pv_count metric that counts persistent volumes by the volume plugin name and volume mode.",
+    "markdown": "There is a new pv_collector_total_pv_count metric that counts persistent volumes by the volume plugin name and volume mode. ([#95719](https://github.com/kubernetes/kubernetes/pull/95719), [@tsmetana](https://github.com/tsmetana)) [SIG Apps, Instrumentation, Storage and Testing]",
+    "author": "tsmetana",
+    "author_url": "https://github.com/tsmetana",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95719",
+    "pr_number": 95719,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "instrumentation", "storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95741": {
+    "commit": "fbf46a4c5bb3b5a5a52edf7fe2cac4910a274547",
+    "text": "Add WindowsContainerResources and Annotations to CRI-API UpdateContainerResourcesRequest",
+    "markdown": "Add WindowsContainerResources and Annotations to CRI-API UpdateContainerResourcesRequest ([#95741](https://github.com/kubernetes/kubernetes/pull/95741), [@katiewasnothere](https://github.com/katiewasnothere)) [SIG Node]",
+    "author": "katiewasnothere",
+    "author_url": "https://github.com/katiewasnothere",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95741",
+    "pr_number": 95741,
+    "areas": ["kubelet"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "95770": {
+    "commit": "a4aa494cc1c99a0a9e58d135ff43eb9a965d4f96",
+    "text": "Remove ready file and its directory (which is created during volume SetUp) during emptyDir volume TearDown.",
+    "markdown": "Remove ready file and its directory (which is created during volume SetUp) during emptyDir volume TearDown. ([#95770](https://github.com/kubernetes/kubernetes/pull/95770), [@jingxu97](https://github.com/jingxu97)) [SIG Storage]",
+    "author": "jingxu97",
+    "author_url": "https://github.com/jingxu97",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95770",
+    "pr_number": 95770,
+    "kinds": ["bug"],
+    "sigs": ["storage"]
+  },
+  "95839": {
+    "commit": "0e0cc1ead8ae5937a45e8ca9fa68eb300a1a2f50",
+    "text": "Add pod_ based CPU and memory metrics to Kubelet's  /metrics/resource endpoint",
+    "markdown": "Add pod_ based CPU and memory metrics to Kubelet's  /metrics/resource endpoint ([#95839](https://github.com/kubernetes/kubernetes/pull/95839), [@egernst](https://github.com/egernst)) [SIG Instrumentation, Node and Testing]",
+    "author": "egernst",
+    "author_url": "https://github.com/egernst",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95839",
+    "pr_number": 95839,
+    "areas": ["kubelet", "test"],
+    "kinds": ["feature"],
+    "sigs": ["instrumentation", "node", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95863": {
+    "commit": "e95af138b538d4beace1eceaeb454c57072130d9",
+    "text": "Volume snapshot e2e test to validate PVC and VolumeSnapshotContent finalizer",
+    "markdown": "Volume snapshot e2e test to validate PVC and VolumeSnapshotContent finalizer ([#95863](https://github.com/kubernetes/kubernetes/pull/95863), [@RaunakShah](https://github.com/RaunakShah)) [SIG Cloud Provider, Storage and Testing]",
+    "author": "RaunakShah",
+    "author_url": "https://github.com/RaunakShah",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95863",
+    "pr_number": 95863,
+    "areas": ["e2e-test-framework", "provider/gcp", "test"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider", "storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95892": {
+    "commit": "fe5f2cf8ef5d77787f419cb5f2edc9eba476d725",
+    "text": "change plugin name in fsgroupapplymetrics of csi and flexvolume to distinguish different driver",
+    "markdown": "Change plugin name in fsgroupapplymetrics of csi and flexvolume to distinguish different driver ([#95892](https://github.com/kubernetes/kubernetes/pull/95892), [@JornShen](https://github.com/JornShen)) [SIG Instrumentation, Storage and Testing]",
+    "author": "JornShen",
+    "author_url": "https://github.com/JornShen",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95892",
+    "pr_number": 95892,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["instrumentation", "storage", "testing"],
+    "duplicate": true
+  },
+  "95895": {
+    "commit": "f102cc887e57f83485b58d37e77b247270cf2ade",
+    "text": "kube-apiserver now deletes expired kube-apiserver Lease objects:\n- The feature is under feature gate `APIServerIdentity`.\n- A flag is added to kube-apiserver: `identity-lease-garbage-collection-check-period-seconds`",
+    "markdown": "Kube-apiserver now deletes expired kube-apiserver Lease objects:\n  - The feature is under feature gate `APIServerIdentity`.\n  - A flag is added to kube-apiserver: `identity-lease-garbage-collection-check-period-seconds` ([#95895](https://github.com/kubernetes/kubernetes/pull/95895), [@roycaihw](https://github.com/roycaihw)) [SIG API Machinery, Apps, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1965-kube-apiserver-identity/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "roycaihw",
+    "author_url": "https://github.com/roycaihw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95895",
+    "pr_number": 95895,
+    "areas": ["apiserver", "test"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery", "apps", "auth", "testing"],
+    "duplicate": true
+  },
+  "95896": {
+    "commit": "8d6829fe1e844876aa77755e23af1ab35e4790c5",
+    "text": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:",
+    "markdown": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: ([#95896](https://github.com/kubernetes/kubernetes/pull/95896), [@zshihang](https://github.com/zshihang)) [SIG API Machinery and Cluster Lifecycle]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens",
+        "type": "KEP"
+      }
+    ],
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95896",
+    "pr_number": 95896,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "cluster-lifecycle"],
+    "feature": true,
+    "duplicate": true
+  },
+  "95933": {
+    "commit": "cd99c63570eb1489dd631c12ea86db708dbdcd59",
+    "text": "Fix bug in JSON path parser where an error occurs when a range is empty",
+    "markdown": "Fix bug in JSON path parser where an error occurs when a range is empty ([#95933](https://github.com/kubernetes/kubernetes/pull/95933), [@brianpursley](https://github.com/brianpursley)) [SIG API Machinery]",
+    "author": "brianpursley",
+    "author_url": "https://github.com/brianpursley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95933",
+    "pr_number": 95933,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "95935": {
+    "commit": "a439bc55724f6560c14bf4e025946c0e6312629b",
+    "text": "--redirect-container-streaming is no longer functional. The flag will be removed in v1.22",
+    "markdown": "--redirect-container-streaming is no longer functional. The flag will be removed in v1.22 ([#95935](https://github.com/kubernetes/kubernetes/pull/95935), [@tallclair](https://github.com/tallclair)) [SIG Node]",
+    "author": "tallclair",
+    "author_url": "https://github.com/tallclair",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95935",
+    "pr_number": 95935,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"]
+  },
+  "95981": {
+    "commit": "ba7b1f7a89ffed78115ab0229b7504d05f6c7d48",
+    "text": "HTTP/2 connection health check is enabled by default in all Kubernetes clients. The feature should work out-of-the-box. If needed, users can tune the feature via the HTTP2_READ_IDLE_TIMEOUT_SECONDS and HTTP2_PING_TIMEOUT_SECONDS environment variables. The feature is disabled if HTTP2_READ_IDLE_TIMEOUT_SECONDS is set to 0.",
+    "markdown": "HTTP/2 connection health check is enabled by default in all Kubernetes clients. The feature should work out-of-the-box. If needed, users can tune the feature via the HTTP2_READ_IDLE_TIMEOUT_SECONDS and HTTP2_PING_TIMEOUT_SECONDS environment variables. The feature is disabled if HTTP2_READ_IDLE_TIMEOUT_SECONDS is set to 0. ([#95981](https://github.com/kubernetes/kubernetes/pull/95981), [@caesarxuchao](https://github.com/caesarxuchao)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation and Node]",
+    "author": "caesarxuchao",
+    "author_url": "https://github.com/caesarxuchao",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95981",
+    "pr_number": 95981,
+    "areas": ["apiserver", "cloudprovider", "code-generation", "dependency", "kubectl"],
+    "kinds": ["bug"],
+    "sigs": [
+      "api-machinery",
+      "cli",
+      "cloud-provider",
+      "cluster-lifecycle",
+      "instrumentation",
+      "node"
+    ],
+    "duplicate": true
+  },
+  "96033": {
+    "commit": "819ff9b0870506b889e156adc5e66e314f8d148e",
+    "text": "Reminder: The labels \"failure-domain.beta.kubernetes.io/zone\" and \"failure-domain.beta.kubernetes.io/region\" are deprecated in favor of \"topology.kubernetes.io/zone\" and \"topology.kubernetes.io/region\" respectively.  All users of the \"failure-domain.beta...\" labels should switch to the \"topology...\" equivalents.",
+    "markdown": "Reminder: The labels \"failure-domain.beta.kubernetes.io/zone\" and \"failure-domain.beta.kubernetes.io/region\" are deprecated in favor of \"topology.kubernetes.io/zone\" and \"topology.kubernetes.io/region\" respectively.  All users of the \"failure-domain.beta...\" labels should switch to the \"topology...\" equivalents. ([#96033](https://github.com/kubernetes/kubernetes/pull/96033), [@thockin](https://github.com/thockin)) [SIG API Machinery, Apps, CLI, Cloud Provider, Network, Node, Scheduling, Storage and Testing]",
+    "author": "thockin",
+    "author_url": "https://github.com/thockin",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96033",
+    "pr_number": 96033,
+    "areas": ["apiserver", "cloudprovider", "e2e-test-framework", "kubectl", "kubelet", "test"],
+    "kinds": ["api-change", "cleanup"],
+    "sigs": [
+      "api-machinery",
+      "apps",
+      "cli",
+      "cloud-provider",
+      "network",
+      "node",
+      "scheduling",
+      "storage",
+      "testing"
+    ],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "96054": {
+    "commit": "df794c1ddad17b9cd1d3e7fd1409ed8e2b9cf854",
+    "text": "The kubelet_runtime_operations_duration_seconds metric buckets were set to 0.005 0.0125 0.03125 0.078125 0.1953125 0.48828125 1.220703125 3.0517578125 7.62939453125 19.073486328125 47.6837158203125 119.20928955078125 298.0232238769531 and 745.0580596923828 seconds",
+    "markdown": "The kubelet_runtime_operations_duration_seconds metric buckets were set to 0.005 0.0125 0.03125 0.078125 0.1953125 0.48828125 1.220703125 3.0517578125 7.62939453125 19.073486328125 47.6837158203125 119.20928955078125 298.0232238769531 and 745.0580596923828 seconds ([#96054](https://github.com/kubernetes/kubernetes/pull/96054), [@alvaroaleman](https://github.com/alvaroaleman)) [SIG Instrumentation and Node]",
+    "author": "alvaroaleman",
+    "author_url": "https://github.com/alvaroaleman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96054",
+    "pr_number": 96054,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["instrumentation", "node"],
+    "feature": true,
+    "duplicate": true
+  },
+  "96058": {
+    "commit": "ee9f11b95f01b32dade5d8dc7329625c40ac0e63",
+    "text": "`kubectl debug` gains support for changing container images when copying a pod for debugging, similar to how `kubectl set image` works. See `kubectl help debug` for more information.",
+    "markdown": "`kubectl debug` gains support for changing container images when copying a pod for debugging, similar to how `kubectl set image` works. See `kubectl help debug` for more information. ([#96058](https://github.com/kubernetes/kubernetes/pull/96058), [@verb](https://github.com/verb)) [SIG CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug",
+        "type": "KEP"
+      }
+    ],
+    "author": "verb",
+    "author_url": "https://github.com/verb",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96058",
+    "pr_number": 96058,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "96061": {
+    "commit": "59ac565dbf603f0636dbbcc2bb61a35fb2969d7e",
+    "text": "If the user specifies an invalid timeout in the request URL, the request will be aborted with an HTTP 400.\n- If the user specifies a timeout in the request URL that exceeds the maximum request deadline allowed by the apiserver, the request will be aborted with an HTTP 400.",
+    "markdown": "If the user specifies an invalid timeout in the request URL, the request will be aborted with an HTTP 400.\n  - If the user specifies a timeout in the request URL that exceeds the maximum request deadline allowed by the apiserver, the request will be aborted with an HTTP 400. ([#96061](https://github.com/kubernetes/kubernetes/pull/96061), [@tkashem](https://github.com/tkashem)) [SIG API Machinery, Network and Testing]",
+    "author": "tkashem",
+    "author_url": "https://github.com/tkashem",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96061",
+    "pr_number": 96061,
+    "areas": ["apiserver", "test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "network", "testing"],
+    "duplicate": true
+  },
+  "96071": {
+    "commit": "6e0fb9ad7fa80adf8c90a97e00d9ff610766ce2e",
+    "text": "Scheduler now ignores Pod update events if the resourceVersion of old and new Pods are identical.",
+    "markdown": "Scheduler now ignores Pod update events if the resourceVersion of old and new Pods are identical. ([#96071](https://github.com/kubernetes/kubernetes/pull/96071), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]",
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96071",
+    "pr_number": 96071,
+    "kinds": ["feature", "flake"],
+    "sigs": ["scheduling"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "96111": {
+    "commit": "667b2be621de91a4254af6499ce742332c981b76",
+    "text": "Support multiple standard load balancers in one cluster",
+    "markdown": "Support multiple standard load balancers in one cluster ([#96111](https://github.com/kubernetes/kubernetes/pull/96111), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "documentation": [
+      {
+        "url": "https://kubernetes-sigs.github.io/cloud-provider-azure/development/design-docs/multiple-slb/",
+        "type": "external"
+      }
+    ],
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96111",
+    "pr_number": 96111,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "96127": {
+    "commit": "ba514718da1a9f84e6be18cf52f8b9ca2b86aa1f",
+    "text": "Changed: default \"Accept-Encoding\" header removed from HTTP probes. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes",
+    "markdown": "Changed: default \"Accept-Encoding\" header removed from HTTP probes. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes ([#96127](https://github.com/kubernetes/kubernetes/pull/96127), [@fonsecas72](https://github.com/fonsecas72)) [SIG Network and Node]",
+    "author": "fonsecas72",
+    "author_url": "https://github.com/fonsecas72",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96127",
+    "pr_number": 96127,
+    "kinds": ["cleanup"],
+    "sigs": ["network", "node"],
+    "duplicate": true
+  },
+  "96129": {
+    "commit": "b2dc35dab2cdd2aa33ba8240bb6e53478e63c435",
+    "text": "Adds kubelet alpha feature, `GracefulNodeShutdown` which makes kubelet aware of node system shutdowns and result in graceful termination of pods during a system shutdown.",
+    "markdown": "Adds kubelet alpha feature, `GracefulNodeShutdown` which makes kubelet aware of node system shutdowns and result in graceful termination of pods during a system shutdown. ([#96129](https://github.com/kubernetes/kubernetes/pull/96129), [@bobbypage](https://github.com/bobbypage)) [SIG Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2000-graceful-node-shutdown/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "bobbypage",
+    "author_url": "https://github.com/bobbypage",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96129",
+    "pr_number": 96129,
+    "areas": ["dependency", "kubelet"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "96138": {
+    "commit": "468f9f6cac392d941dd6a4d8a331f38cbf0090d3",
+    "text": "`kubectl alpha debug` has graduated to beta and is now `kubectl debug`.",
+    "markdown": "`kubectl alpha debug` has graduated to beta and is now `kubectl debug`. ([#96138](https://github.com/kubernetes/kubernetes/pull/96138), [@verb](https://github.com/verb)) [SIG CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug",
+        "type": "KEP"
+      }
+    ],
+    "author": "verb",
+    "author_url": "https://github.com/verb",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96138",
+    "pr_number": 96138,
+    "areas": ["kubectl", "test"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "96144": {
+    "commit": "89ba702d8a135097f5f79e284c1c675e437068f7",
+    "text": "skip [k8s.io/kubernetes@v1.19.0/test/e2e/storage/testsuites/base.go:162]: Driver azure-disk doesn't support snapshot type DynamicSnapshot -- skipping\nskip [k8s.io/kubernetes@v1.19.0/test/e2e/storage/testsuites/base.go:185]: Driver azure-disk doesn't support ntfs -- skipping",
+    "markdown": "Skip [k8s.io/kubernetes@v1.19.0/test/e2e/storage/testsuites/base.go:162]: Driver azure-disk doesn't support snapshot type DynamicSnapshot -- skipping\n  skip [k8s.io/kubernetes@v1.19.0/test/e2e/storage/testsuites/base.go:185]: Driver azure-disk doesn't support ntfs -- skipping ([#96144](https://github.com/kubernetes/kubernetes/pull/96144), [@qinpingli](https://github.com/qinpingli)) [SIG Storage and Testing]",
+    "author": "qinpingli",
+    "author_url": "https://github.com/qinpingli",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96144",
+    "pr_number": 96144,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["storage", "testing"],
+    "duplicate": true
+  },
+  "96179": {
+    "commit": "5fe43caddbbf0ccfc354becd7aae48810b5d34ac",
+    "text": "NONE",
+    "markdown": "NONE ([#96179](https://github.com/kubernetes/kubernetes/pull/96179), [@bbyrne5](https://github.com/bbyrne5)) [SIG Network]",
+    "author": "bbyrne5",
+    "author_url": "https://github.com/bbyrne5",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96179",
+    "pr_number": 96179,
+    "kinds": ["cleanup"],
+    "sigs": ["network"]
+  },
+  "96190": {
+    "commit": "ee0d35895d0f8a8a29e095eecb28f1c12a217908",
+    "text": "Introduce kubectl-convert plugin.",
+    "markdown": "Introduce kubectl-convert plugin. ([#96190](https://github.com/kubernetes/kubernetes/pull/96190), [@soltysh](https://github.com/soltysh)) [SIG CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/1020-kubectl-staging/README.md",
+        "type": "KEP"
+      },
+      {
+        "description": "[Code Organization Agenda]",
+        "url": "https://docs.google.com/document/d/1HtTI0rJEGP_MSf6eO87aCmx_tzpovPAAg7U2Zxwm8FE/edit?ts=5c9d0a4c#bookmark=id.fqfpdy1w5idg",
+        "type": "external"
+      }
+    ],
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96190",
+    "pr_number": 96190,
+    "areas": ["kubectl", "test"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli", "testing"],
+    "duplicate": true
+  },
+  "96197": {
+    "commit": "8bdd10b7d73cb0d705b895e0c9a5646dfbb19a24",
+    "text": "The beta `RootCAConfigMap` feature gate is enabled by default and causes kube-controller-manager to publish a \"kube-root-ca.crt\" ConfigMap to every namespace. This ConfigMap contains a CA bundle used for verifying connections to the kube-apiserver.",
+    "markdown": "The beta `RootCAConfigMap` feature gate is enabled by default and causes kube-controller-manager to publish a \"kube-root-ca.crt\" ConfigMap to every namespace. This ConfigMap contains a CA bundle used for verifying connections to the kube-apiserver. ([#96197](https://github.com/kubernetes/kubernetes/pull/96197), [@zshihang](https://github.com/zshihang)) [SIG API Machinery, Apps, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens",
+        "type": "KEP"
+      }
+    ],
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96197",
+    "pr_number": 96197,
+    "areas": ["apiserver", "test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "auth", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "96202": {
+    "commit": "e5194dd9362febb142f8187d2ad070203da8a71a",
+    "text": "NodeAffinity plugin can be configured with AddedAffinity.",
+    "markdown": "NodeAffinity plugin can be configured with AddedAffinity. ([#96202](https://github.com/kubernetes/kubernetes/pull/96202), [@alculquicondor](https://github.com/alculquicondor)) [SIG Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/reference/scheduling/config/",
+        "type": "official"
+      },
+      {
+        "description": "[KEP]",
+        "url": "https://git.k8s.io/enhancements/keps/sig-scheduling/785-scheduler-component-config-api",
+        "type": "external"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96202",
+    "pr_number": 96202,
+    "areas": ["kubelet", "test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "scheduling", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "96211": {
+    "commit": "b192630522f4167302748409f4e9f710202fe98c",
+    "text": "Fix paging issues when Azure API returns empty values with non-empty nextLink",
+    "markdown": "Fix paging issues when Azure API returns empty values with non-empty nextLink ([#96211](https://github.com/kubernetes/kubernetes/pull/96211), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]",
+    "author": "feiskyer",
+    "author_url": "https://github.com/feiskyer",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96211",
+    "pr_number": 96211,
+    "areas": ["cloudprovider", "dependency", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "96217": {
+    "commit": "7340c3498ac23f46fc8b6bff4d5ac664a9c64a3b",
+    "text": "exposes and sets a default timeout for the TokenReview client for DelegatingAuthenticationOptions",
+    "markdown": "Exposes and sets a default timeout for the TokenReview client for DelegatingAuthenticationOptions ([#96217](https://github.com/kubernetes/kubernetes/pull/96217), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery and Cloud Provider]",
+    "author": "p0lyn0mial",
+    "author_url": "https://github.com/p0lyn0mial",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96217",
+    "pr_number": 96217,
+    "areas": ["apiserver", "cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "cloud-provider"],
+    "duplicate": true
+  },
+  "96224": {
+    "commit": "734889ed822d1a60c6dd61ccd8f1ed0e8ab31ea5",
+    "text": "Fix vSphere volumes that could be erroneously attached to wrong node",
+    "markdown": "Fix vSphere volumes that could be erroneously attached to wrong node ([#96224](https://github.com/kubernetes/kubernetes/pull/96224), [@gnufied](https://github.com/gnufied)) [SIG Cloud Provider and Storage]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96224",
+    "pr_number": 96224,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider", "storage"],
+    "duplicate": true
+  },
+  "96236": {
+    "commit": "b16f36b251ddbfef5f12fed58640de53512631f0",
+    "text": "API priority and fairness metrics use snake_case in label names",
+    "markdown": "API priority and fairness metrics use snake_case in label names ([#96236](https://github.com/kubernetes/kubernetes/pull/96236), [@adtac](https://github.com/adtac)) [SIG API Machinery, Cluster Lifecycle, Instrumentation and Testing]",
+    "author": "adtac",
+    "author_url": "https://github.com/adtac",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96236",
+    "pr_number": 96236,
+    "areas": ["apiserver", "test"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "cluster-lifecycle", "instrumentation", "testing"],
+    "duplicate": true
+  },
+  "96247": {
+    "commit": "23207436cdc06f9a4174a7146f1c5dd2d1d8b646",
+    "text": "e2e test for PodFsGroupChangePolicy",
+    "markdown": "E2e test for PodFsGroupChangePolicy ([#96247](https://github.com/kubernetes/kubernetes/pull/96247), [@saikat-royc](https://github.com/saikat-royc)) [SIG Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/695-skip-permission-change",
+        "type": "KEP"
+      }
+    ],
+    "author": "saikat-royc",
+    "author_url": "https://github.com/saikat-royc",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96247",
+    "pr_number": 96247,
+    "areas": ["e2e-test-framework", "test"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "96251": {
+    "commit": "48a2bca89377897ea9ae50594934636e626e9551",
+    "text": "Improve error messages related to nodePort endpoint changes conntrack entries cleanup.",
+    "markdown": "Improve error messages related to nodePort endpoint changes conntrack entries cleanup. ([#96251](https://github.com/kubernetes/kubernetes/pull/96251), [@ravens](https://github.com/ravens)) [SIG Network]",
+    "author": "ravens",
+    "author_url": "https://github.com/ravens",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96251",
+    "pr_number": 96251,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "96266": {
+    "commit": "afb2342318562a62e832907b8183388244c770e0",
+    "text": "Fix memory leak in kube-apiserver when underlying time goes forth and back.",
+    "markdown": "Fix memory leak in kube-apiserver when underlying time goes forth and back. ([#96266](https://github.com/kubernetes/kubernetes/pull/96266), [@chenyw1990](https://github.com/chenyw1990)) [SIG API Machinery]",
+    "author": "chenyw1990",
+    "author_url": "https://github.com/chenyw1990",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96266",
+    "pr_number": 96266,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "96273": {
+    "commit": "23eadbeabda78b00bfa6d3e7271986bfac10370c",
+    "text": "If BoundServiceAccountTokenVolume is enabled, cluster admins can use metric `serviceaccount_stale_tokens_total` to monitor workloads that are depending on the extended tokens. If there are no such workloads, turn off extended tokens by starting `kube-apiserver` with flag `--service-account-extend-token-expiration=false`",
+    "markdown": "If BoundServiceAccountTokenVolume is enabled, cluster admins can use metric `serviceaccount_stale_tokens_total` to monitor workloads that are depending on the extended tokens. If there are no such workloads, turn off extended tokens by starting `kube-apiserver` with flag `--service-account-extend-token-expiration=false` ([#96273](https://github.com/kubernetes/kubernetes/pull/96273), [@zshihang](https://github.com/zshihang)) [SIG API Machinery and Auth]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens",
+        "type": "KEP"
+      }
+    ],
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96273",
+    "pr_number": 96273,
+    "areas": ["apiserver"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "96308": {
+    "commit": "0e421222703010b78fa9970c08ac3685d972d5f8",
+    "text": "update max azure data disk count map",
+    "markdown": "Update max azure data disk count map ([#96308](https://github.com/kubernetes/kubernetes/pull/96308), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96308",
+    "pr_number": 96308,
+    "areas": ["provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider", "storage"],
+    "duplicate": true
+  },
+  "96312": {
+    "commit": "48a0ef6a396f84ec93a8e68d9843c6fe27c4e848",
+    "text": "Users will now be able to configure all supported values for AWS NLB health check interval and thresholds for new resources.",
+    "markdown": "Users will now be able to configure all supported values for AWS NLB health check interval and thresholds for new resources. ([#96312](https://github.com/kubernetes/kubernetes/pull/96312), [@kishorj](https://github.com/kishorj)) [SIG Cloud Provider]",
+    "author": "kishorj",
+    "author_url": "https://github.com/kishorj",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96312",
+    "pr_number": 96312,
+    "areas": ["cloudprovider"],
+    "kinds": ["cleanup"],
+    "sigs": ["cloud-provider"]
+  },
+  "96327": {
+    "commit": "b044fadf66da7b5c940da417f5d4c527e7d03c2d",
+    "text": "AppProtocol is now GA for Endpoints and Services. The ServiceAppProtocol feature gate will be deprecated in 1.21.",
+    "markdown": "AppProtocol is now GA for Endpoints and Services. The ServiceAppProtocol feature gate will be deprecated in 1.21. ([#96327](https://github.com/kubernetes/kubernetes/pull/96327), [@robscott](https://github.com/robscott)) [SIG Apps and Network]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96327",
+    "pr_number": 96327,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "network"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "96338": {
+    "commit": "d17621bee697074b1ee33d03cf9343d4518ab5f7",
+    "text": "Support customize load balancer health probe protocol and request path",
+    "markdown": "Support customize load balancer health probe protocol and request path ([#96338](https://github.com/kubernetes/kubernetes/pull/96338), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96338",
+    "pr_number": 96338,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "96355": {
+    "commit": "e21ce4bae23e6bb639c5c69094692b5d0f82b4b2",
+    "text": "fix pull image error from multiple ACRs using azure managed identity",
+    "markdown": "Fix pull image error from multiple ACRs using azure managed identity ([#96355](https://github.com/kubernetes/kubernetes/pull/96355), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96355",
+    "pr_number": 96355,
+    "areas": ["provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "96369": {
+    "commit": "eed1047c6fba428b8e620d55aba7b4fcbaffe42b",
+    "text": "Fixed a bug that prevents kubectl to validate CRDs with schema using x-kubernetes-preserve-unknown-fields on object fields.",
+    "markdown": "Fixed a bug that prevents kubectl to validate CRDs with schema using x-kubernetes-preserve-unknown-fields on object fields. ([#96369](https://github.com/kubernetes/kubernetes/pull/96369), [@gautierdelorme](https://github.com/gautierdelorme)) [SIG API Machinery and Testing]",
+    "author": "gautierdelorme",
+    "author_url": "https://github.com/gautierdelorme",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96369",
+    "pr_number": 96369,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "testing"],
+    "duplicate": true
+  },
+  "96370": {
+    "commit": "0ad06e991ab0d0708593e3e6415c521c6b76b7d1",
+    "text": "Add --experimental-logging-sanitization flag enabling runtime protection from leaking sensitive data in logs",
+    "markdown": "Add --experimental-logging-sanitization flag enabling runtime protection from leaking sensitive data in logs ([#96370](https://github.com/kubernetes/kubernetes/pull/96370), [@serathius](https://github.com/serathius)) [SIG API Machinery, Cluster Lifecycle and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/59e5c698639a8489ee3808c13fc9526f746c5fc4/keps/sig-instrumentation/1753-logs-sanitization",
+        "type": "KEP"
+      }
+    ],
+    "author": "serathius",
+    "author_url": "https://github.com/serathius",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96370",
+    "pr_number": 96370,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "cluster-lifecycle", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "96376": {
+    "commit": "006020b71e8d702a06148eb19dc76d21ea54b164",
+    "text": "Move configurable fsgroup change policy for pods to beta",
+    "markdown": "Move configurable fsgroup change policy for pods to beta ([#96376](https://github.com/kubernetes/kubernetes/pull/96376), [@gnufied](https://github.com/gnufied)) [SIG Apps and Storage]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96376",
+    "pr_number": 96376,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "storage"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "96397": {
+    "commit": "80f2101da12e8ba27a81d15955d84c78534147cf",
+    "text": "Updates docs and guidance on cloud provider InstancesV2 and Zones interface for external cloud providers:\n- removes experimental warning for InstancesV2\n- document that implementation of InstancesV2 will disable calls to Zones\n- deprecate Zones in favor of InstancesV2",
+    "markdown": "Updates docs and guidance on cloud provider InstancesV2 and Zones interface for external cloud providers:\n  - removes experimental warning for InstancesV2\n  - document that implementation of InstancesV2 will disable calls to Zones\n  - deprecate Zones in favor of InstancesV2 ([#96397](https://github.com/kubernetes/kubernetes/pull/96397), [@andrewsykim](https://github.com/andrewsykim)) [SIG Cloud Provider]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96397",
+    "pr_number": 96397,
+    "areas": ["cloudprovider"],
+    "kinds": ["documentation"],
+    "sigs": ["cloud-provider"]
+  },
+  "96426": {
+    "commit": "ae95984e885bc9e418042272a622b519eff324cc",
+    "text": "kube-scheduler now logs processed component config at startup",
+    "markdown": "Kube-scheduler now logs processed component config at startup ([#96426](https://github.com/kubernetes/kubernetes/pull/96426), [@damemi](https://github.com/damemi)) [SIG Scheduling]",
+    "author": "damemi",
+    "author_url": "https://github.com/damemi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96426",
+    "pr_number": 96426,
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling"]
+  },
+  "96439": {
+    "commit": "c3769096c6783996ac493cba2e8e6371f23da922",
+    "text": "Fix a bug that DefaultPreemption plugin is disabled when using (legacy) scheduler policy.",
+    "markdown": "Fix a bug that DefaultPreemption plugin is disabled when using (legacy) scheduler policy. ([#96439](https://github.com/kubernetes/kubernetes/pull/96439), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling and Testing]",
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96439",
+    "pr_number": 96439,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["scheduling", "testing"],
+    "duplicate": true
+  },
+  "96440": {
+    "commit": "765d949bfc35032aa9bf2eb70724ecfde497e32d",
+    "text": "EndpointSlice has a new NodeName field guarded by the EndpointSliceNodeName feature gate.\n- EndpointSlice topology field will be deprecated in an upcoming release.\n- EndpointSlice \"IP\" address type is formally removed after being deprecated in Kubernetes 1.17.\n- The discovery.k8s.io/v1alpha1 API is deprecated and will be removed in Kubernetes 1.21.",
+    "markdown": "EndpointSlice has a new NodeName field guarded by the EndpointSliceNodeName feature gate.\n  - EndpointSlice topology field will be deprecated in an upcoming release.\n  - EndpointSlice \"IP\" address type is formally removed after being deprecated in Kubernetes 1.17.\n  - The discovery.k8s.io/v1alpha1 API is deprecated and will be removed in Kubernetes 1.21. ([#96440](https://github.com/kubernetes/kubernetes/pull/96440), [@robscott](https://github.com/robscott)) [SIG API Machinery, Apps and Network]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96440",
+    "pr_number": 96440,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps", "network"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "96443": {
+    "commit": "798eb0772003a6efcd570aad6c11c4a51c07975a",
+    "text": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#96443](https://github.com/kubernetes/kubernetes/pull/96443), [@alaypatel07](https://github.com/alaypatel07)) [SIG Apps]",
+    "author": "alaypatel07",
+    "author_url": "https://github.com/alaypatel07",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96443",
+    "pr_number": 96443,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": ["apps"]
+  },
+  "96450": {
+    "commit": "38c5652aa8f4691633f074ec95aeaaefecda21d4",
+    "text": "Support custom tags for cloud provider managed resources",
+    "markdown": "Support custom tags for cloud provider managed resources ([#96450](https://github.com/kubernetes/kubernetes/pull/96450), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96450",
+    "pr_number": 96450,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "96464": {
+    "commit": "c21c56a061f9775f338e627e8ba91330dc2ae133",
+    "text": "Fix IP fragmentation of UDP and TCP packets not supported issues on LoadBalancer rules",
+    "markdown": "Fix IP fragmentation of UDP and TCP packets not supported issues on LoadBalancer rules ([#96464](https://github.com/kubernetes/kubernetes/pull/96464), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96464",
+    "pr_number": 96464,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "96525": {
+    "commit": "ec734aced701ade27b2f68e8a6584c89be9c4acb",
+    "text": "The kube-apiserver will no longer serve APIs that should have been deleted in GA non-alpha levels.  Alpha levels will continue to serve the removed APIs so that CI doesn't immediately break.",
+    "markdown": "The kube-apiserver will no longer serve APIs that should have been deleted in GA non-alpha levels.  Alpha levels will continue to serve the removed APIs so that CI doesn't immediately break. ([#96525](https://github.com/kubernetes/kubernetes/pull/96525), [@deads2k](https://github.com/deads2k)) [SIG API Machinery]",
+    "author": "deads2k",
+    "author_url": "https://github.com/deads2k",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96525",
+    "pr_number": 96525,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "96527": {
+    "commit": "36f571404fcb136011024b89efaa2a0d089acd5f",
+    "text": "API priority and fairness graduated to beta\n1.19 servers with APF turned on should not be run in a multi-server cluster with 1.20+ servers.",
+    "markdown": "API priority and fairness graduated to beta\n  1.19 servers with APF turned on should not be run in a multi-server cluster with 1.20+ servers. ([#96527](https://github.com/kubernetes/kubernetes/pull/96527), [@adtac](https://github.com/adtac)) [SIG API Machinery and Testing]",
+    "author": "adtac",
+    "author_url": "https://github.com/adtac",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96527",
+    "pr_number": 96527,
+    "areas": ["apiserver", "test"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery", "testing"],
+    "duplicate": true
+  },
+  "96528": {
+    "commit": "1a4e1f6534150797a3429e6791b22ba60d366634",
+    "text": "Document that ServiceTopology feature is required to use `service.spec.topologyKeys`.",
+    "markdown": "Document that ServiceTopology feature is required to use `service.spec.topologyKeys`. ([#96528](https://github.com/kubernetes/kubernetes/pull/96528), [@andrewsykim](https://github.com/andrewsykim)) [SIG Apps]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96528",
+    "pr_number": 96528,
+    "kinds": ["api-change", "documentation"],
+    "sigs": ["apps"],
+    "duplicate_kind": true
+  },
+  "96533": {
+    "commit": "742436c431c78766a3858e7a91ab2e7185174b04",
+    "text": "Reduce volume name length for vsphere volumes",
+    "markdown": "Reduce volume name length for vsphere volumes ([#96533](https://github.com/kubernetes/kubernetes/pull/96533), [@gnufied](https://github.com/gnufied)) [SIG Storage]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96533",
+    "pr_number": 96533,
+    "kinds": ["bug"],
+    "sigs": ["storage"]
+  },
+  "96545": {
+    "commit": "1c2f5c3a65177dc9b7cb23538b3d5a90d31b2f27",
+    "text": "Update the route table tag in the route reconcile loop",
+    "markdown": "Update the route table tag in the route reconcile loop ([#96545](https://github.com/kubernetes/kubernetes/pull/96545), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96545",
+    "pr_number": 96545,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "96586": {
+    "commit": "e4bd128ec61fcf9cf41756fc9b260a2e37afc938",
+    "text": "Fixes code generation for non-namespaced create subresources fake client test.",
+    "markdown": "Fixes code generation for non-namespaced create subresources fake client test. ([#96586](https://github.com/kubernetes/kubernetes/pull/96586), [@Doude](https://github.com/Doude)) [SIG API Machinery]",
+    "author": "Doude",
+    "author_url": "https://github.com/Doude",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96586",
+    "pr_number": 96586,
+    "areas": ["code-generation"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "96627": {
+    "commit": "d5b7ef86bb3ddf22d6d58c9ad88eb891346bdf90",
+    "text": "The Conformance test \"validates that there is no conflict between pods with same hostPort but different hostIP and protocol\" now validates the connectivity to each hostPort, in addition to the functionality.",
+    "markdown": "The Conformance test \"validates that there is no conflict between pods with same hostPort but different hostIP and protocol\" now validates the connectivity to each hostPort, in addition to the functionality. ([#96627](https://github.com/kubernetes/kubernetes/pull/96627), [@aojea](https://github.com/aojea)) [SIG Scheduling and Testing]",
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96627",
+    "pr_number": 96627,
+    "areas": ["conformance", "test"],
+    "kinds": ["cleanup", "failing-test"],
+    "sigs": ["scheduling", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.20.0-beta.2.json',
   'assets/release-notes-1.19.4.json',
   'assets/release-notes-1.17.14.json',
   'assets/release-notes-1.20.0-beta.1.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.20.0-beta.2` 