### PR TITLE
Patch relnotes.k8s.io to release v1.26.0-beta.0

### DIFF
--- a/src/assets/release-notes-1.26.0-beta.0.json
+++ b/src/assets/release-notes-1.26.0-beta.0.json
@@ -1,0 +1,1271 @@
+{
+  "103177": {
+    "commit": "b7e6c23e9f73e4cc0209e94fe95c5e2809998bf6",
+    "text": "Add a method `StreamWithContext` to remotecommand.Executor to support cancelable SPDY executor stream.",
+    "markdown": "Add a method `StreamWithContext` to remotecommand.Executor to support cancelable SPDY executor stream. ([#103177](https://github.com/kubernetes/kubernetes/pull/103177), [@arkbriar](https://github.com/arkbriar)) [SIG API Machinery, CLI, Node and Testing]",
+    "author": "arkbriar",
+    "author_url": "https://github.com/arkbriar",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/103177",
+    "pr_number": 103177,
+    "areas": ["test", "kubelet", "kubectl", "e2e-test-framework"],
+    "kinds": ["bug", "feature"],
+    "sigs": ["node", "api-machinery", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108250": {
+    "commit": "bef207003148dfe061672269003d4727afb5170c",
+    "text": "Add a kube-proxy flag (--iptables-localhost-nodeports, default true) to allow disabling NodePort services on loopback addresses. Note: this only applies to iptables mode and ipv4.",
+    "markdown": "Add a kube-proxy flag (--iptables-localhost-nodeports, default true) to allow disabling NodePort services on loopback addresses. Note: this only applies to iptables mode and ipv4. ([#108250](https://github.com/kubernetes/kubernetes/pull/108250), [@cyclinder](https://github.com/cyclinder)) [SIG API Machinery, Cloud Provider, Network, Node, Scalability, Storage and Testing]",
+    "author": "cyclinder",
+    "author_url": "https://github.com/cyclinder",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108250",
+    "pr_number": 108250,
+    "areas": ["test", "kubelet", "cloudprovider", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "scalability",
+      "storage",
+      "node",
+      "api-machinery",
+      "testing",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "109189": {
+    "commit": "e721272d10dd6c4d85ff613182ba0eaddcec9272",
+    "text": "kubectl config view now automatically redacts any secret fields marked with a datapolicy tag",
+    "markdown": "Kubectl config view now automatically redacts any secret fields marked with a datapolicy tag ([#109189](https://github.com/kubernetes/kubernetes/pull/109189), [@mpuckett159](https://github.com/mpuckett159)) [SIG API Machinery, Auth, CLI and Testing]",
+    "author": "mpuckett159",
+    "author_url": "https://github.com/mpuckett159",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109189",
+    "pr_number": 109189,
+    "areas": ["test", "kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109505": {
+    "commit": "d96e052d981537ae9d2376ee6ac73f3ae6817f69",
+    "text": "Do not raise an error when setting an annotation with the same value, just ignore it.",
+    "markdown": "Do not raise an error when setting an annotation with the same value, just ignore it. ([#109505](https://github.com/kubernetes/kubernetes/pull/109505), [@zigarn](https://github.com/zigarn)) [SIG CLI]",
+    "author": "zigarn",
+    "author_url": "https://github.com/zigarn",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109505",
+    "pr_number": 109505,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "110268": {
+    "commit": "3edbebe3488ccb085826d7a3a6d225101ff11ee6",
+    "text": "The iptables kube-proxy backend should process service/endpoint changes\nmore efficiently in very large clusters.",
+    "markdown": "The iptables kube-proxy backend should process service/endpoint changes\n  more efficiently in very large clusters. ([#110268](https://github.com/kubernetes/kubernetes/pull/110268), [@danwinship](https://github.com/danwinship)) [SIG Instrumentation and Network]",
+    "author": "danwinship",
+    "author_url": "https://github.com/danwinship",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110268",
+    "pr_number": 110268,
+    "areas": ["ipvs"],
+    "kinds": ["feature"],
+    "sigs": ["network", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "110618": {
+    "commit": "4086b45af3761d59cb82af6ee427d2d6557c1cbc",
+    "text": "Dropped support for the Container Runtime Interface (CRI) version `v1alpha2`, which means that container runtimes just have to implement `v1`.",
+    "markdown": "Dropped support for the Container Runtime Interface (CRI) version `v1alpha2`, which means that container runtimes just have to implement `v1`. ([#110618](https://github.com/kubernetes/kubernetes/pull/110618), [@saschagrunert](https://github.com/saschagrunert)) [SIG Node and Security]",
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110618",
+    "pr_number": 110618,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "security"],
+    "duplicate": true
+  },
+  "110907": {
+    "commit": "20a9f7786aa4ee0b6e1619c7974ea4562d2b2500",
+    "text": "kubectl apply: warning that kubectl will ignore no-namespaced resource `pv \u0026 namespace` in a future release if the namespace is specified and allowlist is not specified",
+    "markdown": "Kubectl apply: warning that kubectl will ignore no-namespaced resource `pv \u0026 namespace` in a future release if the namespace is specified and allowlist is not specified ([#110907](https://github.com/kubernetes/kubernetes/pull/110907), [@pacoxu](https://github.com/pacoxu)) [SIG CLI]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110907",
+    "pr_number": 110907,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "111384": {
+    "commit": "114594e1d265a90820683acd2ed2783513aac4c3",
+    "text": "Add support for Evented PLEG feature gate",
+    "markdown": "Add support for Evented PLEG feature gate ([#111384](https://github.com/kubernetes/kubernetes/pull/111384), [@harche](https://github.com/harche)) [SIG Node and Testing]",
+    "author": "harche",
+    "author_url": "https://github.com/harche",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111384",
+    "pr_number": 111384,
+    "areas": ["test", "kubelet", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "111879": {
+    "commit": "886da71e7588c198dcb9a6c7cccfedb478110e57",
+    "text": "\"NONE\"",
+    "markdown": "\"NONE\" ([#111879](https://github.com/kubernetes/kubernetes/pull/111879), [@sanwishe](https://github.com/sanwishe)) [SIG API Machinery]",
+    "author": "sanwishe",
+    "author_url": "https://github.com/sanwishe",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111879",
+    "pr_number": 111879,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"],
+    "do_not_publish": true
+  },
+  "111930": {
+    "commit": "1bf4af4584234741ed7ffeea5eda3ec1127aa335",
+    "text": "Add the metric pod_start_sli_duration_seconds to kubelet",
+    "markdown": "Add the metric pod_start_sli_duration_seconds to kubelet ([#111930](https://github.com/kubernetes/kubernetes/pull/111930), [@azylinski](https://github.com/azylinski)) [SIG Instrumentation, Node and Testing]",
+    "author": "azylinski",
+    "author_url": "https://github.com/azylinski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111930",
+    "pr_number": 111930,
+    "areas": ["test", "kubelet", "e2e-test-framework"],
+    "kinds": ["feature"],
+    "sigs": ["node", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112011": {
+    "commit": "c519bc02e83d22c517a3063b24d0ced7934ca927",
+    "text": "Added selector validation to HorizontalPodAutoscaler: when multiple HPAs select the same set of Pods, scaling now will be disabled for those HPAs with the reason `AmbiguousSelector`. This change also covers a case when multiple HPAs point to the same deployment.",
+    "markdown": "Added selector validation to HorizontalPodAutoscaler: when multiple HPAs select the same set of Pods, scaling now will be disabled for those HPAs with the reason `AmbiguousSelector`. This change also covers a case when multiple HPAs point to the same deployment. ([#112011](https://github.com/kubernetes/kubernetes/pull/112011), [@pbeschetnov](https://github.com/pbeschetnov)) [SIG Apps and Autoscaling]",
+    "author": "pbeschetnov",
+    "author_url": "https://github.com/pbeschetnov",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112011",
+    "pr_number": 112011,
+    "kinds": ["feature"],
+    "sigs": ["autoscaling", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112127": {
+    "commit": "b4f42864f58f6feac250b2dd32f99b992c8ed184",
+    "text": "Fixed DaemonSet to update the status even if it fails to create a pod.",
+    "markdown": "Fixed DaemonSet to update the status even if it fails to create a pod. ([#112127](https://github.com/kubernetes/kubernetes/pull/112127), [@gjkim42](https://github.com/gjkim42)) [SIG Apps and Testing]",
+    "author": "gjkim42",
+    "author_url": "https://github.com/gjkim42",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112127",
+    "pr_number": 112127,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["apps", "testing"],
+    "duplicate": true
+  },
+  "112261": {
+    "commit": "3e8c848cfce00a9ac80a0b2a44dbc671891a33ef",
+    "text": "Deprecated the following kubectl run flags, which are ignored if set: --cascade, --filename, --force, --grace-period, --kustomize, --recursive, --timeout, --wait",
+    "markdown": "Deprecated the following kubectl run flags, which are ignored if set: --cascade, --filename, --force, --grace-period, --kustomize, --recursive, --timeout, --wait ([#112261](https://github.com/kubernetes/kubernetes/pull/112261), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]",
+    "author": "brianpursley",
+    "author_url": "https://github.com/brianpursley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112261",
+    "pr_number": 112261,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "112360": {
+    "commit": "4e732e20d05e32081b94be30050806ecca440f8b",
+    "text": "Kubelet adds the following pod failure conditions:\n- DisruptionTarget (graceful node shutdown, node pressure eviction)",
+    "markdown": "Kubelet adds the following pod failure conditions:\n  - DisruptionTarget (graceful node shutdown, node pressure eviction) ([#112360](https://github.com/kubernetes/kubernetes/pull/112360), [@mimowo](https://github.com/mimowo)) [SIG Apps, Node and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures",
+        "type": "KEP"
+      }
+    ],
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112360",
+    "pr_number": 112360,
+    "areas": ["test", "kubelet", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112593": {
+    "commit": "0f8fb9f916d499137f16424c6891cf48547617b2",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#112593](https://github.com/kubernetes/kubernetes/pull/112593), [@dashanji](https://github.com/dashanji)) [SIG API Machinery]",
+    "author": "dashanji",
+    "author_url": "https://github.com/dashanji",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112593",
+    "pr_number": 112593,
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"],
+    "do_not_publish": true
+  },
+  "112679": {
+    "commit": "7752c3a8e0fbf59739f40526b2235347ff78000e",
+    "text": "Deprecate the apiserver_request_slo_duration_seconds metric for v1.27 in favor of apiserver_request_sli_duration_seconds for naming consistency purposes with other SLI-specific metrics and to avoid any confusion between SLOs and SLIs.",
+    "markdown": "Deprecate the apiserver_request_slo_duration_seconds metric for v1.27 in favor of apiserver_request_sli_duration_seconds for naming consistency purposes with other SLI-specific metrics and to avoid any confusion between SLOs and SLIs. ([#112679](https://github.com/kubernetes/kubernetes/pull/112679), [@dgrisonnet](https://github.com/dgrisonnet)) [SIG API Machinery and Instrumentation]",
+    "author": "dgrisonnet",
+    "author_url": "https://github.com/dgrisonnet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112679",
+    "pr_number": 112679,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112744": {
+    "commit": "ff19efdf9bd2d1f4abece3229f1e36c1d58b96df",
+    "text": "Added a feature that allows a StatefulSet to start numbering replicas from an arbitrary non-negative ordinal, using the `.spec.ordinals.start` field.",
+    "markdown": "Added a feature that allows a StatefulSet to start numbering replicas from an arbitrary non-negative ordinal, using the `.spec.ordinals.start` field. ([#112744](https://github.com/kubernetes/kubernetes/pull/112744), [@pwschuurman](https://github.com/pwschuurman)) [SIG API Machinery and Apps]",
+    "author": "pwschuurman",
+    "author_url": "https://github.com/pwschuurman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112744",
+    "pr_number": 112744,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112838": {
+    "commit": "32ea818d21c64bc0f9ab65b131d763e0c4401f79",
+    "text": "The LegacyServiceAccountTokenNoAutoGeneration feature gate has been promoted to GA",
+    "markdown": "The LegacyServiceAccountTokenNoAutoGeneration feature gate has been promoted to GA ([#112838](https://github.com/kubernetes/kubernetes/pull/112838), [@zshihang](https://github.com/zshihang)) [SIG API Machinery, Apps, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2799-reduction-of-secret-based-service-account-token",
+        "type": "KEP"
+      }
+    ],
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112838",
+    "pr_number": 112838,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112895": {
+    "commit": "82ce61afc7bcbddb0f1f3d86145d46811410b33a",
+    "text": "Moving MixedProtocolLBService from beta to GA",
+    "markdown": "Moving MixedProtocolLBService from beta to GA ([#112895](https://github.com/kubernetes/kubernetes/pull/112895), [@janosi](https://github.com/janosi)) [SIG Apps, Network and Testing]",
+    "author": "janosi",
+    "author_url": "https://github.com/janosi",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112895",
+    "pr_number": 112895,
+    "areas": ["test", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112905": {
+    "commit": "26a6e1234869b5c546195aaf416f3424cd3c3dc8",
+    "text": "For `kubectl`, `--server-side` now migrates ownership of all fields used by client-side-apply to the specified `--fieldmanager`. This prevents fields previously specified using kubectl from being able to live outside of server-side-apply's management and become undeleteable.",
+    "markdown": "For `kubectl`, `--server-side` now migrates ownership of all fields used by client-side-apply to the specified `--fieldmanager`. This prevents fields previously specified using kubectl from being able to live outside of server-side-apply's management and become undeleteable. ([#112905](https://github.com/kubernetes/kubernetes/pull/112905), [@alexzielenski](https://github.com/alexzielenski)) [SIG API Machinery, CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[Discussion]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3518#discussion_r984724392",
+        "type": "KEP"
+      }
+    ],
+    "author": "alexzielenski",
+    "author_url": "https://github.com/alexzielenski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112905",
+    "pr_number": 112905,
+    "areas": ["test", "kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "cli", "testing"],
+    "duplicate": true
+  },
+  "112914": {
+    "commit": "75bb437a6b3a992e60d2422f8d390280d42bba59",
+    "text": "Added a --topology-manager-policy-options flag to the kubelet to support fine tuning the topology manager policies. The first policy option, `prefer-closest-numa-nodes`, allows these policies to favor sets of NUMA nodes with shorter distance between nodes when making admission decisions.",
+    "markdown": "Added a --topology-manager-policy-options flag to the kubelet to support fine tuning the topology manager policies. The first policy option, `prefer-closest-numa-nodes`, allows these policies to favor sets of NUMA nodes with shorter distance between nodes when making admission decisions. ([#112914](https://github.com/kubernetes/kubernetes/pull/112914), [@PiotrProkop](https://github.com/PiotrProkop)) [SIG API Machinery and Node]",
+    "author": "PiotrProkop",
+    "author_url": "https://github.com/PiotrProkop",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112914",
+    "pr_number": 112914,
+    "areas": ["kubelet", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112961": {
+    "commit": "a7bafa13616e3a7439ff1b02fc1057f9a2c9c3a8",
+    "text": "Adding alpha support for WindowsHostNetworking feature",
+    "markdown": "Adding alpha support for WindowsHostNetworking feature ([#112961](https://github.com/kubernetes/kubernetes/pull/112961), [@marosset](https://github.com/marosset)) [SIG Node and Windows]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/3503-host-network-support-for-windows-pods",
+        "type": "KEP"
+      }
+    ],
+    "author": "marosset",
+    "author_url": "https://github.com/marosset",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112961",
+    "pr_number": 112961,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "windows"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112980": {
+    "commit": "25dc4c4f320ecb75b936220c1c66741bce4b9014",
+    "text": "Graduate Kubelet Device Manager to GA.",
+    "markdown": "Graduate Kubelet Device Manager to GA. ([#112980](https://github.com/kubernetes/kubernetes/pull/112980), [@swatisehgal](https://github.com/swatisehgal)) [SIG Cloud Provider and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3574",
+        "type": "KEP"
+      }
+    ],
+    "author": "swatisehgal",
+    "author_url": "https://github.com/swatisehgal",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112980",
+    "pr_number": 112980,
+    "areas": ["kubelet", "provider/gcp"],
+    "kinds": ["feature"],
+    "sigs": ["node", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113008": {
+    "commit": "ead17f3dc806d54b1fa2dc6e7a95180b4b90460b",
+    "text": "Promote cronjob_job_creation_skew metric to stable to follow the cronjob v2 controller, the following metrics had their name updated to match metrics API guidelines:\n- cronjob_job_creation_skew_duration_seconds -\u003e job_creation_skew_duration_seconds",
+    "markdown": "Promote cronjob_job_creation_skew metric to stable to follow the cronjob v2 controller, the following metrics had their name updated to match metrics API guidelines:\n  - cronjob_job_creation_skew_duration_seconds -\u003e job_creation_skew_duration_seconds ([#113008](https://github.com/kubernetes/kubernetes/pull/113008), [@soltysh](https://github.com/soltysh)) [SIG Apps and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/19",
+        "type": "KEP"
+      }
+    ],
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113008",
+    "pr_number": 113008,
+    "areas": ["stable-metrics"],
+    "kinds": ["cleanup"],
+    "sigs": ["apps", "instrumentation"],
+    "duplicate": true
+  },
+  "113010": {
+    "commit": "39d9981dc2b550ae8f02ebfd039925ede15542e3",
+    "text": "Promote  job-related metrics to stable to follow IndexedJobs GA, the following metrics had their name updated to match metrics API guidelines:\n- job_sync_total -\u003e job_syncs_total\n- job_finished_total -\u003e jobs_finished_total",
+    "markdown": "Promote  job-related metrics to stable to follow IndexedJobs GA, the following metrics had their name updated to match metrics API guidelines:\n  - job_sync_total -\u003e job_syncs_total\n  - job_finished_total -\u003e jobs_finished_total ([#113010](https://github.com/kubernetes/kubernetes/pull/113010), [@soltysh](https://github.com/soltysh)) [SIG Apps and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2214",
+        "type": "KEP"
+      }
+    ],
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113010",
+    "pr_number": 113010,
+    "areas": ["stable-metrics"],
+    "kinds": ["cleanup"],
+    "sigs": ["apps", "instrumentation"],
+    "duplicate": true
+  },
+  "113018": {
+    "commit": "433787d25ba51755bb913eb6a33d1b37e6444aeb",
+    "text": "Graduate Kubelet CPU Manager to GA.",
+    "markdown": "Graduate Kubelet CPU Manager to GA. ([#113018](https://github.com/kubernetes/kubernetes/pull/113018), [@fromanirh](https://github.com/fromanirh)) [SIG Node and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3570",
+        "type": "KEP"
+      }
+    ],
+    "author": "fromanirh",
+    "author_url": "https://github.com/fromanirh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113018",
+    "pr_number": 113018,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113021": {
+    "commit": "1a41cb898547683b73a6f91b6d731d439c84f48a",
+    "text": "kubelet: Fixes a startup crash in devicemanager",
+    "markdown": "Kubelet: Fixes a startup crash in devicemanager ([#113021](https://github.com/kubernetes/kubernetes/pull/113021), [@rphillips](https://github.com/rphillips)) [SIG Node]",
+    "author": "rphillips",
+    "author_url": "https://github.com/rphillips",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113021",
+    "pr_number": 113021,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "113116": {
+    "commit": "bbbb79712cb6b0a72b2695f21a95ad7bb4cc45e6",
+    "text": "Added a `--prune-allowlist` flag that can be used with `kubectl apply --prune`. This flag replaces and functions the same as the `--prune-whitelist` flag, which has been deprecated.",
+    "markdown": "Added a `--prune-allowlist` flag that can be used with `kubectl apply --prune`. This flag replaces and functions the same as the `--prune-whitelist` flag, which has been deprecated. ([#113116](https://github.com/kubernetes/kubernetes/pull/113116), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]",
+    "author": "brianpursley",
+    "author_url": "https://github.com/brianpursley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113116",
+    "pr_number": 113116,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup"],
+    "sigs": ["cli"]
+  },
+  "113146": {
+    "commit": "b0cbf71f5c443460679052ca0cf4800e9d61ab5b",
+    "text": "Adds alpha --output plaintext protected by environment variable `KUBECTL_EXPLAIN_OPENAPIV3`",
+    "markdown": "Adds alpha --output plaintext protected by environment variable `KUBECTL_EXPLAIN_OPENAPIV3` ([#113146](https://github.com/kubernetes/kubernetes/pull/113146), [@alexzielenski](https://github.com/alexzielenski)) [SIG CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3515-kubectl-explain-openapiv3",
+        "type": "KEP"
+      }
+    ],
+    "author": "alexzielenski",
+    "author_url": "https://github.com/alexzielenski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113146",
+    "pr_number": 113146,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "113160": {
+    "commit": "7cd98dec08cbe3ac1ed7d5238bb179760103795d",
+    "text": "make Azure File CSI migration as GA in 1.26",
+    "markdown": "Make Azure File CSI migration as GA in 1.26 ([#113160](https://github.com/kubernetes/kubernetes/pull/113160), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113160",
+    "pr_number": 113160,
+    "areas": ["provider/azure"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "113171": {
+    "commit": "8058e8eff8ba8541ddd48cd54bbb19a3fce62c09",
+    "text": "Yes, aggregated discovery will be alpha and can be toggled with the AggregatedDiscoveryEndpoint feature flag",
+    "markdown": "Yes, aggregated discovery will be alpha and can be toggled with the AggregatedDiscoveryEndpoint feature flag ([#113171](https://github.com/kubernetes/kubernetes/pull/113171), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Apps, Architecture, Auth, Autoscaling, CLI, Cloud Provider, Cluster Lifecycle, Network, Node, Release, Scalability, Scheduling, Storage and Testing]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113171",
+    "pr_number": 113171,
+    "areas": [
+      "test",
+      "kubelet",
+      "apiserver",
+      "kubectl",
+      "cloudprovider",
+      "provider/gcp",
+      "release-eng",
+      "kubeadm",
+      "conformance",
+      "code-generation",
+      "ipvs",
+      "e2e-test-framework",
+      "dependency",
+      "stable-metrics"
+    ],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "network",
+      "scalability",
+      "scheduling",
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "autoscaling",
+      "auth",
+      "apps",
+      "cli",
+      "testing",
+      "release",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113186": {
+    "commit": "d94261e904c90578e913c42c4d2a0fc8cb30937f",
+    "text": "Add a new namespace alpha field to DataSourceRef field in PersistentVolumeClaimSpec API.",
+    "markdown": "Add a new namespace alpha field to DataSourceRef field in PersistentVolumeClaimSpec API. ([#113186](https://github.com/kubernetes/kubernetes/pull/113186), [@ttakahashi21](https://github.com/ttakahashi21)) [SIG API Machinery, Apps, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3294-provision-volumes-from-cross-namespace-snapshots",
+        "type": "KEP"
+      }
+    ],
+    "author": "ttakahashi21",
+    "author_url": "https://github.com/ttakahashi21",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113186",
+    "pr_number": 113186,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["storage", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113206": {
+    "commit": "b7f5de17aeef93481f32a4cb804a72cd9ed9c8f3",
+    "text": "Fix cost estimation of token creation request for service account in Priority and Fairness.",
+    "markdown": "Fix cost estimation of token creation request for service account in Priority and Fairness. ([#113206](https://github.com/kubernetes/kubernetes/pull/113206), [@marseel](https://github.com/marseel)) [SIG API Machinery]",
+    "author": "marseel",
+    "author_url": "https://github.com/marseel",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113206",
+    "pr_number": 113206,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113217": {
+    "commit": "ed1610ad15f91b72017c5d69dc4f7d59a17c270f",
+    "text": "API Server tracing now includes the latency of authorization, priorityandfairness, impersonation, audit, and authentication filters.",
+    "markdown": "API Server tracing now includes the latency of authorization, priorityandfairness, impersonation, audit, and authentication filters. ([#113217](https://github.com/kubernetes/kubernetes/pull/113217), [@dashpole](https://github.com/dashpole)) [SIG API Machinery and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/bddca24910fb349e2eb0ac1c822c77f0f32fe9c6/keps/sig-instrumentation/647-apiserver-tracing/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "dashpole",
+    "author_url": "https://github.com/dashpole",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113217",
+    "pr_number": 113217,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113225": {
+    "commit": "d3601a0f0625503993539809b1ef9f59c709a237",
+    "text": "DelegateFSGroupToCSIDriver feature is GA.",
+    "markdown": "DelegateFSGroupToCSIDriver feature is GA. ([#113225](https://github.com/kubernetes/kubernetes/pull/113225), [@bertinatto](https://github.com/bertinatto)) [SIG Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node and Storage]",
+    "author": "bertinatto",
+    "author_url": "https://github.com/bertinatto",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113225",
+    "pr_number": 113225,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["feature"],
+    "sigs": [
+      "storage",
+      "node",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true
+  },
+  "113274": {
+    "commit": "8c77820759cc28a5d82e9a68f3d335d1a27f4466",
+    "text": "New Pod API field `.spec.schedulingGates` is introduced to enable users to control when to mark a Pod as scheduling ready.",
+    "markdown": "New Pod API field `.spec.schedulingGates` is introduced to enable users to control when to mark a Pod as scheduling ready. ([#113274](https://github.com/kubernetes/kubernetes/pull/113274), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Apps, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness",
+        "type": "KEP"
+      }
+    ],
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113274",
+    "pr_number": 113274,
+    "areas": ["test", "code-generation", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113275": {
+    "commit": "95bd687a284f63535cbf48b0696d8ae57c9929ef",
+    "text": "A new `preEnqueue` extension point is added to scheduler's component config v1beta2/v1beta3/v1.",
+    "markdown": "A new `preEnqueue` extension point is added to scheduler's component config v1beta2/v1beta3/v1. ([#113275](https://github.com/kubernetes/kubernetes/pull/113275), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG API Machinery, Apps, Instrumentation, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness",
+        "type": "KEP"
+      }
+    ],
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113275",
+    "pr_number": 113275,
+    "areas": ["test", "code-generation", "e2e-test-framework", "stable-metrics"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113291": {
+    "commit": "2940484a9a4836e6eda159582815a7f03c84ffe4",
+    "text": "Fix the PodAndContainerStatsFromCRI feature, instead of supplementing with stats from cAdvisor.",
+    "markdown": "Fix the PodAndContainerStatsFromCRI feature, instead of supplementing with stats from cAdvisor. ([#113291](https://github.com/kubernetes/kubernetes/pull/113291), [@mengjiao-liu](https://github.com/mengjiao-liu)) [SIG Instrumentation and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2371-cri-pod-container-stats#current-fulfiller-of-metrics-endpoints--future-proposal",
+        "type": "KEP"
+      }
+    ],
+    "author": "mengjiao-liu",
+    "author_url": "https://github.com/mengjiao-liu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113291",
+    "pr_number": 113291,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node", "instrumentation"],
+    "duplicate": true
+  },
+  "113307": {
+    "commit": "72f2e1cc0d543c942e318d3100386ffc6369f576",
+    "text": "Update the Lease identity naming format for the APIServerIdentity feature to use a persistent name",
+    "markdown": "Update the Lease identity naming format for the APIServerIdentity feature to use a persistent name ([#113307](https://github.com/kubernetes/kubernetes/pull/113307), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery, Node and Testing]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113307",
+    "pr_number": 113307,
+    "areas": ["test", "kubelet", "apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["node", "api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113314": {
+    "commit": "f8de12778945f560fe6f39a9bf76b4adf020a2fa",
+    "text": "Introduce v1alpha1 API for validating admission policies, enabling extensible admission control via CEL expressions (KEP  3488: CEL for Admission Control). To use, enable the `ValidatingAdmissionPolicy` feature gate and the `admissionregistration.k8s.io/v1alpha1` API via `--runtime-config`.",
+    "markdown": "Introduce v1alpha1 API for validating admission policies, enabling extensible admission control via CEL expressions (KEP  3488: CEL for Admission Control). To use, enable the `ValidatingAdmissionPolicy` feature gate and the `admissionregistration.k8s.io/v1alpha1` API via `--runtime-config`. ([#113314](https://github.com/kubernetes/kubernetes/pull/113314), [@cici37](https://github.com/cici37)) [SIG API Machinery, Auth, Cloud Provider and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3488-cel-admission-control",
+        "type": "KEP"
+      }
+    ],
+    "author": "cici37",
+    "author_url": "https://github.com/cici37",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113314",
+    "pr_number": 113314,
+    "areas": ["test", "apiserver", "cloudprovider", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing", "cloud-provider"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113329": {
+    "commit": "06ba3835321b85419a2d444a7ac5e8847ba6ec79",
+    "text": "RetroactiveDefaultStorageClass feature is now beta.",
+    "markdown": "RetroactiveDefaultStorageClass feature is now beta. ([#113329](https://github.com/kubernetes/kubernetes/pull/113329), [@RomanBednar](https://github.com/RomanBednar)) [SIG Apps, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3333",
+        "type": "KEP"
+      }
+    ],
+    "author": "RomanBednar",
+    "author_url": "https://github.com/RomanBednar",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113329",
+    "pr_number": 113329,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113336": {
+    "commit": "ee640d775637bcb740f6af8f7f0ee03ef853b643",
+    "text": "CSIMigrationvSphere upgraded to GA and locked to true. Do not upgrade to K8s 1.26 if you need Windows support until vSphere CSI Driver adds support for it in a version post v2.7.x.",
+    "markdown": "CSIMigrationvSphere upgraded to GA and locked to true. Do not upgrade to K8s 1.26 if you need Windows support until vSphere CSI Driver adds support for it in a version post v2.7.x. ([#113336](https://github.com/kubernetes/kubernetes/pull/113336), [@divyenpatel](https://github.com/divyenpatel)) [SIG Storage]",
+    "author": "divyenpatel",
+    "author_url": "https://github.com/divyenpatel",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113336",
+    "pr_number": 113336,
+    "kinds": ["feature"],
+    "sigs": ["storage"],
+    "feature": true
+  },
+  "113340": {
+    "commit": "83fe3aae4b6dbde92c6b130ee059a28814300f52",
+    "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on cloud-controller-manager allowing you to scrape health check metrics.",
+    "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on cloud-controller-manager allowing you to scrape health check metrics. ([#113340](https://github.com/kubernetes/kubernetes/pull/113340), [@Richabanker](https://github.com/Richabanker)) [SIG Cloud Provider]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/3466", "type": "external" }
+    ],
+    "author": "Richabanker",
+    "author_url": "https://github.com/Richabanker",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113340",
+    "pr_number": 113340,
+    "areas": ["cloudprovider"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "113351": {
+    "commit": "5ca805fdeeb31db31805aaa02d96dc0a0c3cfe15",
+    "text": "The EndpointSliceTerminatingCondition feature gate has graduated to GA. The gate is now locked and will be removed in v1.28.",
+    "markdown": "The EndpointSliceTerminatingCondition feature gate has graduated to GA. The gate is now locked and will be removed in v1.28. ([#113351](https://github.com/kubernetes/kubernetes/pull/113351), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery, Apps, Network and Testing]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113351",
+    "pr_number": 113351,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113360": {
+    "commit": "7e0e0c8ec3a6f68db0a9c259836a9ad8792fa67b",
+    "text": "Enable the \"Retriable and non-retriable pod failures for jobs\" feature into beta",
+    "markdown": "Enable the \"Retriable and non-retriable pod failures for jobs\" feature into beta ([#113360](https://github.com/kubernetes/kubernetes/pull/113360), [@mimowo](https://github.com/mimowo)) [SIG Apps, Auth, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures",
+        "type": "KEP"
+      }
+    ],
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113360",
+    "pr_number": 113360,
+    "areas": ["test", "kubelet", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "node", "auth", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113363": {
+    "commit": "fccd8b12d0ef817406fde33be8cc1b6b2f5ab718",
+    "text": "The ProxyTerminatingEndpoints feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is Local and there are only terminating pods remaining on a node.",
+    "markdown": "The ProxyTerminatingEndpoints feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is Local and there are only terminating pods remaining on a node. ([#113363](https://github.com/kubernetes/kubernetes/pull/113363), [@andrewsykim](https://github.com/andrewsykim)) [SIG Network]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113363",
+    "pr_number": 113363,
+    "kinds": ["feature"],
+    "sigs": ["network"],
+    "feature": true
+  },
+  "113369": {
+    "commit": "421213b7a17b4d2753b3a00b7332a4bec3aba127",
+    "text": "The resourceVersion returned in objects from delete responses is now consistent with the resourceVersion contained in the delete watch event",
+    "markdown": "The resourceVersion returned in objects from delete responses is now consistent with the resourceVersion contained in the delete watch event ([#113369](https://github.com/kubernetes/kubernetes/pull/113369), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113369",
+    "pr_number": 113369,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113476": {
+    "commit": "9bbd0fbdb2bf7d9f6b21e268357316fa7c556f83",
+    "text": "Promoting WindowsHostProcessContainers to stable",
+    "markdown": "Promoting WindowsHostProcessContainers to stable ([#113476](https://github.com/kubernetes/kubernetes/pull/113476), [@marosset](https://github.com/marosset)) [SIG Apps, Node, Testing and Windows]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support",
+        "type": "KEP"
+      }
+    ],
+    "author": "marosset",
+    "author_url": "https://github.com/marosset",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113476",
+    "pr_number": 113476,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "apps", "windows", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113481": {
+    "commit": "5899432f92d27a6acb9198336a7abcad51311c39",
+    "text": "Pod logs using --timestamps are not broken up with timestamps anymore.",
+    "markdown": "Pod logs using --timestamps are not broken up with timestamps anymore. ([#113481](https://github.com/kubernetes/kubernetes/pull/113481), [@rphillips](https://github.com/rphillips)) [SIG Node]",
+    "author": "rphillips",
+    "author_url": "https://github.com/rphillips",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113481",
+    "pr_number": 113481,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "113485": {
+    "commit": "1193a9abcbd6c6ce6fc7d4ce38872f1933ef5159",
+    "text": "Priority and Fairness has introduced a new feature called _borrowing_ that allows an API priority level\nto borrow a number of seats from other priority level(s). As a cluster operator, you can enable borrowing\nfor a certain priority level configuration object via the two newly introduced fields `lendablePercent`, and\n`borrowingLimitPercent` located under the `.spec.limited` field of the designated priority level.\nThis PR adds the following metrics.\n- `apiserver_flowcontrol_nominal_limit_seats`: Nominal number of execution seats configured for each priority level\n- `apiserver_flowcontrol_lower_limit_seats`: Configured lower bound on number of execution seats available to each priority level\n- `apiserver_flowcontrol_upper_limit_seats`: Configured upper bound on number of execution seats available to each priority level\n- `apiserver_flowcontrol_demand_seats`: Observations, at the end of every nanosecond, of (the number of seats each priority level could use) / (nominal number of seats for that level)\n- `apiserver_flowcontrol_demand_seats_high_watermark`: High watermark, over last adjustment period, of demand_seats\n- `apiserver_flowcontrol_demand_seats_average`: Time-weighted average, over last adjustment period, of demand_seats\n- `apiserver_flowcontrol_demand_seats_stdev`: Time-weighted standard deviation, over last adjustment period, of demand_seats\n- `apiserver_flowcontrol_demand_seats_smoothed`: Smoothed seat demands\n- `apiserver_flowcontrol_target_seats`: Seat allocation targets\n- `apiserver_flowcontrol_seat_fair_frac`: Fair fraction of server's concurrency to allocate to each priority level that can use it\n- `apiserver_flowcontrol_current_limit_seats`: current derived number of execution seats available to each priority level\n\nThe possibility of borrowing means that the old metric apiserver_flowcontrol_request_concurrency_limit can no longer mean both the configured concurrency limit and the enforced concurrency limit.  Henceforth it means the configured concurrency limit.",
+    "markdown": "Priority and Fairness has introduced a new feature called _borrowing_ that allows an API priority level\n  to borrow a number of seats from other priority level(s). As a cluster operator, you can enable borrowing\n  for a certain priority level configuration object via the two newly introduced fields `lendablePercent`, and\n  `borrowingLimitPercent` located under the `.spec.limited` field of the designated priority level.\n  This PR adds the following metrics.\n  - `apiserver_flowcontrol_nominal_limit_seats`: Nominal number of execution seats configured for each priority level\n  - `apiserver_flowcontrol_lower_limit_seats`: Configured lower bound on number of execution seats available to each priority level\n  - `apiserver_flowcontrol_upper_limit_seats`: Configured upper bound on number of execution seats available to each priority level\n  - `apiserver_flowcontrol_demand_seats`: Observations, at the end of every nanosecond, of (the number of seats each priority level could use) / (nominal number of seats for that level)\n  - `apiserver_flowcontrol_demand_seats_high_watermark`: High watermark, over last adjustment period, of demand_seats\n  - `apiserver_flowcontrol_demand_seats_average`: Time-weighted average, over last adjustment period, of demand_seats\n  - `apiserver_flowcontrol_demand_seats_stdev`: Time-weighted standard deviation, over last adjustment period, of demand_seats\n  - `apiserver_flowcontrol_demand_seats_smoothed`: Smoothed seat demands\n  - `apiserver_flowcontrol_target_seats`: Seat allocation targets\n  - `apiserver_flowcontrol_seat_fair_frac`: Fair fraction of server's concurrency to allocate to each priority level that can use it\n  - `apiserver_flowcontrol_current_limit_seats`: current derived number of execution seats available to each priority level\n  \n  The possibility of borrowing means that the old metric apiserver_flowcontrol_request_concurrency_limit can no longer mean both the configured concurrency limit and the enforced concurrency limit.  Henceforth it means the configured concurrency limit. ([#113485](https://github.com/kubernetes/kubernetes/pull/113485), [@MikeSpreitzer](https://github.com/MikeSpreitzer)) [SIG API Machinery and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1040-priority-and-fairness#dispatching",
+        "type": "KEP"
+      }
+    ],
+    "author": "MikeSpreitzer",
+    "author_url": "https://github.com/MikeSpreitzer",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113485",
+    "pr_number": 113485,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113491": {
+    "commit": "153bc2ef1a1a8d0982494d380661896ec64b154e",
+    "text": "Pod Security admission: the pod-security `warn` level will now default to the `enforce` level.",
+    "markdown": "Pod Security admission: the pod-security `warn` level will now default to the `enforce` level. ([#113491](https://github.com/kubernetes/kubernetes/pull/113491), [@tallclair](https://github.com/tallclair)) [SIG Auth and Security]",
+    "author": "tallclair",
+    "author_url": "https://github.com/tallclair",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113491",
+    "pr_number": 113491,
+    "kinds": ["feature"],
+    "sigs": ["auth", "security"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113496": {
+    "commit": "7a465163694131e6d66fe95a7e91f2f8235306bf",
+    "text": "Graduate ServiceInternalTrafficPolicy feature to GA",
+    "markdown": "Graduate ServiceInternalTrafficPolicy feature to GA ([#113496](https://github.com/kubernetes/kubernetes/pull/113496), [@avoltz](https://github.com/avoltz)) [SIG Apps and Network]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2086",
+        "type": "KEP"
+      }
+    ],
+    "author": "avoltz",
+    "author_url": "https://github.com/avoltz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113496",
+    "pr_number": 113496,
+    "areas": ["ipvs"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113500": {
+    "commit": "c326b2713f0d2d836209409bf4387d8e9e84af76",
+    "text": "NodeInclusionPolicy in podTopologySpread plugin is enabled by default.",
+    "markdown": "NodeInclusionPolicy in podTopologySpread plugin is enabled by default. ([#113500](https://github.com/kubernetes/kubernetes/pull/113500), [@kerthcet](https://github.com/kerthcet)) [SIG API Machinery, Apps, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/issues/3094",
+        "type": "KEP"
+      }
+    ],
+    "author": "kerthcet",
+    "author_url": "https://github.com/kerthcet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113500",
+    "pr_number": 113500,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113501": {
+    "commit": "70263d55b281878121684337c0a7f205dabba5ec",
+    "text": "kubelet: fix nil pointer in reflector start for standalone mode",
+    "markdown": "Kubelet: fix nil pointer in reflector start for standalone mode ([#113501](https://github.com/kubernetes/kubernetes/pull/113501), [@pacoxu](https://github.com/pacoxu)) [SIG Node]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113501",
+    "pr_number": 113501,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "113510": {
+    "commit": "ac95e5b701dff7acc994dcdf5192264e7f6fe02a",
+    "text": "Graduate JobTrackingWithFinalizers to stable.\nJobs created before the feature was enabled are still tracked without finalizers.\nUsers can choose to migrate jobs to tracking with finalizers by adding the annotation batch.kubernetes.io/job-tracking.\nIf the annotation was already present and the user attempts to remove it, the control plane adds the annotation back.",
+    "markdown": "Graduate JobTrackingWithFinalizers to stable.\n  Jobs created before the feature was enabled are still tracked without finalizers.\n  Users can choose to migrate jobs to tracking with finalizers by adding the annotation batch.kubernetes.io/job-tracking.\n  If the annotation was already present and the user attempts to remove it, the control plane adds the annotation back. ([#113510](https://github.com/kubernetes/kubernetes/pull/113510), [@alculquicondor](https://github.com/alculquicondor)) [SIG API Machinery, Apps and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/a4b5f5c8e9aa857f9bf1f7df2a9a8b9ee660ed1e/keps/sig-apps/2307-job-tracking-without-lingering-pods#beta---ga-graduation",
+        "type": "KEP"
+      },
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-tracking-with-finalizers",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113510",
+    "pr_number": 113510,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113511": {
+    "commit": "8128d8789650f1b02f41292fa7927ec32ca8f4dd",
+    "text": "NodeOutOfServiceVolumeDetach is now beta.",
+    "markdown": "NodeOutOfServiceVolumeDetach is now beta. ([#113511](https://github.com/kubernetes/kubernetes/pull/113511), [@xing-yang](https://github.com/xing-yang)) [SIG Node and Storage]",
+    "author": "xing-yang",
+    "author_url": "https://github.com/xing-yang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113511",
+    "pr_number": 113511,
+    "kinds": ["feature"],
+    "sigs": ["storage", "node"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113519": {
+    "commit": "b4e6bed525fc8fbfe4b43e6cab65db1b5555ac3b",
+    "text": "Adds metrics `force_delete_pods_total` and `force_delete_pod_errors_total` in the Pod GC Controller.",
+    "markdown": "Adds metrics `force_delete_pods_total` and `force_delete_pod_errors_total` in the Pod GC Controller. ([#113519](https://github.com/kubernetes/kubernetes/pull/113519), [@xing-yang](https://github.com/xing-yang)) [SIG Apps]",
+    "author": "xing-yang",
+    "author_url": "https://github.com/xing-yang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113519",
+    "pr_number": 113519,
+    "kinds": ["feature"],
+    "sigs": ["apps"],
+    "feature": true
+  },
+  "113521": {
+    "commit": "7b6e4e4d8b12bfa0770f649611c4968b610d2b87",
+    "text": "Resolves an issue that causes winkernel proxier to treat stale VIPs as valid",
+    "markdown": "Resolves an issue that causes winkernel proxier to treat stale VIPs as valid ([#113521](https://github.com/kubernetes/kubernetes/pull/113521), [@daschott](https://github.com/daschott)) [SIG Network and Windows]",
+    "author": "daschott",
+    "author_url": "https://github.com/daschott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113521",
+    "pr_number": 113521,
+    "kinds": ["bug"],
+    "sigs": ["network", "windows"],
+    "duplicate": true
+  },
+  "113529": {
+    "commit": "b1dd1cd2f177ecf228cbbfb0db9327a276098be8",
+    "text": "A new API server flag --encryption-provider-config-automatic-reload has been added to control when the encryption config should be automatically reloaded without needing to restart the server.  All KMS plugins are merged into a single healthz check at /healthz/kms-providers when reload is enabled, or when only KMS v2 plugins are used.",
+    "markdown": "A new API server flag --encryption-provider-config-automatic-reload has been added to control when the encryption config should be automatically reloaded without needing to restart the server.  All KMS plugins are merged into a single healthz check at /healthz/kms-providers when reload is enabled, or when only KMS v2 plugins are used. ([#113529](https://github.com/kubernetes/kubernetes/pull/113529), [@enj](https://github.com/enj)) [SIG API Machinery, Auth and Testing]",
+    "author": "enj",
+    "author_url": "https://github.com/enj",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113529",
+    "pr_number": 113529,
+    "areas": ["test", "apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "duplicate": true
+  },
+  "113544": {
+    "commit": "4faede03fa4a124ef9b91736eec313a31951f3b5",
+    "text": "Added: publishing events when enabling/disabling topologyAwareHints.",
+    "markdown": "Added: publishing events when enabling/disabling topologyAwareHints. ([#113544](https://github.com/kubernetes/kubernetes/pull/113544), [@LiorLieberman](https://github.com/LiorLieberman)) [SIG Apps and Network]",
+    "author": "LiorLieberman",
+    "author_url": "https://github.com/LiorLieberman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113544",
+    "pr_number": 113544,
+    "kinds": ["feature"],
+    "sigs": ["network", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113550": {
+    "commit": "2acad1b8c4b5f9a4991885ef34de1dc771139628",
+    "text": "Kubernetes is now built with Go 1.19.3",
+    "markdown": "Kubernetes is now built with Go 1.19.3 ([#113550](https://github.com/kubernetes/kubernetes/pull/113550), [@xmudrii](https://github.com/xmudrii)) [SIG Release and Testing]",
+    "author": "xmudrii",
+    "author_url": "https://github.com/xmudrii",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113550",
+    "pr_number": 113550,
+    "areas": ["test", "release-eng", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["testing", "release"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113580": {
+    "commit": "208b2b7ca9f211c0d4a8df903bfb65fd6065d527",
+    "text": "Fix that disruption controller changes the status of a stale disruption condition after 2 min when the PodDisruptionConditions feature gate is enabled",
+    "markdown": "Fix that disruption controller changes the status of a stale disruption condition after 2 min when the PodDisruptionConditions feature gate is enabled ([#113580](https://github.com/kubernetes/kubernetes/pull/113580), [@mimowo](https://github.com/mimowo)) [SIG Auth]",
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113580",
+    "pr_number": 113580,
+    "kinds": ["bug"],
+    "sigs": ["auth"]
+  },
+  "113596": {
+    "commit": "da735b541514f65ab4e693a28a3637fad7a288b3",
+    "text": "Added reconstruction of SELinux mount context after kubelet restart. Feature SELinuxMountReadWriteOncePod is now fully implemented and kubelet does not lose its cache of SELinux contexts after kubelet process restart.",
+    "markdown": "Added reconstruction of SELinux mount context after kubelet restart. Feature SELinuxMountReadWriteOncePod is now fully implemented and kubelet does not lose its cache of SELinux contexts after kubelet process restart. ([#113596](https://github.com/kubernetes/kubernetes/pull/113596), [@jsafrane](https://github.com/jsafrane)) [SIG Apps, Node, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling",
+        "type": "KEP"
+      }
+    ],
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113596",
+    "pr_number": 113596,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "node", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113609": {
+    "commit": "b4040b3b863737674a492f8fd415eff8503ba0b4",
+    "text": "Add alpha support for returning container and pod metrics from CRI, instead of cAdvsior",
+    "markdown": "Add alpha support for returning container and pod metrics from CRI, instead of cAdvsior ([#113609](https://github.com/kubernetes/kubernetes/pull/113609), [@haircommander](https://github.com/haircommander)) [SIG Architecture, Instrumentation and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2371",
+        "type": "KEP"
+      }
+    ],
+    "author": "haircommander",
+    "author_url": "https://github.com/haircommander",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113609",
+    "pr_number": 113609,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "instrumentation", "architecture"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113629": {
+    "commit": "3a99a5954d6497b4238d011cec4d33422d3957a0",
+    "text": "Promote the `APIServerIdentity` feature to Beta. By default, each kube-apiserver will now create a Lease in the `kube-system` namespace. These lease objects can be used to identify the number of active API servers in the cluster, and may also be used for future features such as the Storage Version API.",
+    "markdown": "Promote the `APIServerIdentity` feature to Beta. By default, each kube-apiserver will now create a Lease in the `kube-system` namespace. These lease objects can be used to identify the number of active API servers in the cluster, and may also be used for future features such as the Storage Version API. ([#113629](https://github.com/kubernetes/kubernetes/pull/113629), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery and Testing]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113629",
+    "pr_number": 113629,
+    "areas": ["test", "apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113636": {
+    "commit": "d72926d4915133550e41de1252fe2a4aa0aa3745",
+    "text": "Kubectl shell completions for the bash shell now include descriptions.",
+    "markdown": "Kubectl shell completions for the bash shell now include descriptions. ([#113636](https://github.com/kubernetes/kubernetes/pull/113636), [@marckhouzam](https://github.com/marckhouzam)) [SIG CLI]",
+    "author": "marckhouzam",
+    "author_url": "https://github.com/marckhouzam",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113636",
+    "pr_number": 113636,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "113697": {
+    "commit": "47f8c4bec63a2c4d6406cd615b41cd16f12be434",
+    "text": "If you enabled automatic reload of encryption configuration with API server flag --encryption-provider-config-automatic-reload, ensure all the KMS provider names (v1 and v2) in the encryption configuration are unique.",
+    "markdown": "If you enabled automatic reload of encryption configuration with API server flag --encryption-provider-config-automatic-reload, ensure all the KMS provider names (v1 and v2) in the encryption configuration are unique. ([#113697](https://github.com/kubernetes/kubernetes/pull/113697), [@aramase](https://github.com/aramase)) [SIG API Machinery and Auth]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements",
+        "type": "KEP"
+      }
+    ],
+    "author": "aramase",
+    "author_url": "https://github.com/aramase",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113697",
+    "pr_number": 113697,
+    "areas": ["apiserver"],
+    "kinds": ["bug", "api-change"],
+    "sigs": ["api-machinery", "auth"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113699": {
+    "commit": "f2c89045f45fc9d03ac49ba7e31c92933c739d20",
+    "text": "metav1.LabelSelectors specified in API objects are now validated to ensure they do not contain invalid label values that will error at time of use. Existing invalid objects can be updated, but new objects are required to contain valid label selectors.",
+    "markdown": "Metav1.LabelSelectors specified in API objects are now validated to ensure they do not contain invalid label values that will error at time of use. Existing invalid objects can be updated, but new objects are required to contain valid label selectors. ([#113699](https://github.com/kubernetes/kubernetes/pull/113699), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps, Auth, Network and Storage]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113699",
+    "pr_number": 113699,
+    "kinds": ["bug", "api-change"],
+    "sigs": ["network", "storage", "api-machinery", "auth", "apps"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113710": {
+    "commit": "b6d021b7e375a09d56b75c530ede1781e61a0581",
+    "text": "CLI flag `pod-eviction-timeout` is deprecated and will be removed together with `enable-taint-manager` in v1.27.",
+    "markdown": "CLI flag `pod-eviction-timeout` is deprecated and will be removed together with `enable-taint-manager` in v1.27. ([#113710](https://github.com/kubernetes/kubernetes/pull/113710), [@kerthcet](https://github.com/kerthcet)) [SIG API Machinery and Apps]",
+    "author": "kerthcet",
+    "author_url": "https://github.com/kerthcet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113710",
+    "pr_number": 113710,
+    "kinds": ["feature", "deprecation"],
+    "sigs": ["api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113711": {
+    "commit": "429f1527a7ac94e5280cb41931e74ac52d7a3fb1",
+    "text": "apiserver: use the correct error when logging errors updating managedFields",
+    "markdown": "Apiserver: use the correct error when logging errors updating managedFields ([#113711](https://github.com/kubernetes/kubernetes/pull/113711), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113711",
+    "pr_number": 113711,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113719": {
+    "commit": "e21438fca5f5e6988091bf0b39be51fcc19cfd8b",
+    "text": "bump runc to v1.1.4",
+    "markdown": "Bump runc to v1.1.4 ([#113719](https://github.com/kubernetes/kubernetes/pull/113719), [@pacoxu](https://github.com/pacoxu)) [SIG Node]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113719",
+    "pr_number": 113719,
+    "areas": ["dependency"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "113735": {
+    "commit": "72a25b17726b3059982dcc740fb8d05ec0c24f95",
+    "text": "Rename the feature gate for CEL in Admission Control to `ValidatingAdmissionPolicy`.",
+    "markdown": "Rename the feature gate for CEL in Admission Control to `ValidatingAdmissionPolicy`. ([#113735](https://github.com/kubernetes/kubernetes/pull/113735), [@cici37](https://github.com/cici37)) [SIG API Machinery and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3488-cel-admission-control",
+        "type": "KEP"
+      }
+    ],
+    "author": "cici37",
+    "author_url": "https://github.com/cici37",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113735",
+    "pr_number": 113735,
+    "areas": ["test", "apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "testing"],
+    "duplicate": true
+  },
+  "113749": {
+    "commit": "c61c3fc492424bfcfabf132650c2bc4404ef2727",
+    "text": "NOTE",
+    "markdown": "NOTE ([#113749](https://github.com/kubernetes/kubernetes/pull/113749), [@jpbetz](https://github.com/jpbetz)) [SIG API Machinery]",
+    "author": "jpbetz",
+    "author_url": "https://github.com/jpbetz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113749",
+    "pr_number": 113749,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113754": {
+    "commit": "e9ef6ee8b363b4e9b2d2d852ecc436d9bfdbd189",
+    "text": "`kubelet_kubelet_credential_provider_plugin_duration` is renamed `kubelet_credential_provider_plugin_duration` and `kubelet_kubelet_credential_provider_plugin_errors` is renamed `kubelet_credential_provider_plugin_errors`.",
+    "markdown": "`kubelet_kubelet_credential_provider_plugin_duration` is renamed `kubelet_credential_provider_plugin_duration` and `kubelet_kubelet_credential_provider_plugin_errors` is renamed `kubelet_credential_provider_plugin_errors`. ([#113754](https://github.com/kubernetes/kubernetes/pull/113754), [@logicalhan](https://github.com/logicalhan)) [SIG Instrumentation and Node]",
+    "author": "logicalhan",
+    "author_url": "https://github.com/logicalhan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113754",
+    "pr_number": 113754,
+    "kinds": ["cleanup"],
+    "sigs": ["node", "instrumentation"],
+    "duplicate": true
+  },
+  "113769": {
+    "commit": "37e73b419e455db34f5fe3e8d815418680ab23df",
+    "text": "Updated cAdvisor to v0.46.0",
+    "markdown": "Updated cAdvisor to v0.46.0 ([#113769](https://github.com/kubernetes/kubernetes/pull/113769), [@bobbypage](https://github.com/bobbypage)) [SIG Architecture, CLI, Cloud Provider, Node and Storage]",
+    "author": "bobbypage",
+    "author_url": "https://github.com/bobbypage",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113769",
+    "pr_number": 113769,
+    "areas": ["kubectl", "cloudprovider", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "node", "cli", "architecture", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113819": {
+    "commit": "50c7ebb5b45818a4244728932ce6113c10c2d41d",
+    "text": "Promote kubectl alpha events to kubectl events",
+    "markdown": "Promote kubectl alpha events to kubectl events ([#113819](https://github.com/kubernetes/kubernetes/pull/113819), [@soltysh](https://github.com/soltysh)) [SIG CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/1440",
+        "type": "KEP"
+      }
+    ],
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113819",
+    "pr_number": 113819,
+    "areas": ["test", "kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.26.0-beta.0.json',
   'assets/release-notes-1.26.0-alpha.2.json',
   'assets/release-notes-1.24.0.json',
   'assets/release-notes-1.26.0-alpha.1.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.26.0-beta.0` 