### PR TITLE
Patch relnotes.k8s.io to release v1.18.11

### DIFF
--- a/src/assets/release-notes-1.18.11.json
+++ b/src/assets/release-notes-1.18.11.json
@@ -1,0 +1,158 @@
+{
+  "89857": {
+    "commit": "5967411709652ab7b9641bf3e26827b5672b2c56",
+    "text": "kube-apiserver: multiple comma-separated protocols in a single X-Stream-Protocol-Version header are now recognized, in addition to multiple headers, complying with RFC2616",
+    "markdown": "Kube-apiserver: multiple comma-separated protocols in a single X-Stream-Protocol-Version header are now recognized, in addition to multiple headers, complying with RFC2616 ([#89857](https://github.com/kubernetes/kubernetes/pull/89857), [@tedyu](https://github.com/tedyu)) [SIG API Machinery]",
+    "author": "tedyu",
+    "author_url": "https://github.com/tedyu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/89857",
+    "pr_number": 89857,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "94107": {
+    "commit": "d5a7e5ab0c958f761f0487c4d18da2cb170644c4",
+    "text": "kube-proxy now trims extra spaces found in loadBalancerSourceRanges to match Service validation.",
+    "markdown": "Kube-proxy now trims extra spaces found in loadBalancerSourceRanges to match Service validation. ([#94107](https://github.com/kubernetes/kubernetes/pull/94107), [@robscott](https://github.com/robscott)) [SIG Network]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94107",
+    "pr_number": 94107,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "94489": {
+    "commit": "856642844f507600e83ffd200de41c70823f3c5b",
+    "text": "An issues preventing volume expand controller to annotate the PVC with `volume.kubernetes.io/storage-resizer` when the PVC StorageClass is already updated to the out-of-tree provisioner is now fixed.",
+    "markdown": "An issues preventing volume expand controller to annotate the PVC with `volume.kubernetes.io/storage-resizer` when the PVC StorageClass is already updated to the out-of-tree provisioner is now fixed. ([#94489](https://github.com/kubernetes/kubernetes/pull/94489), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG API Machinery, Apps and Storage]",
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94489",
+    "pr_number": 94489,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "apps", "storage"],
+    "duplicate": true
+  },
+  "94853": {
+    "commit": "240057b00387d32806ecb70e6f25658690053219",
+    "text": "fix azure file migration panic",
+    "markdown": "Fix azure file migration panic ([#94853](https://github.com/kubernetes/kubernetes/pull/94853), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/94853",
+    "pr_number": 94853,
+    "areas": ["provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "95260": {
+    "commit": "e3767ead2b48c4c5dac97ebdfeecb824ac35eb70",
+    "text": "Fixes high CPU usage in kubectl drain",
+    "markdown": "Fixes high CPU usage in kubectl drain ([#95260](https://github.com/kubernetes/kubernetes/pull/95260), [@amandahla](https://github.com/amandahla)) [SIG CLI]",
+    "author": "amandahla",
+    "author_url": "https://github.com/amandahla",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95260",
+    "pr_number": 95260,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "95427": {
+    "commit": "0036586379f5b9958017200798c4bb7ae7d85519",
+    "text": "Fixed a bug in client-go where new clients with customized `Dial`, `Proxy`, `GetCert` config may get stale HTTP transports.",
+    "markdown": "Fixed a bug in client-go where new clients with customized `Dial`, `Proxy`, `GetCert` config may get stale HTTP transports. ([#95427](https://github.com/kubernetes/kubernetes/pull/95427), [@roycaihw](https://github.com/roycaihw)) [SIG API Machinery]",
+    "author": "roycaihw",
+    "author_url": "https://github.com/roycaihw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95427",
+    "pr_number": 95427,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "95456": {
+    "commit": "c194df43db09e476c141415af9193620df1b1718",
+    "text": "fix azure disk data loss issue on Windows when unmount disk",
+    "markdown": "Fix azure disk data loss issue on Windows when unmount disk ([#95456](https://github.com/kubernetes/kubernetes/pull/95456), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95456",
+    "pr_number": 95456,
+    "areas": ["provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider", "storage"],
+    "duplicate": true
+  },
+  "95463": {
+    "commit": "7234e7f11652db04dbe6ed8d503f4bf189a2445a",
+    "text": "fix azure disk attach failure for disk size bigger than 4TB",
+    "markdown": "Fix azure disk attach failure for disk size bigger than 4TB ([#95463](https://github.com/kubernetes/kubernetes/pull/95463), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95463",
+    "pr_number": 95463,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "95647": {
+    "commit": "1d5e9d55309e3fbea9e773adf6111a5fb0c870f1",
+    "text": "If we set SelectPolicy MinPolicySelect on scaleUp behavior or scaleDown behavior,Horizontal Pod Autoscaler doesn`t automatically scale the number of pods correctly",
+    "markdown": "If we set SelectPolicy MinPolicySelect on scaleUp behavior or scaleDown behavior,Horizontal Pod Autoscaler doesn`t automatically scale the number of pods correctly ([#95647](https://github.com/kubernetes/kubernetes/pull/95647), [@JoshuaAndrew](https://github.com/JoshuaAndrew)) [SIG Apps and Autoscaling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling",
+        "type": "KEP"
+      },
+      {
+        "description": "[Design]",
+        "url": "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md",
+        "type": "external"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/",
+        "type": "official"
+      }
+    ],
+    "author": "JoshuaAndrew",
+    "author_url": "https://github.com/JoshuaAndrew",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95647",
+    "pr_number": 95647,
+    "kinds": ["bug"],
+    "sigs": ["apps", "autoscaling"],
+    "duplicate": true
+  },
+  "95883": {
+    "commit": "a3966121cdfc12b2d30c1225c982c82a45beb663",
+    "text": "Fix a bug that Pods with topologySpreadConstraints get scheduled to nodes without required labels.",
+    "markdown": "Fix a bug that Pods with topologySpreadConstraints get scheduled to nodes without required labels. ([#95883](https://github.com/kubernetes/kubernetes/pull/95883), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]",
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95883",
+    "pr_number": 95883,
+    "kinds": ["bug"],
+    "sigs": ["scheduling"]
+  },
+  "96117": {
+    "commit": "425ded30bc4957d0f000722bb54276ce7c67a4a1",
+    "text": "Disable watchcache for events.k8.io/Event resource for compatibility with core/Event.",
+    "markdown": "Disable watchcache for events.k8.io/Event resource for compatibility with core/Event. ([#96117](https://github.com/kubernetes/kubernetes/pull/96117), [@wojtek-t](https://github.com/wojtek-t)) [SIG Scalability]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96117",
+    "pr_number": 96117,
+    "kinds": ["bug"],
+    "sigs": ["scalability"]
+  },
+  "96181": {
+    "commit": "4238d51ae79d21c064df7976ecd0467fec61d366",
+    "text": "Disabled `LocalStorageCapacityIsolation` feature gate is honored during scheduling.",
+    "markdown": "Disabled `LocalStorageCapacityIsolation` feature gate is honored during scheduling. ([#96181](https://github.com/kubernetes/kubernetes/pull/96181), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]",
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96181",
+    "pr_number": 96181,
+    "kinds": ["bug"],
+    "sigs": ["scheduling"]
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.18.11.json',
   'assets/release-notes-1.20.0-beta.2.json',
   'assets/release-notes-1.19.4.json',
   'assets/release-notes-1.17.14.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.18.11` 