### PR TITLE
Patch relnotes.k8s.io to release v1.24.0-beta.0

### DIFF
--- a/src/assets/release-notes-1.24.0-beta.0.json
+++ b/src/assets/release-notes-1.24.0-beta.0.json
@@ -1,0 +1,1365 @@
+{
+  "101218": {
+    "commit": "6c96ac04ff970809d815c871958be702d3065db1",
+    "text": "Kubelet now checks \"NoExecute\" taint/toleration before accepting pods, except for static pods.",
+    "markdown": "Kubelet now checks \"NoExecute\" taint/toleration before accepting pods, except for static pods. ([#101218](https://github.com/kubernetes/kubernetes/pull/101218), [@gjkim42](https://github.com/gjkim42)) [SIG Node]",
+    "author": "gjkim42",
+    "author_url": "https://github.com/gjkim42",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/101218",
+    "pr_number": 101218,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "102265": {
+    "commit": "2cb3c7f706dbf266820fbde2e1b23a320e5d3de7",
+    "text": "allow kubectl to manage resources by filename patterns without the shell expanding it first",
+    "markdown": "Allow kubectl to manage resources by filename patterns without the shell expanding it first ([#102265](https://github.com/kubernetes/kubernetes/pull/102265), [@danielrodriguez](https://github.com/danielrodriguez)) [SIG CLI]",
+    "author": "danielrodriguez",
+    "author_url": "https://github.com/danielrodriguez",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/102265",
+    "pr_number": 102265,
+    "areas": ["kubectl", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "103516": {
+    "commit": "801c39b4781c8ef8e2334ba1ecd2b50dc1ffbd8f",
+    "text": "kube-apiserver: Subresources such as 'status' and 'scale' now support tabular output content types.",
+    "markdown": "Kube-apiserver: Subresources such as 'status' and 'scale' now support tabular output content types. ([#103516](https://github.com/kubernetes/kubernetes/pull/103516), [@ykakarap](https://github.com/ykakarap)) [SIG API Machinery, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource",
+        "type": "KEP"
+      }
+    ],
+    "author": "ykakarap",
+    "author_url": "https://github.com/ykakarap",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/103516",
+    "pr_number": 103516,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "104736": {
+    "commit": "1c031d4fa8450550fa9a6bd5abe7fac45816156e",
+    "text": "Improve kubectl's user help commands readability",
+    "markdown": "Improve kubectl's user help commands readability ([#104736](https://github.com/kubernetes/kubernetes/pull/104736), [@lauchokyip](https://github.com/lauchokyip)) [SIG API Machinery, Apps, Architecture, Auth, Autoscaling, CLI, Cloud Provider, Cluster Lifecycle, Contributor Experience, Instrumentation, Network, Node, Release, Scalability, Scheduling, Security, Storage, Testing and Windows]",
+    "author": "lauchokyip",
+    "author_url": "https://github.com/lauchokyip",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/104736",
+    "pr_number": 104736,
+    "areas": [
+      "test",
+      "kubelet",
+      "apiserver",
+      "kubectl",
+      "cloudprovider",
+      "provider/gcp",
+      "release-eng",
+      "kubeadm",
+      "conformance",
+      "code-generation",
+      "ipvs",
+      "e2e-test-framework",
+      "dependency",
+      "network-policy"
+    ],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "scalability",
+      "scheduling",
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "autoscaling",
+      "contributor-experience",
+      "auth",
+      "apps",
+      "windows",
+      "cli",
+      "instrumentation",
+      "testing",
+      "release",
+      "architecture",
+      "cloud-provider",
+      "security"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "106109": {
+    "commit": "83988399e87f9d9674b8327b351e1bdf7c7fe716",
+    "text": "Migrate statefulset files to structured logging",
+    "markdown": "Migrate statefulset files to structured logging ([#106109](https://github.com/kubernetes/kubernetes/pull/106109), [@h4ghhh](https://github.com/h4ghhh)) [SIG Apps and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-loggin",
+        "type": "KEP"
+      }
+    ],
+    "author": "h4ghhh",
+    "author_url": "https://github.com/h4ghhh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/106109",
+    "pr_number": 106109,
+    "areas": ["logging"],
+    "kinds": ["cleanup"],
+    "sigs": ["apps", "instrumentation"],
+    "duplicate": true
+  },
+  "106497": {
+    "commit": "b9141e5c0db795a7183ca08bd23f7c7acfef7e9b",
+    "text": "Services with \"internalTrafficPolicy: Local\" now behave more like\n\"externalTrafficPolicy: Local\". Also, \"internalTrafficPolicy: Local,\nexternalTrafficPolicy: Cluster\" is now implemented correctly.",
+    "markdown": "Services with \"internalTrafficPolicy: Local\" now behave more like\n  \"externalTrafficPolicy: Local\". Also, \"internalTrafficPolicy: Local,\n  externalTrafficPolicy: Cluster\" is now implemented correctly. ([#106497](https://github.com/kubernetes/kubernetes/pull/106497), [@danwinship](https://github.com/danwinship)) [SIG Network]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/9ad538c8c04f7a15a6e7c17c49cac2c47b63a1a1/keps/sig-network/2086-service-internal-traffic-policy",
+        "type": "KEP"
+      }
+    ],
+    "author": "danwinship",
+    "author_url": "https://github.com/danwinship",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/106497",
+    "pr_number": 106497,
+    "areas": ["ipvs"],
+    "kinds": ["bug", "cleanup"],
+    "sigs": ["network"],
+    "duplicate_kind": true
+  },
+  "106792": {
+    "commit": "ec0881a92062ab664777469493c1ec53e454226f",
+    "text": "New feature gate, ServiceIPStaticSubrange, to enable the new strategy in the Service IP allocators, so the IP range is subdivided and dynamic allocated ClusterIP addresses for Services are allocated preferently from the upper range.",
+    "markdown": "New feature gate, ServiceIPStaticSubrange, to enable the new strategy in the Service IP allocators, so the IP range is subdivided and dynamic allocated ClusterIP addresses for Services are allocated preferently from the upper range. ([#106792](https://github.com/kubernetes/kubernetes/pull/106792), [@aojea](https://github.com/aojea)) [SIG Instrumentation]",
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/106792",
+    "pr_number": 106792,
+    "kinds": ["feature"],
+    "sigs": ["instrumentation"],
+    "feature": true
+  },
+  "106824": {
+    "commit": "d429c9820e8570d093d1315e4b8f7a90af55d0a7",
+    "text": "Remove deprecated generator and container-port flags",
+    "markdown": "Remove deprecated generator and container-port flags ([#106824](https://github.com/kubernetes/kubernetes/pull/106824), [@lauchokyip](https://github.com/lauchokyip)) [SIG CLI]",
+    "author": "lauchokyip",
+    "author_url": "https://github.com/lauchokyip",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/106824",
+    "pr_number": 106824,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "107090": {
+    "commit": "28755c32b51dd4052cc79be8a2df4b2eef5e73f6",
+    "text": "CEL validation failure returns object type instead of object.",
+    "markdown": "CEL validation failure returns object type instead of object. ([#107090](https://github.com/kubernetes/kubernetes/pull/107090), [@cici37](https://github.com/cici37)) [SIG API Machinery]",
+    "author": "cici37",
+    "author_url": "https://github.com/cici37",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107090",
+    "pr_number": 107090,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "107178": {
+    "commit": "9ac1b4b68f3d97eaf41f3974e2eacf09ed0885ac",
+    "text": "The deprecated kube-controller-manager flag '--deployment-controller-sync-period' has been removed, it is not used by the deployment controller.",
+    "markdown": "The deprecated kube-controller-manager flag '--deployment-controller-sync-period' has been removed, it is not used by the deployment controller. ([#107178](https://github.com/kubernetes/kubernetes/pull/107178), [@SataQiu](https://github.com/SataQiu)) [SIG API Machinery and Apps]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107178",
+    "pr_number": 107178,
+    "areas": ["code-generation"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["api-machinery", "apps"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "107180": {
+    "commit": "0b79a791eda116199c40b13b21121274c56df374",
+    "text": "ServerResources was deprecated in February 2019 (https://github.com/kubernetes/kubernetes/commit/618050e) and now it's being removed and ServerGroupsAndResources is suggested to be used instead",
+    "markdown": "ServerResources was deprecated in February 2019 (https://github.com/kubernetes/kubernetes/commit/618050e) and now it's being removed and ServerGroupsAndResources is suggested to be used instead ([#107180](https://github.com/kubernetes/kubernetes/pull/107180), [@ardaguclu](https://github.com/ardaguclu)) [SIG API Machinery, Apps and CLI]",
+    "author": "ardaguclu",
+    "author_url": "https://github.com/ardaguclu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107180",
+    "pr_number": 107180,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "apps", "cli"],
+    "duplicate": true
+  },
+  "107395": {
+    "commit": "f97825e1cea6d06813c53319c70e2568778067f0",
+    "text": "Indexed Jobs graduates to stable",
+    "markdown": "Indexed Jobs graduates to stable ([#107395](https://github.com/kubernetes/kubernetes/pull/107395), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps, Architecture and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "http://git.k8s.io/enhancements/keps/sig-apps/2214-indexed-job",
+        "type": "external"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/tasks/job/indexed-parallel-processing-static/",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107395",
+    "pr_number": 107395,
+    "areas": ["test", "conformance", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["apps", "testing", "architecture"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "107476": {
+    "commit": "dd1e43332a478f64a861a576975a679697cd52a5",
+    "text": "JobReadyPods graduates to Beta and it's enabled by default.",
+    "markdown": "JobReadyPods graduates to Beta and it's enabled by default. ([#107476](https://github.com/kubernetes/kubernetes/pull/107476), [@alculquicondor](https://github.com/alculquicondor)) [SIG API Machinery, Apps and Testing]",
+    "documentation": [
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobStatus",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107476",
+    "pr_number": 107476,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "107631": {
+    "commit": "349900472a38a29fd6d85f7e4880d4f3d72ad6ee",
+    "text": "Fix the bug that the outdated services may be sent to the cloud provider",
+    "markdown": "Fix the bug that the outdated services may be sent to the cloud provider ([#107631](https://github.com/kubernetes/kubernetes/pull/107631), [@lzhecheng](https://github.com/lzhecheng)) [SIG Cloud Provider and Network]",
+    "author": "lzhecheng",
+    "author_url": "https://github.com/lzhecheng",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107631",
+    "pr_number": 107631,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["network", "cloud-provider"],
+    "duplicate": true
+  },
+  "107681": {
+    "commit": "05b59e77175a87b7caca8b27a3ed2478df3d452e",
+    "text": "mark AzureDisk CSI migration as GA",
+    "markdown": "Mark AzureDisk CSI migration as GA ([#107681](https://github.com/kubernetes/kubernetes/pull/107681), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]",
+    "documentation": [
+      {
+        "url": "https://testgrid.k8s.io/provider-azure-azuredisk-csi-driver#pr-azuredisk-csi-driver-e2e-migration",
+        "type": "external"
+      },
+      {
+        "url": "https://testgrid.k8s.io/provider-azure-azuredisk-csi-driver#pr-azuredisk-csi-driver-e2e-migration-windows",
+        "type": "external"
+      }
+    ],
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107681",
+    "pr_number": 107681,
+    "areas": ["provider/azure"],
+    "kinds": ["documentation", "feature"],
+    "sigs": ["storage", "cloud-provider"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "107750": {
+    "commit": "928a5db93befc75cace252cb55d97d1681aa4d43",
+    "text": "A node IP provided to kublet via `--node-ip` will now be preferred for\nwhen determining the node's primary IP and using the external cloud provider\n(CCM).",
+    "markdown": "A node IP provided to kublet via `--node-ip` will now be preferred for\n  when determining the node's primary IP and using the external cloud provider\n  (CCM). ([#107750](https://github.com/kubernetes/kubernetes/pull/107750), [@stephenfin](https://github.com/stephenfin)) [SIG Cloud Provider and Node]",
+    "author": "stephenfin",
+    "author_url": "https://github.com/stephenfin",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107750",
+    "pr_number": 107750,
+    "areas": ["kubelet", "cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["node", "cloud-provider"],
+    "duplicate": true
+  },
+  "107845": {
+    "commit": "df98f75e937cb74eb2f6bc68174355210a55893a",
+    "text": "Failure to start a container cannot accidentally result in the pod being considered \"Succeeded\" in the presence of deletion.",
+    "markdown": "Failure to start a container cannot accidentally result in the pod being considered \"Succeeded\" in the presence of deletion. ([#107845](https://github.com/kubernetes/kubernetes/pull/107845), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node]",
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107845",
+    "pr_number": 107845,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "107859": {
+    "commit": "82f701aae224c8fe59572f3a899197597f129f4b",
+    "text": "Promote IdentifyPodOS feature to beta.",
+    "markdown": "Promote IdentifyPodOS feature to beta. ([#107859](https://github.com/kubernetes/kubernetes/pull/107859), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla)) [SIG API Machinery, Apps, Node, Testing and Windows]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-windows/2802-identify-windows-pods-apiserver-admission",
+        "type": "KEP"
+      }
+    ],
+    "author": "ravisantoshgudimetla",
+    "author_url": "https://github.com/ravisantoshgudimetla",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107859",
+    "pr_number": 107859,
+    "areas": ["test", "code-generation", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery", "apps", "windows", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "107963": {
+    "commit": "42a12010829962c6e87cee8e4bc217d39d7a8043",
+    "text": "Adds a new Status subresource in Network Policy objects",
+    "markdown": "Adds a new Status subresource in Network Policy objects ([#107963](https://github.com/kubernetes/kubernetes/pull/107963), [@rikatz](https://github.com/rikatz)) [SIG API Machinery, Apps, Network and Testing]",
+    "author": "rikatz",
+    "author_url": "https://github.com/rikatz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107963",
+    "pr_number": 107963,
+    "areas": ["test", "apiserver", "code-generation", "network-policy"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "107986": {
+    "commit": "a6e65a246c31ab874dac50ad5a2f1f0ce5bdcdfb",
+    "text": "Promote graceful shutdown based on pod priority to beta",
+    "markdown": "Promote graceful shutdown based on pod priority to beta ([#107986](https://github.com/kubernetes/kubernetes/pull/107986), [@wzshiming](https://github.com/wzshiming)) [SIG Instrumentation, Node and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "wzshiming",
+    "author_url": "https://github.com/wzshiming",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107986",
+    "pr_number": 107986,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108016": {
+    "commit": "2ecfdcc427dd1d081476a0ac641107a365e51a71",
+    "text": "The `v1` version of `LeaderMigrationConfiguration` supports only `leases` API for leader election. To use formerly supported mechanisms, please continue using `v1beta1`.",
+    "markdown": "The `v1` version of `LeaderMigrationConfiguration` supports only `leases` API for leader election. To use formerly supported mechanisms, please continue using `v1beta1`. ([#108016](https://github.com/kubernetes/kubernetes/pull/108016), [@jiahuif](https://github.com/jiahuif)) [SIG API Machinery and Cloud Provider]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2436",
+        "type": "KEP"
+      }
+    ],
+    "author": "jiahuif",
+    "author_url": "https://github.com/jiahuif",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108016",
+    "pr_number": 108016,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108032": {
+    "commit": "0f2300575c805bb70ba181957684361bcd25f86a",
+    "text": "This adds an optional `timeZone` field as part of the CronJob spec to support running cron jobs in a specific time zone.",
+    "markdown": "This adds an optional `timeZone` field as part of the CronJob spec to support running cron jobs in a specific time zone. ([#108032](https://github.com/kubernetes/kubernetes/pull/108032), [@deejross](https://github.com/deejross)) [SIG API Machinery and Apps]",
+    "author": "deejross",
+    "author_url": "https://github.com/deejross",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108032",
+    "pr_number": 108032,
+    "areas": ["apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108073": {
+    "commit": "ef404e989d6c3cf83987773d0ece3c6c4ece8489",
+    "text": "CEL CRD validation expressions may now reference existing object state using the identifier `oldSelf`.",
+    "markdown": "CEL CRD validation expressions may now reference existing object state using the identifier `oldSelf`. ([#108073](https://github.com/kubernetes/kubernetes/pull/108073), [@benluddy](https://github.com/benluddy)) [SIG API Machinery and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/787e5513d09096756c61aaba1916a73cb1dd348b/keps/sig-api-machinery/2876-crd-validation-expression-language#transition-rules",
+        "type": "KEP"
+      }
+    ],
+    "author": "benluddy",
+    "author_url": "https://github.com/benluddy",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108073",
+    "pr_number": 108073,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108146": {
+    "commit": "faf7ad612057f34d34491c039f91331ba311919f",
+    "text": "Updating kubelet permissions check for Windows nodes to see if process is elevated instead of checking if process owner is in Administrators group",
+    "markdown": "Updating kubelet permissions check for Windows nodes to see if process is elevated instead of checking if process owner is in Administrators group ([#108146](https://github.com/kubernetes/kubernetes/pull/108146), [@marosset](https://github.com/marosset)) [SIG Node and Windows]",
+    "author": "marosset",
+    "author_url": "https://github.com/marosset",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108146",
+    "pr_number": 108146,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node", "windows"],
+    "duplicate": true
+  },
+  "108290": {
+    "commit": "b9792a9daef4d978c5c30b6d10cbcdfa77a9b6ac",
+    "text": "Introduce a v1alpha1 networking API for ClusterCIDRConfig",
+    "markdown": "Introduce a v1alpha1 networking API for ClusterCIDRConfig ([#108290](https://github.com/kubernetes/kubernetes/pull/108290), [@sarveshr7](https://github.com/sarveshr7)) [SIG API Machinery, Apps, Auth, CLI, Cloud Provider, Instrumentation, Network and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/2594",
+        "type": "KEP"
+      }
+    ],
+    "author": "sarveshr7",
+    "author_url": "https://github.com/sarveshr7",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108290",
+    "pr_number": 108290,
+    "areas": ["test", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "api-machinery",
+      "auth",
+      "apps",
+      "cli",
+      "instrumentation",
+      "testing",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108350": {
+    "commit": "c18c2447cf602ee1a76113200b3f5b6200a24a34",
+    "text": "Changes the kubectl --validate flag from a bool to a string that accepts the values {true, strict, warn, false, ignore}\n- true/strict - perform validation and error the request on any invalid fields in the ojbect. It will attempt to perform server-side validation if it is enabled on the apiserver, otherwise it will fall back to client-side validation.\n- warn - perform server-side validation and warn on any invalid fields (but ultimately let the request succeed by dropping any invalid fields from the object). If validation is not available on the server, perform no validation.\n- false/ignore - perform no validation, silently dropping invalid fields from the object.",
+    "markdown": "Changes the kubectl --validate flag from a bool to a string that accepts the values {true, strict, warn, false, ignore}\n  - true/strict - perform validation and error the request on any invalid fields in the ojbect. It will attempt to perform server-side validation if it is enabled on the apiserver, otherwise it will fall back to client-side validation.\n  - warn - perform server-side validation and warn on any invalid fields (but ultimately let the request succeed by dropping any invalid fields from the object). If validation is not available on the server, perform no validation.\n  - false/ignore - perform no validation, silently dropping invalid fields from the object. ([#108350](https://github.com/kubernetes/kubernetes/pull/108350), [@kevindelgado](https://github.com/kevindelgado)) [SIG API Machinery, CLI, Node and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2885-server-side-unknown-field-validation",
+        "type": "KEP"
+      }
+    ],
+    "author": "kevindelgado",
+    "author_url": "https://github.com/kevindelgado",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108350",
+    "pr_number": 108350,
+    "areas": ["test", "kubelet", "apiserver", "kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["node", "api-machinery", "cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108445": {
+    "commit": "24a71990e02edbfd0a05f4abfdedcab991525874",
+    "text": "CSIStorageCapacity.storage.k8s.io: The v1beta1 version of this API is deprecated in favor of v1, and will be removed in v1.27. If a CSI driver supports storage capacity tracking, then it must get deployed with a release of external-provisioner that supports the v1 API.",
+    "markdown": "CSIStorageCapacity.storage.k8s.io: The v1beta1 version of this API is deprecated in favor of v1, and will be removed in v1.27. If a CSI driver supports storage capacity tracking, then it must get deployed with a release of external-provisioner that supports the v1 API. ([#108445](https://github.com/kubernetes/kubernetes/pull/108445), [@pohly](https://github.com/pohly)) [SIG API Machinery, Architecture, Auth, Scheduling, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/1472",
+        "type": "KEP"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/storage/storage-capacity/",
+        "type": "official"
+      },
+      {
+        "description": "[Other doc]",
+        "url": "https://kubernetes-csi.github.io/docs/storage-capacity-tracking.html",
+        "type": "external"
+      }
+    ],
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108445",
+    "pr_number": 108445,
+    "areas": ["test", "apiserver", "conformance", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "storage", "api-machinery", "auth", "testing", "architecture"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108455": {
+    "commit": "9bb5823b83c2929b059498b1e59c08261257126b",
+    "text": "Fix a race in timeout handler that could lead to kube-apiserver crashes",
+    "markdown": "Fix a race in timeout handler that could lead to kube-apiserver crashes ([#108455](https://github.com/kubernetes/kubernetes/pull/108455), [@Argh4k](https://github.com/Argh4k)) [SIG API Machinery]",
+    "author": "Argh4k",
+    "author_url": "https://github.com/Argh4k",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108455",
+    "pr_number": 108455,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "108486": {
+    "commit": "c00975370a5bf81328dc56396ee05edc7306e238",
+    "text": "Non graceful node shutdown handling.",
+    "markdown": "Non graceful node shutdown handling. ([#108486](https://github.com/kubernetes/kubernetes/pull/108486), [@sonasingh46](https://github.com/sonasingh46)) [SIG Apps, Node and Storage]",
+    "documentation": [
+      {
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown",
+        "type": "KEP"
+      }
+    ],
+    "author": "sonasingh46",
+    "author_url": "https://github.com/sonasingh46",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108486",
+    "pr_number": 108486,
+    "areas": ["kubelet"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["storage", "node", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108493": {
+    "commit": "c4f8c57b43843abd13bae677b73c622e1c30b46f",
+    "text": "kubectl now supports shell completion for the \u003ctype\u003e/\u003cname\u003e format for specifying resources.\n\nkubectl now provides shell completion for container names following the --container/-c flag of the exec command.\n\nkubectl's shell completion now suggests resource types for commands that only apply to pods.",
+    "markdown": "Kubectl now supports shell completion for the \u003ctype\u003e/\u003cname\u003e format for specifying resources.\n  \n  kubectl now provides shell completion for container names following the --container/-c flag of the exec command.\n  \n  kubectl's shell completion now suggests resource types for commands that only apply to pods. ([#108493](https://github.com/kubernetes/kubernetes/pull/108493), [@marckhouzam](https://github.com/marckhouzam)) [SIG CLI]",
+    "author": "marckhouzam",
+    "author_url": "https://github.com/marckhouzam",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108493",
+    "pr_number": 108493,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "108505": {
+    "commit": "bb3800f0225dcc025b9bb01f8525f99e5c36d5ce",
+    "text": "Re-adds response status and headers on verbose kubectl responses",
+    "markdown": "Re-adds response status and headers on verbose kubectl responses ([#108505](https://github.com/kubernetes/kubernetes/pull/108505), [@rikatz](https://github.com/rikatz)) [SIG API Machinery and CLI]",
+    "author": "rikatz",
+    "author_url": "https://github.com/rikatz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108505",
+    "pr_number": 108505,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "cli"],
+    "duplicate": true
+  },
+  "108522": {
+    "commit": "8168c68bb6dcf313f74e2d20cc6711d7aca7cf77",
+    "text": "Support for gRPC probes is now in beta. GRPCContainerProbe feature gate is enabled by default.",
+    "markdown": "Support for gRPC probes is now in beta. GRPCContainerProbe feature gate is enabled by default. ([#108522](https://github.com/kubernetes/kubernetes/pull/108522), [@SergeyKanzhelev](https://github.com/SergeyKanzhelev)) [SIG API Machinery, Apps, Node and Testing]",
+    "author": "SergeyKanzhelev",
+    "author_url": "https://github.com/SergeyKanzhelev",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108522",
+    "pr_number": 108522,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108531": {
+    "commit": "ea006f5246dded2db606dac7c642041cfbe1ccb1",
+    "text": "SPDY transport in client-go will no longer follow redirects.",
+    "markdown": "SPDY transport in client-go will no longer follow redirects. ([#108531](https://github.com/kubernetes/kubernetes/pull/108531), [@tallclair](https://github.com/tallclair)) [SIG API Machinery and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1558-streaming-proxy-redirects",
+        "type": "KEP"
+      }
+    ],
+    "author": "tallclair",
+    "author_url": "https://github.com/tallclair",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108531",
+    "pr_number": 108531,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "api-machinery"],
+    "duplicate": true
+  },
+  "108613": {
+    "commit": "0b8a665d508a861713398d0480e4789802c70607",
+    "text": "Fix a bug that out-of-tree plugin is misplaced when using scheduler v1beta3 config",
+    "markdown": "Fix a bug that out-of-tree plugin is misplaced when using scheduler v1beta3 config ([#108613](https://github.com/kubernetes/kubernetes/pull/108613), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling and Testing]",
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108613",
+    "pr_number": 108613,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["scheduling", "testing"],
+    "duplicate": true
+  },
+  "108617": {
+    "commit": "95e30f66c300c76ce21c0ca0e8bc4bf4a45e028f",
+    "text": "CEL regex patterns in x-kubernetes-valiation rules are compiled when CRDs are created/updated if the pattern is provided as a string constant in the expression. Any regex compile errors are reported as a CRD create/update validation error.",
+    "markdown": "CEL regex patterns in x-kubernetes-valiation rules are compiled when CRDs are created/updated if the pattern is provided as a string constant in the expression. Any regex compile errors are reported as a CRD create/update validation error. ([#108617](https://github.com/kubernetes/kubernetes/pull/108617), [@jpbetz](https://github.com/jpbetz)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node and Storage]",
+    "author": "jpbetz",
+    "author_url": "https://github.com/jpbetz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108617",
+    "pr_number": 108617,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["feature"],
+    "sigs": [
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true
+  },
+  "108691": {
+    "commit": "57a739bdf209e544133add5cd0759fd00650de7c",
+    "text": "Apply ProxyTerminatingEndpoints to all traffic policies (external, internal, cluster, local).",
+    "markdown": "Apply ProxyTerminatingEndpoints to all traffic policies (external, internal, cluster, local). ([#108691](https://github.com/kubernetes/kubernetes/pull/108691), [@andrewsykim](https://github.com/andrewsykim)) [SIG Network and Testing]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108691",
+    "pr_number": 108691,
+    "areas": ["test", "ipvs"],
+    "kinds": ["feature"],
+    "sigs": ["network", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108693": {
+    "commit": "12667440025c5e9dcfb49a3457b701c8d374ed85",
+    "text": "Call NodeExpand on all nodes in case of RWX volumes",
+    "markdown": "Call NodeExpand on all nodes in case of RWX volumes ([#108693](https://github.com/kubernetes/kubernetes/pull/108693), [@gnufied](https://github.com/gnufied)) [SIG Apps, Node and Storage]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108693",
+    "pr_number": 108693,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["storage", "node", "apps"],
+    "duplicate": true
+  },
+  "108701": {
+    "commit": "2786b78b5a242452e6c7eda5a310609f77a482b9",
+    "text": "add PreemptionPolicy in PriorityClass describe",
+    "markdown": "Add PreemptionPolicy in PriorityClass describe ([#108701](https://github.com/kubernetes/kubernetes/pull/108701), [@denkensk](https://github.com/denkensk)) [SIG CLI and Scheduling]",
+    "author": "denkensk",
+    "author_url": "https://github.com/denkensk",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108701",
+    "pr_number": 108701,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "cli"],
+    "duplicate": true
+  },
+  "108717": {
+    "commit": "bb67b5e9e830fba239c1e7957e5dcbefdce92a37",
+    "text": "The metadata.clusterName field is deprecated. This field has always been unwritable and always blank, but its presence is confusing, so we will remove it next release. Out of an abundance of caution, this release we have merely changed the name in the go struct to ensure any accidental client uses are found before complete removal.",
+    "markdown": "The metadata.clusterName field is deprecated. This field has always been unwritable and always blank, but its presence is confusing, so we will remove it next release. Out of an abundance of caution, this release we have merely changed the name in the go struct to ensure any accidental client uses are found before complete removal. ([#108717](https://github.com/kubernetes/kubernetes/pull/108717), [@lavalamp](https://github.com/lavalamp)) [SIG API Machinery, Apps, Auth, Scheduling and Testing]",
+    "author": "lavalamp",
+    "author_url": "https://github.com/lavalamp",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108717",
+    "pr_number": 108717,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["cleanup", "api-change", "deprecation"],
+    "sigs": ["scheduling", "api-machinery", "auth", "apps", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108724": {
+    "commit": "92c30bf6bdefce5d3e2e29aa3c0c0989cd313827",
+    "text": "CycleState is now optimized for \"write once and read many times\".",
+    "markdown": "CycleState is now optimized for \"write once and read many times\". ([#108724](https://github.com/kubernetes/kubernetes/pull/108724), [@sanposhiho](https://github.com/sanposhiho)) [SIG Scheduling]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108724",
+    "pr_number": 108724,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "108736": {
+    "commit": "9fe98d8babc7b8b8a766b8c48e4ca7bc75ef81bc",
+    "text": "The AnyVolumeDataSource feature is now beta, and the feature gate is enabled by default. In order to provide user feedback on PVCs with data sources, deployers must install the VolumePopulators CRD and the data-source-validator controller.",
+    "markdown": "The AnyVolumeDataSource feature is now beta, and the feature gate is enabled by default. In order to provide user feedback on PVCs with data sources, deployers must install the VolumePopulators CRD and the data-source-validator controller. ([#108736](https://github.com/kubernetes/kubernetes/pull/108736), [@bswartz](https://github.com/bswartz)) [SIG Apps, Storage and Testing]",
+    "author": "bswartz",
+    "author_url": "https://github.com/bswartz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108736",
+    "pr_number": 108736,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["storage", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108748": {
+    "commit": "6c67869ff2f797efeb9a59a594c2413a876ea8e0",
+    "text": "fix --retries functionality for negative values in kubectl cp",
+    "markdown": "Fix --retries functionality for negative values in kubectl cp ([#108748](https://github.com/kubernetes/kubernetes/pull/108748), [@atiratree](https://github.com/atiratree)) [SIG CLI]",
+    "author": "atiratree",
+    "author_url": "https://github.com/atiratree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108748",
+    "pr_number": 108748,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "108752": {
+    "commit": "8776931abbd93532e672b7accc41c32aaf2eb653",
+    "text": "Fix issue where the job controller might not remove the job tracking finalizer from pods when deleting a job, or when the pod is orphan",
+    "markdown": "Fix issue where the job controller might not remove the job tracking finalizer from pods when deleting a job, or when the pod is orphan ([#108752](https://github.com/kubernetes/kubernetes/pull/108752), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps and Testing]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108752",
+    "pr_number": 108752,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["apps", "testing"],
+    "duplicate": true
+  },
+  "108758": {
+    "commit": "b0254c8a0b202083b12fbfaae7ff1ba4f7288ca0",
+    "text": "add one metrics(`kubelet_volume_stats_health_abnormal`) of volume health state to kubelet",
+    "markdown": "Add one metrics(`kubelet_volume_stats_health_abnormal`) of volume health state to kubelet ([#108758](https://github.com/kubernetes/kubernetes/pull/108758), [@fengzixu](https://github.com/fengzixu)) [SIG Instrumentation, Node, Storage and Testing]",
+    "documentation": [
+      { "url": "https://github.com/kubernetes/enhancements/pull/2900", "type": "KEP" }
+    ],
+    "author": "fengzixu",
+    "author_url": "https://github.com/fengzixu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108758",
+    "pr_number": 108758,
+    "areas": ["test", "kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["storage", "node", "instrumentation", "testing"],
+    "duplicate": true
+  },
+  "108817": {
+    "commit": "af059a0731c42bee1350cdb91844c4fef2b374ef",
+    "text": "`kubectl version` now includes information on the embedded version of Kustomize",
+    "markdown": "`kubectl version` now includes information on the embedded version of Kustomize ([#108817](https://github.com/kubernetes/kubernetes/pull/108817), [@KnVerey](https://github.com/KnVerey)) [SIG CLI and Testing]",
+    "author": "KnVerey",
+    "author_url": "https://github.com/KnVerey",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108817",
+    "pr_number": 108817,
+    "areas": ["test", "kubectl", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108820": {
+    "commit": "e3982ce472af31efe0cfb5165271c84f1ace0b0f",
+    "text": "Remove deprecated `--serviceaccount`, `--hostport`, `--requests` and `--limits` from kubectl run.",
+    "markdown": "Remove deprecated `--serviceaccount`, `--hostport`, `--requests` and `--limits` from kubectl run. ([#108820](https://github.com/kubernetes/kubernetes/pull/108820), [@mozillazg](https://github.com/mozillazg)) [SIG CLI]",
+    "author": "mozillazg",
+    "author_url": "https://github.com/mozillazg",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108820",
+    "pr_number": 108820,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "108831": {
+    "commit": "dbd37cb8a8b6a54a7637ec6a6471979ce4260929",
+    "text": "Skip re-allocate logic if pod is already removed to avoid panic",
+    "markdown": "Skip re-allocate logic if pod is already removed to avoid panic ([#108831](https://github.com/kubernetes/kubernetes/pull/108831), [@waynepeking348](https://github.com/waynepeking348)) [SIG Node]",
+    "author": "waynepeking348",
+    "author_url": "https://github.com/waynepeking348",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108831",
+    "pr_number": 108831,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "108847": {
+    "commit": "ed16ef22061a8246236e0049a34d7cf305462e34",
+    "text": "Kubelet external Credential Provider feature is moved to Beta.  Credential Provider Plugin and Credential Provider Config API's updated from v1alpha1 to v1beta1 with no API changes.",
+    "markdown": "Kubelet external Credential Provider feature is moved to Beta.  Credential Provider Plugin and Credential Provider Config API's updated from v1alpha1 to v1beta1 with no API changes. ([#108847](https://github.com/kubernetes/kubernetes/pull/108847), [@adisky](https://github.com/adisky)) [SIG API Machinery and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2133-kubelet-credential-providers",
+        "type": "KEP"
+      }
+    ],
+    "author": "adisky",
+    "author_url": "https://github.com/adisky",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108847",
+    "pr_number": 108847,
+    "areas": ["code-generation"],
+    "kinds": ["api-change"],
+    "sigs": ["node", "api-machinery"],
+    "duplicate": true
+  },
+  "108859": {
+    "commit": "0a6309044585e52d88c4f414d84613ce903a587b",
+    "text": "Skip x-kubernetes-validations rules if having fundamental error against OpenAPIv3 schema.",
+    "markdown": "Skip x-kubernetes-validations rules if having fundamental error against OpenAPIv3 schema. ([#108859](https://github.com/kubernetes/kubernetes/pull/108859), [@cici37](https://github.com/cici37)) [SIG API Machinery and Testing]",
+    "author": "cici37",
+    "author_url": "https://github.com/cici37",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108859",
+    "pr_number": 108859,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108870": {
+    "commit": "5984099509fde391ed63769efc0b518a8a5736c3",
+    "text": "Kubernetes 1.24 bumped version of golang it is compiled with to go1.18, which introduced significant changes to its garbage collection algorithm. As a result, we observed an increase in memory usage for kube-apiserver in larger an heavily loaded clusters up to ~25% (with the benefit of API call latencies drop by up to 10x on 99th percentiles). If the memory increase is not acceptable for you you can mitigate by setting GOGC env variable (for our tests using GOGC=63 brings memory usage back to original value, although the exact value may depend on usage patterns on your cluster).",
+    "markdown": "Kubernetes 1.24 bumped version of golang it is compiled with to go1.18, which introduced significant changes to its garbage collection algorithm. As a result, we observed an increase in memory usage for kube-apiserver in larger an heavily loaded clusters up to ~25% (with the benefit of API call latencies drop by up to 10x on 99th percentiles). If the memory increase is not acceptable for you you can mitigate by setting GOGC env variable (for our tests using GOGC=63 brings memory usage back to original value, although the exact value may depend on usage patterns on your cluster). ([#108870](https://github.com/kubernetes/kubernetes/pull/108870), [@dims](https://github.com/dims)) [SIG Architecture, Release and Testing]",
+    "author": "dims",
+    "author_url": "https://github.com/dims",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108870",
+    "pr_number": 108870,
+    "areas": ["test", "release-eng", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["testing", "release", "architecture"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108889": {
+    "commit": "ea0dc6ed417c7cd398cd5e02cdaf04721265eee2",
+    "text": "The `ServerSideFieldValidation` feature has graduated to beta and is now enabled by default. Kubectl 1.24 and newer will use server-side validation instead of client-side validation when writing to API servers with the feature enabled.",
+    "markdown": "The `ServerSideFieldValidation` feature has graduated to beta and is now enabled by default. Kubectl 1.24 and newer will use server-side validation instead of client-side validation when writing to API servers with the feature enabled. ([#108889](https://github.com/kubernetes/kubernetes/pull/108889), [@kevindelgado](https://github.com/kevindelgado)) [SIG API Machinery, Architecture, CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2885",
+        "type": "KEP"
+      }
+    ],
+    "author": "kevindelgado",
+    "author_url": "https://github.com/kevindelgado",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108889",
+    "pr_number": 108889,
+    "areas": ["test", "apiserver", "kubectl", "conformance"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery", "cli", "testing", "architecture"],
+    "duplicate": true
+  },
+  "108898": {
+    "commit": "1f493f6f91d0ead75eabd14874900fe6e9ae15f0",
+    "text": "OpenAPI definitions served by kube-api-server now include enum types by default.",
+    "markdown": "OpenAPI definitions served by kube-api-server now include enum types by default. ([#108898](https://github.com/kubernetes/kubernetes/pull/108898), [@jiahuif](https://github.com/jiahuif)) [SIG API Machinery]",
+    "author": "jiahuif",
+    "author_url": "https://github.com/jiahuif",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108898",
+    "pr_number": 108898,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "108919": {
+    "commit": "2161071d0b985a033c5a81df122734da31ffce18",
+    "text": "Rename unschedulableQ to unschedulablePods",
+    "markdown": "Rename unschedulableQ to unschedulablePods ([#108919](https://github.com/kubernetes/kubernetes/pull/108919), [@denkensk](https://github.com/denkensk)) [SIG Instrumentation, Scheduling and Testing]",
+    "author": "denkensk",
+    "author_url": "https://github.com/denkensk",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108919",
+    "pr_number": 108919,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "instrumentation", "testing"],
+    "duplicate": true
+  },
+  "108927": {
+    "commit": "d9819f05d0154677aee3e643c5498511fabce38a",
+    "text": "Record requests rejected with 429 in the apiserver_request_total metric",
+    "markdown": "Record requests rejected with 429 in the apiserver_request_total metric ([#108927](https://github.com/kubernetes/kubernetes/pull/108927), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Instrumentation]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108927",
+    "pr_number": 108927,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "duplicate": true
+  },
+  "108929": {
+    "commit": "ac6ef262df159be05ad842d13447bae52ba828ad",
+    "text": "Move volume expansion feature to GA",
+    "markdown": "Move volume expansion feature to GA ([#108929](https://github.com/kubernetes/kubernetes/pull/108929), [@gnufied](https://github.com/gnufied)) [SIG API Machinery, Apps, Auth, Node, Storage and Testing]",
+    "author": "gnufied",
+    "author_url": "https://github.com/gnufied",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108929",
+    "pr_number": 108929,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "node", "api-machinery", "auth", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "108953": {
+    "commit": "8b158fa7304906f0da30f2a0e007be3ccced7354",
+    "text": "Remove insecure serving configuration from cloud-provider package, which is consumed by cloud-controller-managers.",
+    "markdown": "Remove insecure serving configuration from cloud-provider package, which is consumed by cloud-controller-managers. ([#108953](https://github.com/kubernetes/kubernetes/pull/108953), [@nckturner](https://github.com/nckturner)) [SIG Cloud Provider and Testing]",
+    "author": "nckturner",
+    "author_url": "https://github.com/nckturner",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108953",
+    "pr_number": 108953,
+    "areas": ["test", "cloudprovider"],
+    "kinds": ["cleanup", "deprecation"],
+    "sigs": ["testing", "cloud-provider"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108965": {
+    "commit": "51cd36cf80b29c8ac04eaa7c9ada1859cd71015c",
+    "text": "None.",
+    "markdown": "None. ([#108965](https://github.com/kubernetes/kubernetes/pull/108965), [@adisky](https://github.com/adisky)) [SIG Node and Testing]",
+    "author": "adisky",
+    "author_url": "https://github.com/adisky",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108965",
+    "pr_number": 108965,
+    "areas": ["test"],
+    "kinds": ["failing-test"],
+    "sigs": ["node", "testing"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "108987": {
+    "commit": "5a651eacbc7176c5922ec9c9137d00fbbbc2b683",
+    "text": "Deprecate kubectl version long output, will be replaced with kubectl version --short. Users requiring full output should use --output=yaml|json instead.",
+    "markdown": "Deprecate kubectl version long output, will be replaced with kubectl version --short. Users requiring full output should use --output=yaml|json instead. ([#108987](https://github.com/kubernetes/kubernetes/pull/108987), [@soltysh](https://github.com/soltysh)) [SIG CLI]",
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108987",
+    "pr_number": 108987,
+    "areas": ["kubectl"],
+    "sigs": ["cli"]
+  },
+  "108988": {
+    "commit": "736a02316715d7eb9a8bd34c6af123f07c1d34d1",
+    "text": "update the k8s.io/system-validators library to v1.7.0",
+    "markdown": "Update the k8s.io/system-validators library to v1.7.0 ([#108988](https://github.com/kubernetes/kubernetes/pull/108988), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]",
+    "author": "neolit123",
+    "author_url": "https://github.com/neolit123",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108988",
+    "pr_number": 108988,
+    "areas": ["dependency"],
+    "kinds": ["feature"],
+    "sigs": ["cluster-lifecycle"],
+    "feature": true
+  },
+  "108992": {
+    "commit": "656dc213ce43f1ecfa7f54eb1f01864468f8f0e2",
+    "text": "Adds `OpenAPIV3SchemaInterface` to `DiscoveryClient` and its variants for fetching OpenAPI v3 schema documents.",
+    "markdown": "Adds `OpenAPIV3SchemaInterface` to `DiscoveryClient` and its variants for fetching OpenAPI v3 schema documents. ([#108992](https://github.com/kubernetes/kubernetes/pull/108992), [@alexzielenski](https://github.com/alexzielenski)) [SIG API Machinery, Architecture, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2896",
+        "type": "KEP"
+      }
+    ],
+    "author": "alexzielenski",
+    "author_url": "https://github.com/alexzielenski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108992",
+    "pr_number": 108992,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "kubeadm", "code-generation", "dependency"],
+    "kinds": ["feature"],
+    "sigs": [
+      "api-machinery",
+      "cluster-lifecycle",
+      "cli",
+      "instrumentation",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true
+  },
+  "108994": {
+    "commit": "1ff499ac1382ca7dd62022d5f256e19fcc41c40d",
+    "text": "Updates `kubectl kustomize` and `kubectl apply -k` to Kustomize v4.5.4",
+    "markdown": "Updates `kubectl kustomize` and `kubectl apply -k` to Kustomize v4.5.4 ([#108994](https://github.com/kubernetes/kubernetes/pull/108994), [@KnVerey](https://github.com/KnVerey)) [SIG CLI]",
+    "documentation": [
+      {
+        "url": "https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.4",
+        "type": "external"
+      }
+    ],
+    "author": "KnVerey",
+    "author_url": "https://github.com/KnVerey",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108994",
+    "pr_number": 108994,
+    "areas": ["kubectl", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "108995": {
+    "commit": "5b8dbfbbcf304bd0f260a9e99e3555dce8f46514",
+    "text": "The infrastructure for contextual logging is complete (feature gate implemented, JSON backend ready).",
+    "markdown": "The infrastructure for contextual logging is complete (feature gate implemented, JSON backend ready). ([#108995](https://github.com/kubernetes/kubernetes/pull/108995), [@pohly](https://github.com/pohly)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Network, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3077",
+        "type": "KEP"
+      }
+    ],
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108995",
+    "pr_number": 108995,
+    "areas": ["test", "kubelet", "apiserver", "kubectl", "cloudprovider"],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "scheduling",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "testing",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "109018": {
+    "commit": "24cb73bb9027b089e05d27cc29be0987ab8153ae",
+    "text": "Deprecate apiserver_dropped_requests_total metric. The same data can be read from apiserver_request_terminations_total metric.",
+    "markdown": "Deprecate apiserver_dropped_requests_total metric. The same data can be read from apiserver_request_terminations_total metric. ([#109018](https://github.com/kubernetes/kubernetes/pull/109018), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Instrumentation]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109018",
+    "pr_number": 109018,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "duplicate": true
+  },
+  "109019": {
+    "commit": "58847ef7025d08cf45a6b9def5df48f2ccc3f950",
+    "text": "Custom resource requests with fieldValidation=Strict consistently require apiVersion and kind, matching non-strict requests",
+    "markdown": "Custom resource requests with fieldValidation=Strict consistently require apiVersion and kind, matching non-strict requests ([#109019](https://github.com/kubernetes/kubernetes/pull/109019), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109019",
+    "pr_number": 109019,
+    "kinds": ["bug", "api-change"],
+    "sigs": ["api-machinery"],
+    "duplicate_kind": true
+  },
+  "109024": {
+    "commit": "b2c6de170b0b880ccca0ae783bae09559f8dff04",
+    "text": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#109024](https://github.com/kubernetes/kubernetes/pull/109024), [@stlaz](https://github.com/stlaz)) [SIG API Machinery and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[Other doc]",
+        "url": "https://tip.golang.org/doc/go1.18#sha1",
+        "type": "external"
+      }
+    ],
+    "author": "stlaz",
+    "author_url": "https://github.com/stlaz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109024",
+    "pr_number": 109024,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109029": {
+    "commit": "fe8a663860e624a974fe15e224938b43dc6b8bd4",
+    "text": "Update runc to 1.1.0\nUpdate cadvisor to 0.44.0",
+    "markdown": "Update runc to 1.1.0\n  Update cadvisor to 0.44.0 ([#109029](https://github.com/kubernetes/kubernetes/pull/109029), [@ehashman](https://github.com/ehashman)) [SIG CLI, Node and Testing]",
+    "author": "ehashman",
+    "author_url": "https://github.com/ehashman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109029",
+    "pr_number": 109029,
+    "areas": ["test", "kubelet", "kubectl", "dependency"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "cli", "testing"],
+    "duplicate": true
+  },
+  "109031": {
+    "commit": "904c30562a9a34d26ff3e76db29d00daea2e0f60",
+    "text": "OpenAPI V3 is turned on by default",
+    "markdown": "OpenAPI V3 is turned on by default ([#109031](https://github.com/kubernetes/kubernetes/pull/109031), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Apps, Architecture, Auth, Autoscaling, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Network, Node, Scheduling, Storage and Testing]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109031",
+    "pr_number": 109031,
+    "areas": [
+      "test",
+      "apiserver",
+      "kubectl",
+      "cloudprovider",
+      "kubeadm",
+      "conformance",
+      "code-generation",
+      "ipvs",
+      "e2e-test-framework",
+      "dependency",
+      "network-policy"
+    ],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "scheduling",
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "autoscaling",
+      "auth",
+      "apps",
+      "cli",
+      "instrumentation",
+      "testing",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "109035": {
+    "commit": "78889cd1bb1c823a7f1292d325a31695fc826084",
+    "text": "Enable beta feature HonorPVReclaimPolicy by default.",
+    "markdown": "Enable beta feature HonorPVReclaimPolicy by default. ([#109035](https://github.com/kubernetes/kubernetes/pull/109035), [@deepakkinni](https://github.com/deepakkinni)) [SIG Apps and Storage]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3181",
+        "type": "KEP"
+      }
+    ],
+    "author": "deepakkinni",
+    "author_url": "https://github.com/deepakkinni",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109035",
+    "pr_number": 109035,
+    "kinds": ["feature"],
+    "sigs": ["storage", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109059": {
+    "commit": "749df8e022655390cb563483f18812018211fa0d",
+    "text": "Kubelet now creates an iptables chain named `KUBE-IPTABLES-HINT` in\nthe `mangle` table. Containerized components that need to modify iptables\nrules in the host network namespace can use the existence of this chain\nto more-reliably determine whether the system is using iptables-legacy or\niptables-nft.",
+    "markdown": "Kubelet now creates an iptables chain named `KUBE-IPTABLES-HINT` in\n  the `mangle` table. Containerized components that need to modify iptables\n  rules in the host network namespace can use the existence of this chain\n  to more-reliably determine whether the system is using iptables-legacy or\n  iptables-nft. ([#109059](https://github.com/kubernetes/kubernetes/pull/109059), [@danwinship](https://github.com/danwinship)) [SIG Network and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]: (in progress)",
+        "url": "https://github.com/kubernetes/enhancements/pull/3179",
+        "type": "KEP"
+      }
+    ],
+    "author": "danwinship",
+    "author_url": "https://github.com/danwinship",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109059",
+    "pr_number": 109059,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["network", "node"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109060": {
+    "commit": "40e21e310f07c72eb481f10716fa49559110ee16",
+    "text": "Users who look at iptables dumps will see some changes in the naming and structure of rules.",
+    "markdown": "Users who look at iptables dumps will see some changes in the naming and structure of rules. ([#109060](https://github.com/kubernetes/kubernetes/pull/109060), [@thockin](https://github.com/thockin)) [SIG Network and Testing]",
+    "author": "thockin",
+    "author_url": "https://github.com/thockin",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109060",
+    "pr_number": 109060,
+    "areas": ["test", "ipvs"],
+    "kinds": ["cleanup"],
+    "sigs": ["network", "testing"],
+    "duplicate": true
+  },
+  "109072": {
+    "commit": "d4ac0ebecb5142330f1827120e3e6315a8b69caf",
+    "text": "Leader Migration is now GA. All new configuration files onwards should use version v1.",
+    "markdown": "Leader Migration is now GA. All new configuration files onwards should use version v1. ([#109072](https://github.com/kubernetes/kubernetes/pull/109072), [@jiahuif](https://github.com/jiahuif)) [SIG Cloud Provider]",
+    "author": "jiahuif",
+    "author_url": "https://github.com/jiahuif",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109072",
+    "pr_number": 109072,
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "109074": {
+    "commit": "f25c0e5f094485f710e80377fbb833d3eeed7492",
+    "text": "kubeadm: add the flag \"--experimental-initial-corrupt-check\" to etcd static Pod manifests to ensure etcd member data consistency",
+    "markdown": "Kubeadm: add the flag \"--experimental-initial-corrupt-check\" to etcd static Pod manifests to ensure etcd member data consistency ([#109074](https://github.com/kubernetes/kubernetes/pull/109074), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]",
+    "author": "neolit123",
+    "author_url": "https://github.com/neolit123",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109074",
+    "pr_number": 109074,
+    "areas": ["kubeadm"],
+    "kinds": ["bug", "feature"],
+    "sigs": ["cluster-lifecycle"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "109089": {
+    "commit": "c290874532839f5414f32e968d97830600a2d4cc",
+    "text": "vSphere releases less than 7.0u2 are deprecated as of v1.24. Please consider upgrading vSphere to 7.0u2 or above. vSphere CSI Driver requires minimum vSphere 7.0u2.\n\nGeneral Support for vSphere 6.7 will end on October 15, 2022. vSphere 6.7 Update 3 is deprecated in Kubernetes v1.24.  Customers are recommended to upgrade vSphere (both ESXi and vCenter) to 7.0u2 or above.  vSphere CSI Driver 2.2.3 and higher supports CSI Migration.\n\nSupport for these deprecations will be available till October 15, 2022.",
+    "markdown": "VSphere releases less than 7.0u2 are deprecated as of v1.24. Please consider upgrading vSphere to 7.0u2 or above. vSphere CSI Driver requires minimum vSphere 7.0u2.\n  \n  General Support for vSphere 6.7 will end on October 15, 2022. vSphere 6.7 Update 3 is deprecated in Kubernetes v1.24.  Customers are recommended to upgrade vSphere (both ESXi and vCenter) to 7.0u2 or above.  vSphere CSI Driver 2.2.3 and higher supports CSI Migration.\n  \n  Support for these deprecations will be available till October 15, 2022. ([#109089](https://github.com/kubernetes/kubernetes/pull/109089), [@deepakkinni](https://github.com/deepakkinni)) [SIG Cloud Provider]",
+    "author": "deepakkinni",
+    "author_url": "https://github.com/deepakkinni",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109089",
+    "pr_number": 109089,
+    "areas": ["cloudprovider"],
+    "kinds": ["feature", "deprecation"],
+    "sigs": ["cloud-provider"],
+    "feature": true,
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "109104": {
+    "commit": "fe4cbf6514aa247e1f6d83f33970710b65649685",
+    "text": "Update runc to 1.1.1",
+    "markdown": "Update runc to 1.1.1 ([#109104](https://github.com/kubernetes/kubernetes/pull/109104), [@kolyshkin](https://github.com/kolyshkin)) [SIG Node]",
+    "author": "kolyshkin",
+    "author_url": "https://github.com/kolyshkin",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109104",
+    "pr_number": 109104,
+    "areas": ["dependency"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"]
+  },
+  "109120": {
+    "commit": "c7fc0f9125a239b391df0d7d06e61b8f968ef956",
+    "text": "New \"field_validation_request_duration_seconds\" metric, measures how long requests take, indicating the value of the fieldValidation query parameter and whether or not server-side field validation is enabled on the apiserver",
+    "markdown": "New \"field_validation_request_duration_seconds\" metric, measures how long requests take, indicating the value of the fieldValidation query parameter and whether or not server-side field validation is enabled on the apiserver ([#109120](https://github.com/kubernetes/kubernetes/pull/109120), [@kevindelgado](https://github.com/kevindelgado)) [SIG API Machinery and Instrumentation]",
+    "author": "kevindelgado",
+    "author_url": "https://github.com/kevindelgado",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109120",
+    "pr_number": 109120,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109128": {
+    "commit": "ba1bbb5ac67084b25a17622a6573e648f88f440b",
+    "text": "apiextensions_openapi_v3_regeneration_count metric (alpha) will be emitted for OpenAPI V3.",
+    "markdown": "Apiextensions_openapi_v3_regeneration_count metric (alpha) will be emitted for OpenAPI V3. ([#109128](https://github.com/kubernetes/kubernetes/pull/109128), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery and Instrumentation]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109128",
+    "pr_number": 109128,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109137": {
+    "commit": "2e55595d3baeedcab09745355824f38a60cf6d08",
+    "text": "Fix indexer bug that resulted in incorrect index updates if number of index values for a given object was changing during update",
+    "markdown": "Fix indexer bug that resulted in incorrect index updates if number of index values for a given object was changing during update ([#109137](https://github.com/kubernetes/kubernetes/pull/109137), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109137",
+    "pr_number": 109137,
+    "kinds": ["bug", "regression"],
+    "sigs": ["api-machinery"],
+    "duplicate_kind": true
+  },
+  "82162": {
+    "commit": "f85ff4b5743d501381c76b94a5bc6197b7766190",
+    "text": "MaxUnavailable for StatefulSets, allows faster RollingUpdate by taking down more than 1 pod at a time. The number of pods you want to take down during a RollingUpdate is configurable using maxUnavailable parameter.",
+    "markdown": "MaxUnavailable for StatefulSets, allows faster RollingUpdate by taking down more than 1 pod at a time. The number of pods you want to take down during a RollingUpdate is configurable using maxUnavailable parameter. ([#82162](https://github.com/kubernetes/kubernetes/pull/82162), [@krmayankk](https://github.com/krmayankk)) [SIG API Machinery and Apps]",
+    "author": "krmayankk",
+    "author_url": "https://github.com/krmayankk",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/82162",
+    "pr_number": 82162,
+    "areas": ["code-generation"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery", "apps"],
+    "duplicate": true
+  },
+  "95400": {
+    "commit": "1ea5f9432cf4e4a351f115b2f56394ae947aad5d",
+    "text": "Adds support for \"InterfaceNamePrefix\" and \"BridgeInterface\" as arguments to --detect-local-mode option and also introduces a new optional `--pod-interface-name-prefix` and `--pod-bridge-interface` flags to kube-proxy.",
+    "markdown": "Adds support for \"InterfaceNamePrefix\" and \"BridgeInterface\" as arguments to --detect-local-mode option and also introduces a new optional `--pod-interface-name-prefix` and `--pod-bridge-interface` flags to kube-proxy. ([#95400](https://github.com/kubernetes/kubernetes/pull/95400), [@tssurya](https://github.com/tssurya)) [SIG API Machinery and Network]",
+    "author": "tssurya",
+    "author_url": "https://github.com/tssurya",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/95400",
+    "pr_number": 95400,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "api-machinery"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "99556": {
+    "commit": "a5aa858d44651ba48bdce634a39b55be91216614",
+    "text": "An alpha flag --subresource is added to get, patch, edit replace kubectl commands to fetch and update status and scale subresources.",
+    "markdown": "An alpha flag --subresource is added to get, patch, edit replace kubectl commands to fetch and update status and scale subresources. ([#99556](https://github.com/kubernetes/kubernetes/pull/99556), [@nikhita](https://github.com/nikhita)) [SIG API Machinery, CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource",
+        "type": "KEP"
+      }
+    ],
+    "author": "nikhita",
+    "author_url": "https://github.com/nikhita",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/99556",
+    "pr_number": 99556,
+    "areas": ["test", "kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.24.0-beta.0.json',
   'assets/release-notes-1.24.0-alpha.4.json',
   'assets/release-notes-1.22.7.json',
   'assets/release-notes-1.24.0-alpha.3.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.24.0-beta.0` 