### PR TITLE
Patch relnotes.k8s.io to release v1.20.15

### DIFF
--- a/src/assets/release-notes-1.20.15.json
+++ b/src/assets/release-notes-1.20.15.json
@@ -1,0 +1,25 @@
+{
+  "107461": {
+    "commit": "bd3011edb4db5b2a5d0afbf4569cb70a4783c410",
+    "text": "Fixes a rare race condition handling requests that timeout",
+    "markdown": "Fixes a rare race condition handling requests that timeout ([#107461](https://github.com/kubernetes/kubernetes/pull/107461), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107461",
+    "pr_number": 107461,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "107558": {
+    "commit": "2053ae3cfbbe076a43ac3fd433e374d07b467715",
+    "text": "Fixes a panic in kube-scheduler handling pods with invalid selectors",
+    "markdown": "Fixes a panic in kube-scheduler handling pods with invalid selectors ([#107558](https://github.com/kubernetes/kubernetes/pull/107558), [@Zheaoli](https://github.com/Zheaoli)) [SIG Scheduling]",
+    "author": "Zheaoli",
+    "author_url": "https://github.com/Zheaoli",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107558",
+    "pr_number": 107558,
+    "kinds": ["bug"],
+    "sigs": ["scheduling"]
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.20.15.json',
   'assets/release-notes-1.24.0-alpha.2.json',
   'assets/release-notes-1.24.0-alpha.1.json',
   'assets/release-notes-1.23.3.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.20.15` 