### PR TITLE
Patch relnotes.k8s.io to release v1.18.20

### DIFF
--- a/src/assets/release-notes-1.18.20.json
+++ b/src/assets/release-notes-1.18.20.json
@@ -1,0 +1,16 @@
+{
+  "102838": {
+    "commit": "829f650b0c05adc5ca58b306fc31c39cef91908c",
+    "text": "Reverted the previous fix for portforward cleanup because it introduced a kubelet regression which can lead into segmentation faults.",
+    "markdown": "Reverted the previous fix for portforward cleanup because it introduced a kubelet regression which can lead into segmentation faults. ([#102838](https://github.com/kubernetes/kubernetes/pull/102838), [@saschagrunert](https://github.com/saschagrunert)) [SIG API Machinery and Node]",
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/102838",
+    "pr_number": 102838,
+    "areas": ["kubelet"],
+    "kinds": ["bug", "regression"],
+    "sigs": ["node", "api-machinery"],
+    "duplicate": true,
+    "duplicate_kind": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.18.20.json',
   'assets/release-notes-1.24.0-alpha.2.json',
   'assets/release-notes-1.24.0-alpha.1.json',
   'assets/release-notes-1.23.3.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.18.20` 