### PR TITLE
Patch relnotes.k8s.io to release v1.23.0-alpha.3

### DIFF
--- a/src/assets/release-notes-1.23.0-alpha.3.json
+++ b/src/assets/release-notes-1.23.0-alpha.3.json
@@ -1,0 +1,503 @@
+{
+  "100125": {
+    "commit": "0734820279ccce8c6034d9d122392fe3a0c7535e",
+    "text": "kube-apiserver: events created via the `events.k8s.io` API group for cluster-scoped objects are now permitted in the default namespace as well for compatibility with events clients and the `v1` API",
+    "markdown": "Kube-apiserver: events created via the `events.k8s.io` API group for cluster-scoped objects are now permitted in the default namespace as well for compatibility with events clients and the `v1` API ([#100125](https://github.com/kubernetes/kubernetes/pull/100125), [@h4ghhh](https://github.com/h4ghhh)) [SIG API Machinery, Apps and Testing]",
+    "author": "h4ghhh",
+    "author_url": "https://github.com/h4ghhh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/100125",
+    "pr_number": 100125,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "apps", "testing"],
+    "duplicate": true
+  },
+  "102242": {
+    "commit": "a48a2efbd45ad77901dd09f2665d8cc1e1d8dbf6",
+    "text": "Remove 'master' as a valid EgressSelection type in the EgressSelectorConfiguration API.",
+    "markdown": "Remove 'master' as a valid EgressSelection type in the EgressSelectorConfiguration API. ([#102242](https://github.com/kubernetes/kubernetes/pull/102242), [@pacoxu](https://github.com/pacoxu)) [SIG API Machinery and Cloud Provider]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/102242",
+    "pr_number": 102242,
+    "areas": ["apiserver", "provider/gcp"],
+    "kinds": ["cleanup", "api-change", "deprecation"],
+    "sigs": ["api-machinery", "cloud-provider"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "103172": {
+    "commit": "fed612c9f8e00cc2d228bbe7afa66f4623085916",
+    "text": "The deprecated --experimental-bootstrap-kubeconfig flag has been removed.\nThis can be set via --bootstrap-kubeconfig.",
+    "markdown": "The deprecated --experimental-bootstrap-kubeconfig flag has been removed.\n  This can be set via --bootstrap-kubeconfig. ([#103172](https://github.com/kubernetes/kubernetes/pull/103172), [@niulechuan](https://github.com/niulechuan)) [SIG Node]",
+    "author": "niulechuan",
+    "author_url": "https://github.com/niulechuan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/103172",
+    "pr_number": 103172,
+    "areas": ["kubelet"],
+    "kinds": ["deprecation"],
+    "sigs": ["node"]
+  },
+  "103174": {
+    "commit": "16823fceb00fc19bbb15bbefd063bf07d66ee96a",
+    "text": "Changes behaviour of kube-proxy start; does not attempt to set specific sysctl values (which does not work in recent Kernel versions anymore in non-init namespaces), when the current sysctl values are already set higher.",
+    "markdown": "Changes behaviour of kube-proxy start; does not attempt to set specific sysctl values (which does not work in recent Kernel versions anymore in non-init namespaces), when the current sysctl values are already set higher. ([#103174](https://github.com/kubernetes/kubernetes/pull/103174), [@Napsty](https://github.com/Napsty)) [SIG Network]",
+    "author": "Napsty",
+    "author_url": "https://github.com/Napsty",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/103174",
+    "pr_number": 103174,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "104163": {
+    "commit": "e8653fe24a8517120b2a3cfb94c4a9ed36591cd9",
+    "text": "The `SupportPodPidsLimit` and  `SupportNodePidsLimit` feature gates that are GA since v1.20 are unconditionally enabled, and can no longer be specified via the `--feature-gates` argument.",
+    "markdown": "The `SupportPodPidsLimit` and  `SupportNodePidsLimit` feature gates that are GA since v1.20 are unconditionally enabled, and can no longer be specified via the `--feature-gates` argument. ([#104163](https://github.com/kubernetes/kubernetes/pull/104163), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/757",
+        "type": "KEP"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/policy/pid-limiting/",
+        "type": "official"
+      }
+    ],
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104163",
+    "pr_number": 104163,
+    "kinds": ["cleanup"],
+    "sigs": ["node"]
+  },
+  "104167": {
+    "commit": "9ff99adc60fe52798555d683c0cb682dd6f69c4d",
+    "text": "The `BoundServiceAccountTokenVolume` feature gate that is GA since v1.22 is unconditionally enabled, and can no longer be specified via the `--feature-gates` argument.",
+    "markdown": "The `BoundServiceAccountTokenVolume` feature gate that is GA since v1.22 is unconditionally enabled, and can no longer be specified via the `--feature-gates` argument. ([#104167](https://github.com/kubernetes/kubernetes/pull/104167), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Auth]",
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104167",
+    "pr_number": 104167,
+    "kinds": ["cleanup"],
+    "sigs": ["auth"]
+  },
+  "104483": {
+    "commit": "48d844ec64bd83a378418d420ba455fa28043cbc",
+    "text": "client-go impersonation config can specify a UID to pass impersonated uid information through in requests.",
+    "markdown": "Client-go impersonation config can specify a UID to pass impersonated uid information through in requests. ([#104483](https://github.com/kubernetes/kubernetes/pull/104483), [@margocrawf](https://github.com/margocrawf)) [SIG API Machinery, Auth and Testing]",
+    "author": "margocrawf",
+    "author_url": "https://github.com/margocrawf",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104483",
+    "pr_number": 104483,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "104624": {
+    "commit": "fa2657b8b2f839b88834579917abda1a816a1970",
+    "text": "kubelet: turn the KubeletConfiguration v1beta1 `ResolverConfig` field from a `string` to `*string`.",
+    "markdown": "Kubelet: turn the KubeletConfiguration v1beta1 `ResolverConfig` field from a `string` to `*string`. ([#104624](https://github.com/kubernetes/kubernetes/pull/104624), [@Haleygo](https://github.com/Haleygo)) [SIG Cluster Lifecycle and Node]",
+    "author": "Haleygo",
+    "author_url": "https://github.com/Haleygo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104624",
+    "pr_number": 104624,
+    "areas": ["kubelet", "kubeadm"],
+    "kinds": ["bug", "api-change"],
+    "sigs": ["node", "cluster-lifecycle"],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "104670": {
+    "commit": "5d7ac70051f4e5e85834852c30d07c5b0cd3c6d0",
+    "text": "turn on CSIMigrationAzureDisk by default on 1.23",
+    "markdown": "Turn on CSIMigrationAzureDisk by default on 1.23 ([#104670](https://github.com/kubernetes/kubernetes/pull/104670), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104670",
+    "pr_number": 104670,
+    "areas": ["provider/azure"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "104691": {
+    "commit": "a53e2eaeaba064309dceca2dc27f3ac09c6375b0",
+    "text": "IPv6DualStack feature moved to stable.\nController Manager flags for the node IPAM controller have slightly changed:\n1. When configuring a dual-stack cluster, the user must specify both --node-cidr-mask-size-ipv4 and --node-cidr-mask-size-ipv6 to set the per-node IP mask sizes, instead of the previous --node-cidr-mask-size flag.\n2. The --node-cidr-mask-size flag is mutually exclusive with --node-cidr-mask-size-ipv4 and --node-cidr-mask-size-ipv6.\n3. Single-stack clusters do not need to change, but may choose to use the more specific flags.  Users can use either the older --node-cidr-mask-size flag or one of the newer --node-cidr-mask-size-ipv4 or --node-cidr-mask-size-ipv6 flags to configure the per-node IP mask size, provided that the flag's IP family matches the cluster's IP family (--cluster-cidr).",
+    "markdown": "IPv6DualStack feature moved to stable.\n  Controller Manager flags for the node IPAM controller have slightly changed:\n  1. When configuring a dual-stack cluster, the user must specify both --node-cidr-mask-size-ipv4 and --node-cidr-mask-size-ipv6 to set the per-node IP mask sizes, instead of the previous --node-cidr-mask-size flag.\n  2. The --node-cidr-mask-size flag is mutually exclusive with --node-cidr-mask-size-ipv4 and --node-cidr-mask-size-ipv6.\n  3. Single-stack clusters do not need to change, but may choose to use the more specific flags.  Users can use either the older --node-cidr-mask-size flag or one of the newer --node-cidr-mask-size-ipv4 or --node-cidr-mask-size-ipv6 flags to configure the per-node IP mask size, provided that the flag's IP family matches the cluster's IP family (--cluster-cidr). ([#104691](https://github.com/kubernetes/kubernetes/pull/104691), [@khenidak](https://github.com/khenidak)) [SIG API Machinery, Apps, Auth, Cloud Provider, Cluster Lifecycle, Network, Node and Testing]",
+    "documentation": [
+      {
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/563-dual-stack",
+        "type": "KEP"
+      },
+      {
+        "url": "https://github.com/kubernetes/enhancements/pull/2860#pullrequestreview-733375378",
+        "type": "KEP"
+      }
+    ],
+    "author": "khenidak",
+    "author_url": "https://github.com/khenidak",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104691",
+    "pr_number": 104691,
+    "areas": ["test", "kubelet", "apiserver", "kubeadm"],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "apps",
+      "testing",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "104782": {
+    "commit": "75a255d2ed9d241a936d3ea5b5424daf17fee9f3",
+    "text": "#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#104782](https://github.com/kubernetes/kubernetes/pull/104782), [@kerthcet](https://github.com/kerthcet)) [SIG Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/2921",
+        "type": "KEP"
+      }
+    ],
+    "author": "kerthcet",
+    "author_url": "https://github.com/kerthcet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104782",
+    "pr_number": 104782,
+    "areas": ["test", "apiserver"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["scheduling", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "104847": {
+    "commit": "d5719800bf044b67a538c679dbd808def36bcf0f",
+    "text": "When a static pod file is deleted and recreated while using a fixed UID, the pod was not properly restarted.",
+    "markdown": "When a static pod file is deleted and recreated while using a fixed UID, the pod was not properly restarted. ([#104847](https://github.com/kubernetes/kubernetes/pull/104847), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Testing]",
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104847",
+    "pr_number": 104847,
+    "areas": ["test", "kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node", "testing"],
+    "duplicate": true
+  },
+  "104854": {
+    "commit": "91f820eee42a8126d95d1d706ae20740c9d57913",
+    "text": "kubeadm: switch the preflight check (called 'Swap') that verifies if swap is enabled on Linux hosts to report a warning instead of an error. This is related to the graduation of the NodeSwap feature gate in the kubelet to Beta and being enabled by default in 1.23 - allows swap support on Linux hosts. In the next release of kubeadm (1.24) the preflight check will be removed, thus we recommend that you stop using it - e.g. via --ignore-preflight-errors or the kubeadm config.",
+    "markdown": "Kubeadm: switch the preflight check (called 'Swap') that verifies if swap is enabled on Linux hosts to report a warning instead of an error. This is related to the graduation of the NodeSwap feature gate in the kubelet to Beta and being enabled by default in 1.23 - allows swap support on Linux hosts. In the next release of kubeadm (1.24) the preflight check will be removed, thus we recommend that you stop using it - e.g. via --ignore-preflight-errors or the kubeadm config. ([#104854](https://github.com/kubernetes/kubernetes/pull/104854), [@pacoxu](https://github.com/pacoxu)) [SIG Cluster Lifecycle]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap",
+        "type": "KEP"
+      }
+    ],
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104854",
+    "pr_number": 104854,
+    "areas": ["kubeadm"],
+    "kinds": ["bug"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "104908": {
+    "commit": "060f5b88d0d554fd8b38333ed25b8e73614ab630",
+    "text": "migrate pkg/proxy to structured logs",
+    "markdown": "Migrate pkg/proxy to structured logs ([#104908](https://github.com/kubernetes/kubernetes/pull/104908), [@CIPHERTron](https://github.com/CIPHERTron)) [SIG Network]",
+    "author": "CIPHERTron",
+    "author_url": "https://github.com/CIPHERTron",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104908",
+    "pr_number": 104908,
+    "areas": ["logging"],
+    "kinds": ["cleanup"],
+    "sigs": ["network"]
+  },
+  "104913": {
+    "commit": "5e2ec0c575ccebe5e1fecd9eca02c1ecd1ccaf3f",
+    "text": "kube-controller incorrectly enabled support for generic ephemeral inline volumes if the storage object in use protection feature was enabled.",
+    "markdown": "Kube-controller incorrectly enabled support for generic ephemeral inline volumes if the storage object in use protection feature was enabled. ([#104913](https://github.com/kubernetes/kubernetes/pull/104913), [@pohly](https://github.com/pohly)) [SIG API Machinery]",
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104913",
+    "pr_number": 104913,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "104923": {
+    "commit": "486ca678a03ef1bceb903376bc8f1757a1293fe0",
+    "text": "XFS-filesystems are now force-formatted (option `-f`) in order to avoid problems being formatted due to detection of magic super-blocks. This aligns with the behaviour of formatting of ext3/4 filesystems.",
+    "markdown": "XFS-filesystems are now force-formatted (option `-f`) in order to avoid problems being formatted due to detection of magic super-blocks. This aligns with the behaviour of formatting of ext3/4 filesystems. ([#104923](https://github.com/kubernetes/kubernetes/pull/104923), [@davidkarlsen](https://github.com/davidkarlsen)) [SIG Storage]",
+    "author": "davidkarlsen",
+    "author_url": "https://github.com/davidkarlsen",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104923",
+    "pr_number": 104923,
+    "kinds": ["bug"],
+    "sigs": ["storage"]
+  },
+  "104928": {
+    "commit": "5449ce7c5c9c3ed0e96b8b078c6c07a346b2891f",
+    "text": "Migrate cmd/proxy/app and pkg/proxy/meta_proxier to structured logging",
+    "markdown": "Migrate cmd/proxy/app and pkg/proxy/meta_proxier to structured logging ([#104928](https://github.com/kubernetes/kubernetes/pull/104928), [@jyz0309](https://github.com/jyz0309)) [SIG Apps, Cluster Lifecycle, Network, Node and Testing]",
+    "author": "jyz0309",
+    "author_url": "https://github.com/jyz0309",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104928",
+    "pr_number": 104928,
+    "areas": ["test", "logging", "kubeadm", "ipvs", "e2e-test-framework"],
+    "kinds": ["cleanup"],
+    "sigs": ["network", "node", "cluster-lifecycle", "apps", "testing"],
+    "duplicate": true
+  },
+  "104942": {
+    "commit": "8975906dfc87732e063bb30e36b181a031988a52",
+    "text": "kubeadm: do not check if the '/etc/kubernetes/manifests' folder is empty on joining worker nodes during preflight",
+    "markdown": "Kubeadm: do not check if the '/etc/kubernetes/manifests' folder is empty on joining worker nodes during preflight ([#104942](https://github.com/kubernetes/kubernetes/pull/104942), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104942",
+    "pr_number": 104942,
+    "areas": ["kubeadm"],
+    "kinds": ["bug", "feature"],
+    "sigs": ["cluster-lifecycle"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "104944": {
+    "commit": "acbeaf8b8e1ee8de55f8167ac9c41d6c7526f9dd",
+    "text": "Migrate `cmd/proxy/{config, healthcheck, winkernel}` to structured logging",
+    "markdown": "Migrate `cmd/proxy/{config, healthcheck, winkernel}` to structured logging ([#104944](https://github.com/kubernetes/kubernetes/pull/104944), [@jyz0309](https://github.com/jyz0309)) [SIG Network]",
+    "author": "jyz0309",
+    "author_url": "https://github.com/jyz0309",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104944",
+    "pr_number": 104944,
+    "areas": ["logging"],
+    "kinds": ["cleanup"],
+    "sigs": ["network"]
+  },
+  "104983": {
+    "commit": "5b489e2846a7fb959252dc5a04fe21ec844e9fad",
+    "text": "The kube-apiserver's Prometheus metrics have been extended with some that describe the costs of handling LIST requests.  They are as follows.\n- *apiserver_cache_list_total*: Counter of LIST requests served from watch cache, broken down by resource_prefix and index_name\n- *apiserver_cache_list_fetched_objects_total*: Counter of objects read from watch cache in the course of serving a LIST request, broken down by resource_prefix and index_name\n- *apiserver_cache_list_evaluated_objects_total*: Counter of objects tested in the course of serving a LIST request from watch cache, broken down by resource_prefix\n- *apiserver_cache_list_returned_objects_total*: Counter of objects returned for a LIST request from watch cache, broken down by resource_prefix\n- *apiserver_storage_list_total*: Counter of LIST requests served from etcd, broken down by resource\n- *apiserver_storage_list_fetched_objects_total*: Counter of objects read from etcd in the course of serving a LIST request, broken down by resource\n- *apiserver_storage_list_evaluated_objects_total*: Counter of objects tested in the course of serving a LIST request from etcd, broken down by resource\n- *apiserver_storage_list_returned_objects_total*: Counter of objects returned for a LIST request from etcd, broken down by resource",
+    "markdown": "The kube-apiserver's Prometheus metrics have been extended with some that describe the costs of handling LIST requests.  They are as follows.\n  - *apiserver_cache_list_total*: Counter of LIST requests served from watch cache, broken down by resource_prefix and index_name\n  - *apiserver_cache_list_fetched_objects_total*: Counter of objects read from watch cache in the course of serving a LIST request, broken down by resource_prefix and index_name\n  - *apiserver_cache_list_evaluated_objects_total*: Counter of objects tested in the course of serving a LIST request from watch cache, broken down by resource_prefix\n  - *apiserver_cache_list_returned_objects_total*: Counter of objects returned for a LIST request from watch cache, broken down by resource_prefix\n  - *apiserver_storage_list_total*: Counter of LIST requests served from etcd, broken down by resource\n  - *apiserver_storage_list_fetched_objects_total*: Counter of objects read from etcd in the course of serving a LIST request, broken down by resource\n  - *apiserver_storage_list_evaluated_objects_total*: Counter of objects tested in the course of serving a LIST request from etcd, broken down by resource\n  - *apiserver_storage_list_returned_objects_total*: Counter of objects returned for a LIST request from etcd, broken down by resource ([#104983](https://github.com/kubernetes/kubernetes/pull/104983), [@MikeSpreitzer](https://github.com/MikeSpreitzer)) [SIG API Machinery and Instrumentation]",
+    "author": "MikeSpreitzer",
+    "author_url": "https://github.com/MikeSpreitzer",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104983",
+    "pr_number": 104983,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "104986": {
+    "commit": "924f1968828da3b0c20a9eea2e19236a47fa689f",
+    "text": "Headless Services with no selector which were created without dual-stack enabled will be defaulted to RequireDualStack instead of PreferDualStack.  This is consistent with such Services which are created with dual-stack enabled.",
+    "markdown": "Headless Services with no selector which were created without dual-stack enabled will be defaulted to RequireDualStack instead of PreferDualStack.  This is consistent with such Services which are created with dual-stack enabled. ([#104986](https://github.com/kubernetes/kubernetes/pull/104986), [@thockin](https://github.com/thockin)) [SIG Network]",
+    "author": "thockin",
+    "author_url": "https://github.com/thockin",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104986",
+    "pr_number": 104986,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "105034": {
+    "commit": "73d51a21dbe7504a00423877e272a279a21a115f",
+    "text": "kubeadm: remove the --port flag from the manifest for the kube-scheduler since the flag has been a NO-OP since 1.23 and insecure serving was removed for the component.",
+    "markdown": "Kubeadm: remove the --port flag from the manifest for the kube-scheduler since the flag has been a NO-OP since 1.23 and insecure serving was removed for the component. ([#105034](https://github.com/kubernetes/kubernetes/pull/105034), [@pacoxu](https://github.com/pacoxu)) [SIG Cluster Lifecycle]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105034",
+    "pr_number": 105034,
+    "areas": ["kubeadm"],
+    "kinds": ["cleanup"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "105035": {
+    "commit": "f06ce08d63db87da3d5cf6aaf8a50c858e5d8a35",
+    "text": "migrated pkg/proxy/winuserspace to structured logging",
+    "markdown": "Migrated pkg/proxy/winuserspace to structured logging ([#105035](https://github.com/kubernetes/kubernetes/pull/105035), [@shivanshu1333](https://github.com/shivanshu1333)) [SIG Network]",
+    "author": "shivanshu1333",
+    "author_url": "https://github.com/shivanshu1333",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105035",
+    "pr_number": 105035,
+    "areas": ["logging"],
+    "kinds": ["cleanup"],
+    "sigs": ["network"]
+  },
+  "105046": {
+    "commit": "fb70ca9b7b24ce90b19b0d565ae43e6af20458ad",
+    "text": "Fix system default topology spreading when nodes don't have zone labels. Pods correctly spread by default now.",
+    "markdown": "Fix system default topology spreading when nodes don't have zone labels. Pods correctly spread by default now. ([#105046](https://github.com/kubernetes/kubernetes/pull/105046), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105046",
+    "pr_number": 105046,
+    "kinds": ["bug"],
+    "sigs": ["scheduling"]
+  },
+  "105069": {
+    "commit": "63e7ee43bb5394abd6dd5010be47ebcb22ec0ef8",
+    "text": "makes the etcd client (used by the API server) retry certain types of errors. The full list of retriable (codes.Unavailable) errors can be found at https://github.com/etcd-io/etcd/blob/main/api/v3rpc/rpctypes/error.go#L72",
+    "markdown": "Makes the etcd client (used by the API server) retry certain types of errors. The full list of retriable (codes.Unavailable) errors can be found at https://github.com/etcd-io/etcd/blob/main/api/v3rpc/rpctypes/error.go#L72 ([#105069](https://github.com/kubernetes/kubernetes/pull/105069), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery]",
+    "author": "p0lyn0mial",
+    "author_url": "https://github.com/p0lyn0mial",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105069",
+    "pr_number": 105069,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "105107": {
+    "commit": "117ef89d2bb4f4bf907280c1c67a12b35e2152df",
+    "text": "Added a new feature gate `CustomResourceValidationExpressions` to enable expression validation for Custom Resource.",
+    "markdown": "Added a new feature gate `CustomResourceValidationExpressions` to enable expression validation for Custom Resource. ([#105107](https://github.com/kubernetes/kubernetes/pull/105107), [@cici37](https://github.com/cici37)) [SIG API Machinery]",
+    "documentation": [
+      { "description": "[KEP]:  \u003c", "url": "http://kep.k8s.io/2876\u003e", "type": "external" }
+    ],
+    "author": "cici37",
+    "author_url": "https://github.com/cici37",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105107",
+    "pr_number": 105107,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "105158": {
+    "commit": "d385d0602a1075837bf8713b9f56964c154aede7",
+    "text": "Update build images to Debian 11 (Bullseye)\n- debian-base:bullseye-v1.0.0\n- debian-iptables:bullseye-v1.0.0\n- go-runner:v2.3.1-go1.17.1-bullseye.0\n- kube-cross:v1.23.0-go1.17.1-bullseye.1\n- setcap:bullseye-v1.0.0\n- cluster/images/etcd: Build 3.5.0-2 image\n- test/conformance/image: Update runner image to base-debian11",
+    "markdown": "Update build images to Debian 11 (Bullseye)\n  - debian-base:bullseye-v1.0.0\n  - debian-iptables:bullseye-v1.0.0\n  - go-runner:v2.3.1-go1.17.1-bullseye.0\n  - kube-cross:v1.23.0-go1.17.1-bullseye.1\n  - setcap:bullseye-v1.0.0\n  - cluster/images/etcd: Build 3.5.0-2 image\n  - test/conformance/image: Update runner image to base-debian11 ([#105158](https://github.com/kubernetes/kubernetes/pull/105158), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, Architecture, Release and Testing]",
+    "author": "justaugustus",
+    "author_url": "https://github.com/justaugustus",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105158",
+    "pr_number": 105158,
+    "areas": ["test", "security", "release-eng", "conformance", "dependency"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "testing", "release", "architecture"],
+    "duplicate": true
+  },
+  "105185": {
+    "commit": "df845f0c47d0f4eab4969f66a2690015ca04a23a",
+    "text": "Fix: ignore not a VMSS error for VMAS nodes in EnsureBackendPoolDeleted.",
+    "markdown": "Fix: ignore not a VMSS error for VMAS nodes in EnsureBackendPoolDeleted. ([#105185](https://github.com/kubernetes/kubernetes/pull/105185), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Cloud Provider]",
+    "author": "ialidzhikov",
+    "author_url": "https://github.com/ialidzhikov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105185",
+    "pr_number": 105185,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "105188": {
+    "commit": "1e21fe694e037431b993ec90ec062d1dcc38cafe",
+    "text": "fix: consolidate logs for instance not found error\nfix: skip not found nodes when reconciling LB backend address pools",
+    "markdown": "Fix: consolidate logs for instance not found error\n  fix: skip not found nodes when reconciling LB backend address pools ([#105188](https://github.com/kubernetes/kubernetes/pull/105188), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]",
+    "author": "nilo19",
+    "author_url": "https://github.com/nilo19",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105188",
+    "pr_number": 105188,
+    "areas": ["cloudprovider", "provider/azure"],
+    "kinds": ["bug"],
+    "sigs": ["cloud-provider"]
+  },
+  "105196": {
+    "commit": "16fdb2f39148e8843e999780fc7bd3ee161349fb",
+    "text": "Enhanced error message for nodes not selected by scheduler due to pod's PersistentVolumeClaim(s) bound to PersistentVolume(s) that do not exist.",
+    "markdown": "Enhanced error message for nodes not selected by scheduler due to pod's PersistentVolumeClaim(s) bound to PersistentVolume(s) that do not exist. ([#105196](https://github.com/kubernetes/kubernetes/pull/105196), [@yibozhuang](https://github.com/yibozhuang)) [SIG Scheduling and Storage]",
+    "author": "yibozhuang",
+    "author_url": "https://github.com/yibozhuang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105196",
+    "pr_number": 105196,
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "storage"],
+    "duplicate": true
+  },
+  "105197": {
+    "commit": "a438f16741fbf064281e4c57e04e17ff4d41bc02",
+    "text": "When feature gate JobTrackingWithFinalizers is enabled:\n- Limit the number of pods tracked in a single job sync to avoid starvation of small jobs.\n- The metric job_pod_finished_total counts the number of finished pods tracked by the job controller",
+    "markdown": "When feature gate JobTrackingWithFinalizers is enabled:\n  - Limit the number of pods tracked in a single job sync to avoid starvation of small jobs.\n  - The metric job_pod_finished_total counts the number of finished pods tracked by the job controller ([#105197](https://github.com/kubernetes/kubernetes/pull/105197), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2307-job-tracking-without-lingering-pods",
+        "type": "KEP"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-tracking-with-finalizers",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105197",
+    "pr_number": 105197,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "105213": {
+    "commit": "35df409a7efba59378a900710c44b8c7c7b681b0",
+    "text": "release-note Removed error message label from kubelet_started_pods_errors_total metric",
+    "markdown": "Release-note Removed error message label from kubelet_started_pods_errors_total metric ([#105213](https://github.com/kubernetes/kubernetes/pull/105213), [@yxxhero](https://github.com/yxxhero)) [SIG Instrumentation and Node]",
+    "author": "yxxhero",
+    "author_url": "https://github.com/yxxhero",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105213",
+    "pr_number": 105213,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node", "instrumentation"],
+    "duplicate": true
+  },
+  "105214": {
+    "commit": "aec9acda6818684a2e9b98b22ee8d0ab23e77580",
+    "text": "Fix job controller syncs: In case of conflicts, ensure that the sync happens with the most up to date information. Improves reliability of JobTrackingWithFinalizers.",
+    "markdown": "Fix job controller syncs: In case of conflicts, ensure that the sync happens with the most up to date information. Improves reliability of JobTrackingWithFinalizers. ([#105214](https://github.com/kubernetes/kubernetes/pull/105214), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105214",
+    "pr_number": 105214,
+    "kinds": ["bug", "flake"],
+    "sigs": ["apps"],
+    "duplicate_kind": true
+  },
+  "105267": {
+    "commit": "528cd3014544c9ae7f97fa5315fe10f069e57f48",
+    "text": "Fixes a bug that could result in the EndpointSlice controller unnecessarily updating EndpointSlices associated with a Service that had Topology Aware Hints enabled.",
+    "markdown": "Fixes a bug that could result in the EndpointSlice controller unnecessarily updating EndpointSlices associated with a Service that had Topology Aware Hints enabled. ([#105267](https://github.com/kubernetes/kubernetes/pull/105267), [@llhuii](https://github.com/llhuii)) [SIG Apps and Network]",
+    "author": "llhuii",
+    "author_url": "https://github.com/llhuii",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105267",
+    "pr_number": 105267,
+    "kinds": ["bug"],
+    "sigs": ["network", "apps"],
+    "duplicate": true
+  },
+  "92853": {
+    "commit": "7bff8adaf683dc7e25b5548e2c16e7393ff8a036",
+    "text": "Add mechanism to load simple sniffer class into fluentd-elasticsearch image",
+    "markdown": "Add mechanism to load simple sniffer class into fluentd-elasticsearch image ([#92853](https://github.com/kubernetes/kubernetes/pull/92853), [@cosmo0920](https://github.com/cosmo0920)) [SIG Cloud Provider and Instrumentation]",
+    "author": "cosmo0920",
+    "author_url": "https://github.com/cosmo0920",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/92853",
+    "pr_number": 92853,
+    "areas": ["provider/gcp"],
+    "kinds": ["feature"],
+    "sigs": ["instrumentation", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.23.0-alpha.3.json',
   'assets/release-notes-1.23.0-alpha.2.json',
   'assets/release-notes-1.23.0-alpha.1.json',
   'assets/release-notes-1.23.0-alpha.0.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.23.0-alpha.3` 