### PR TITLE
Patch relnotes.k8s.io to release v1.20.4

### DIFF
--- a/src/assets/release-notes-1.20.4.json
+++ b/src/assets/release-notes-1.20.4.json
@@ -1,0 +1,16 @@
+{
+  "99081": {
+    "commit": "7b505449b58b944acec206c54659739e398be49f",
+    "text": "NONE",
+    "markdown": "NONE ([#99081](https://github.com/kubernetes/kubernetes/pull/99081), [@heyste](https://github.com/heyste)) [SIG Architecture, Scheduling and Testing]",
+    "author": "heyste",
+    "author_url": "https://github.com/heyste",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/99081",
+    "pr_number": 99081,
+    "areas": ["conformance", "release-eng", "test"],
+    "kinds": ["cleanup"],
+    "sigs": ["architecture", "scheduling", "testing"],
+    "duplicate": true,
+    "do_not_publish": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.20.4.json',
   'assets/release-notes-1.20.1.json',
   'assets/release-notes-1.20.0.json',
   'assets/release-notes-1.18.11.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.20.4` 