### PR TITLE
Patch relnotes.k8s.io to release v1.26.0-alpha.3

### DIFF
--- a/src/assets/release-notes-1.26.0-alpha.3.json
+++ b/src/assets/release-notes-1.26.0-alpha.3.json
@@ -1,0 +1,913 @@
+{
+  "105867": {
+    "commit": "797536fc76854a856bc1d1156c2355705af461ca",
+    "text": "Shell completion will now show plugin names when appropriate.  Furthermore, shell completion will work for plugins that provide such support.",
+    "markdown": "Shell completion will now show plugin names when appropriate.  Furthermore, shell completion will work for plugins that provide such support. ([#105867](https://github.com/kubernetes/kubernetes/pull/105867), [@marckhouzam](https://github.com/marckhouzam)) [SIG CLI]",
+    "author": "marckhouzam",
+    "author_url": "https://github.com/marckhouzam",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/105867",
+    "pr_number": 105867,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "108501": {
+    "commit": "85643c0f93064ad9f9bcd9303972d8308734d269",
+    "text": "kube-controller-manager supports '--concurrent-horizontal-pod-autoscaler-syncs' flag to set the number of horizontal pod autoscaler controller workers.",
+    "markdown": "Kube-controller-manager supports '--concurrent-horizontal-pod-autoscaler-syncs' flag to set the number of horizontal pod autoscaler controller workers. ([#108501](https://github.com/kubernetes/kubernetes/pull/108501), [@zroubalik](https://github.com/zroubalik)) [SIG API Machinery, Apps and Autoscaling]",
+    "author": "zroubalik",
+    "author_url": "https://github.com/zroubalik",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108501",
+    "pr_number": 108501,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "autoscaling", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "108858": {
+    "commit": "c5242edd929fc40f97d3f6ee3e8874ac1b297087",
+    "text": "When the alpha `LegacyServiceAccountTokenTracking` feature gate is enabled, secret-based service account tokens will have a `kubernetes.io/legacy-token-last-used` applied to them containing the date they were last used.",
+    "markdown": "When the alpha `LegacyServiceAccountTokenTracking` feature gate is enabled, secret-based service account tokens will have a `kubernetes.io/legacy-token-last-used` applied to them containing the date they were last used. ([#108858](https://github.com/kubernetes/kubernetes/pull/108858), [@zshihang](https://github.com/zshihang)) [SIG API Machinery, Auth and Testing]",
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108858",
+    "pr_number": 108858,
+    "areas": ["test", "apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "109525": {
+    "commit": "526650fc137b2e68267182b1b5116aa566be51e5",
+    "text": "kubectl wait command with jsonpath flag will wait for target path appear until timeout.",
+    "markdown": "Kubectl wait command with jsonpath flag will wait for target path appear until timeout. ([#109525](https://github.com/kubernetes/kubernetes/pull/109525), [@jonyhy96](https://github.com/jonyhy96)) [SIG CLI and Testing]",
+    "author": "jonyhy96",
+    "author_url": "https://github.com/jonyhy96",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109525",
+    "pr_number": 109525,
+    "areas": ["test", "kubectl"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "110498": {
+    "commit": "cf4d2cc545f62fcfd748a084dff7744f9402bf57",
+    "text": "\"NONE\"",
+    "markdown": "\"NONE\" ([#110498](https://github.com/kubernetes/kubernetes/pull/110498), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG Release]",
+    "author": "yangjunmyfm192085",
+    "author_url": "https://github.com/yangjunmyfm192085",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110498",
+    "pr_number": 110498,
+    "areas": ["release-eng"],
+    "kinds": ["cleanup"],
+    "sigs": ["release"],
+    "do_not_publish": true
+  },
+  "110559": {
+    "commit": "962235c86a1a934fc759be1d3fd3a764fa2efa18",
+    "text": "Admission control plugin \"DefaultStorageClass\": If more than one StorageClass is designated as default (via the \"storageclass.kubernetes.io/is-default-class\" annotation), choose the newest one instead of throwing an error.",
+    "markdown": "Admission control plugin \"DefaultStorageClass\": If more than one StorageClass is designated as default (via the \"storageclass.kubernetes.io/is-default-class\" annotation), choose the newest one instead of throwing an error. ([#110559](https://github.com/kubernetes/kubernetes/pull/110559), [@danishprakash](https://github.com/danishprakash)) [SIG Apps and Storage]",
+    "author": "danishprakash",
+    "author_url": "https://github.com/danishprakash",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110559",
+    "pr_number": 110559,
+    "kinds": ["feature"],
+    "sigs": ["storage", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "111096": {
+    "commit": "afbce897a9c7956fd3219b64abacf46fa5d3e6aa",
+    "text": "Added categories column to the `kubectl api-resources` command's wide output (`-o wide`).\nAdded `--categories` flag to the `kubectl api-resources` command, which can be used to filter the output to show only resources belonging to one or more categories.",
+    "markdown": "Added categories column to the `kubectl api-resources` command's wide output (`-o wide`).\n  Added `--categories` flag to the `kubectl api-resources` command, which can be used to filter the output to show only resources belonging to one or more categories. ([#111096](https://github.com/kubernetes/kubernetes/pull/111096), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]",
+    "author": "brianpursley",
+    "author_url": "https://github.com/brianpursley",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111096",
+    "pr_number": 111096,
+    "areas": ["kubectl"],
+    "kinds": ["cleanup", "feature"],
+    "sigs": ["cli"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "111344": {
+    "commit": "5cb9622347d73a5d9715c9423aaf94cc0e4a5a40",
+    "text": "kube-proxy, will restart in case it detects that the Node assigned pod.Spec.PodCIDRs have changed",
+    "markdown": "Kube-proxy, will restart in case it detects that the Node assigned pod.Spec.PodCIDRs have changed ([#111344](https://github.com/kubernetes/kubernetes/pull/111344), [@aojea](https://github.com/aojea)) [SIG Network]",
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111344",
+    "pr_number": 111344,
+    "areas": ["ipvs"],
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "111616": {
+    "commit": "6f579d3cebe91825dd7dc4c9f9e1474939735bc9",
+    "text": "Kubelet external Credential Provider feature is moved to GA. Credential Provider Plugin and Credential Provider Config APIs updated from v1beta1 to v1 with no API changes.",
+    "markdown": "Kubelet external Credential Provider feature is moved to GA. Credential Provider Plugin and Credential Provider Config APIs updated from v1beta1 to v1 with no API changes. ([#111616](https://github.com/kubernetes/kubernetes/pull/111616), [@ndixita](https://github.com/ndixita)) [SIG API Machinery, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2133-kubelet-credential-providers",
+        "type": "KEP"
+      }
+    ],
+    "author": "ndixita",
+    "author_url": "https://github.com/ndixita",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111616",
+    "pr_number": 111616,
+    "areas": ["test", "kubelet", "code-generation"],
+    "kinds": ["api-change"],
+    "sigs": ["scheduling", "node", "api-machinery", "testing"],
+    "duplicate": true
+  },
+  "111930": {
+    "commit": "8a5fbce96e7c255d3cf8d2f15a83f6746c5c1d1a",
+    "text": "Add the metric pod_start_sli_duration_seconds to kubelet",
+    "markdown": "Add the metric pod_start_sli_duration_seconds to kubelet ([#111930](https://github.com/kubernetes/kubernetes/pull/111930), [@azylinski](https://github.com/azylinski)) [SIG Instrumentation, Node and Testing]",
+    "author": "azylinski",
+    "author_url": "https://github.com/azylinski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111930",
+    "pr_number": 111930,
+    "areas": ["test", "kubelet", "e2e-test-framework"],
+    "kinds": ["feature"],
+    "sigs": ["node", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112133": {
+    "commit": "6705015101d9572157325ddf237ff65c5efb3cef",
+    "text": "kube-proxy: The \"userspace\" proxy mode (deprecated for over a year) is no longer supported on either Linux or Windows.  Users should use \"iptables\" or \"ipvs\" on Linux, or \"kernelspace\" on Windows.",
+    "markdown": "Kube-proxy: The \"userspace\" proxy mode (deprecated for over a year) is no longer supported on either Linux or Windows.  Users should use \"iptables\" or \"ipvs\" on Linux, or \"kernelspace\" on Windows. ([#112133](https://github.com/kubernetes/kubernetes/pull/112133), [@knabben](https://github.com/knabben)) [SIG API Machinery, Network, Scalability, Testing and Windows]",
+    "author": "knabben",
+    "author_url": "https://github.com/knabben",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112133",
+    "pr_number": 112133,
+    "areas": ["test", "code-generation", "e2e-test-framework"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["network", "scalability", "api-machinery", "windows", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112163": {
+    "commit": "d754183866fab256c77d3a677d523587b20ba12c",
+    "text": "Graduate ServiceIPStaticSubrange feature to GA",
+    "markdown": "Graduate ServiceIPStaticSubrange feature to GA ([#112163](https://github.com/kubernetes/kubernetes/pull/112163), [@aojea](https://github.com/aojea)) [SIG Network]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3070",
+        "type": "KEP"
+      },
+      {
+        "description": "[Blog]",
+        "url": "https://kubernetes.io/blog/2022/05/23/service-ip-dynamic-and-static-allocation/",
+        "type": "external"
+      }
+    ],
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112163",
+    "pr_number": 112163,
+    "kinds": ["feature"],
+    "sigs": ["network"],
+    "feature": true
+  },
+  "112374": {
+    "commit": "8fb8bb4e9ae2d2cb2b7cdb4c79c73be344fdc164",
+    "text": "logs of requests that were timed out by a timeout handler will no longer contain a \"statusStack\" and \"logging error output\" fields",
+    "markdown": "Logs of requests that were timed out by a timeout handler will no longer contain a \"statusStack\" and \"logging error output\" fields ([#112374](https://github.com/kubernetes/kubernetes/pull/112374), [@Argh4k](https://github.com/Argh4k)) [SIG API Machinery]",
+    "author": "Argh4k",
+    "author_url": "https://github.com/Argh4k",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112374",
+    "pr_number": 112374,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "112521": {
+    "commit": "521fbd7e6a8eee04d1f641477fe7d87f2dbe3ed0",
+    "text": "Add percentageOfNodesToScore as a scheduler profile level parameter to API version v1. If a profile percentageOfNodesToScore is set, it will override global percentageOfNodesToScore.",
+    "markdown": "Add percentageOfNodesToScore as a scheduler profile level parameter to API version v1. If a profile percentageOfNodesToScore is set, it will override global percentageOfNodesToScore. ([#112521](https://github.com/kubernetes/kubernetes/pull/112521), [@yuanchen8911](https://github.com/yuanchen8911)) [SIG API Machinery, Scheduling and Testing]",
+    "author": "yuanchen8911",
+    "author_url": "https://github.com/yuanchen8911",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112521",
+    "pr_number": 112521,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112553": {
+    "commit": "dad0e937c0f76344363eb691b2668490ffef8537",
+    "text": "kubectl now escapes terminal special characters in output. This fixes CVE-2021-25743.",
+    "markdown": "Kubectl now escapes terminal special characters in output. This fixes CVE-2021-25743. ([#112553](https://github.com/kubernetes/kubernetes/pull/112553), [@dgl](https://github.com/dgl)) [SIG CLI and Security]",
+    "author": "dgl",
+    "author_url": "https://github.com/dgl",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112553",
+    "pr_number": 112553,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli", "security"],
+    "duplicate": true
+  },
+  "112571": {
+    "commit": "6e9f428547ef8708c424f11c9b6645ce5859f2eb",
+    "text": "Nested mountpoints are now group correctly on all cases.",
+    "markdown": "Nested mountpoints are now group correctly on all cases. ([#112571](https://github.com/kubernetes/kubernetes/pull/112571), [@claudiubelu](https://github.com/claudiubelu)) [SIG Storage and Windows]",
+    "author": "claudiubelu",
+    "author_url": "https://github.com/claudiubelu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112571",
+    "pr_number": 112571,
+    "kinds": ["bug"],
+    "sigs": ["storage", "windows"],
+    "duplicate": true
+  },
+  "112643": {
+    "commit": "525280d285c4bb4970e571a1e13a601befd75434",
+    "text": "The `DynamicKubeletConfig` feature gate has been removed from the API server. Dynamic kubelet reconfiguration now cannot be used even when older nodes are still attempting to rely on it. This is aligned with the Kubernetes version skew policy.",
+    "markdown": "The `DynamicKubeletConfig` feature gate has been removed from the API server. Dynamic kubelet reconfiguration now cannot be used even when older nodes are still attempting to rely on it. This is aligned with the Kubernetes version skew policy. ([#112643](https://github.com/kubernetes/kubernetes/pull/112643), [@SergeyKanzhelev](https://github.com/SergeyKanzhelev)) [SIG API Machinery, Apps, Auth, Node and Testing]",
+    "author": "SergeyKanzhelev",
+    "author_url": "https://github.com/SergeyKanzhelev",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112643",
+    "pr_number": 112643,
+    "areas": ["test", "kubelet", "code-generation"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["node", "api-machinery", "auth", "apps", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "112693": {
+    "commit": "6cb473b6c4f1239d411e0a50a1cdf9c4c092c42a",
+    "text": "Bump golang.org/x/net to v0.1.1-0.20221027164007-c63010009c80",
+    "markdown": "Bump golang.org/x/net to v0.1.1-0.20221027164007-c63010009c80 ([#112693](https://github.com/kubernetes/kubernetes/pull/112693), [@aimuz](https://github.com/aimuz)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node, Security and Storage]",
+    "author": "aimuz",
+    "author_url": "https://github.com/aimuz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112693",
+    "pr_number": 112693,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["bug"],
+    "sigs": [
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "architecture",
+      "cloud-provider",
+      "security"
+    ],
+    "duplicate": true
+  },
+  "112696": {
+    "commit": "b932a3ac374d72c188b76bde70008cb58ddf3a68",
+    "text": "Fixed: #22422 Admission controllers can cause unnecessary significant load on apiserver",
+    "markdown": "Fixed: #22422 Admission controllers can cause unnecessary significant load on apiserver ([#112696](https://github.com/kubernetes/kubernetes/pull/112696), [@aimuz](https://github.com/aimuz)) [SIG Scalability]",
+    "author": "aimuz",
+    "author_url": "https://github.com/aimuz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112696",
+    "pr_number": 112696,
+    "kinds": ["bug"],
+    "sigs": ["scalability"]
+  },
+  "112700": {
+    "commit": "0207f7ae8627335cf5684fea40f5fcc5e2691a99",
+    "text": "kubectl: fixed a bug where `kubectl convert` did not pick the right API version",
+    "markdown": "Kubectl: fixed a bug where `kubectl convert` did not pick the right API version ([#112700](https://github.com/kubernetes/kubernetes/pull/112700), [@SataQiu](https://github.com/SataQiu)) [SIG CLI]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112700",
+    "pr_number": 112700,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
+  "112785": {
+    "commit": "f68345b2f09355a59c99df0ce46ef24dfcadab4b",
+    "text": "Fixed a bug where a change in the `appProtocol` for a Service did not trigger a load balancer update.",
+    "markdown": "Fixed a bug where a change in the `appProtocol` for a Service did not trigger a load balancer update. ([#112785](https://github.com/kubernetes/kubernetes/pull/112785), [@MartinForReal](https://github.com/MartinForReal)) [SIG Cloud Provider and Network]",
+    "author": "MartinForReal",
+    "author_url": "https://github.com/MartinForReal",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112785",
+    "pr_number": 112785,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["network", "cloud-provider"],
+    "duplicate": true
+  },
+  "112806": {
+    "commit": "c1602669a667a82b585389b3a70d44cf360b1389",
+    "text": "Service session affinity timeout tests are no longer required for Kubernetes network plugin conformance due to variations in existing implementations. New conformance tests will be developed to better express conformance in future releases.",
+    "markdown": "Service session affinity timeout tests are no longer required for Kubernetes network plugin conformance due to variations in existing implementations. New conformance tests will be developed to better express conformance in future releases. ([#112806](https://github.com/kubernetes/kubernetes/pull/112806), [@dcbw](https://github.com/dcbw)) [SIG Architecture, Network and Testing]",
+    "author": "dcbw",
+    "author_url": "https://github.com/dcbw",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112806",
+    "pr_number": 112806,
+    "areas": ["test", "conformance"],
+    "kinds": ["cleanup"],
+    "sigs": ["network", "testing", "architecture"],
+    "duplicate": true
+  },
+  "112824": {
+    "commit": "0ef0fa0e821fa6c64fb02b4a774d3b0fd38e466e",
+    "text": "The ExpandedDNSConfig feature has graduated to beta and is enabled by default. Note that this feature requires container runtime support.",
+    "markdown": "The ExpandedDNSConfig feature has graduated to beta and is enabled by default. Note that this feature requires container runtime support. ([#112824](https://github.com/kubernetes/kubernetes/pull/112824), [@gjkim42](https://github.com/gjkim42)) [SIG Network and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2595-expanded-dns-config",
+        "type": "KEP"
+      }
+    ],
+    "author": "gjkim42",
+    "author_url": "https://github.com/gjkim42",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112824",
+    "pr_number": 112824,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["network", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112838": {
+    "commit": "af72ea5c07708039823fb28a9d741c647acb376d",
+    "text": "The LegacyServiceAccountTokenNoAutoGeneration feature gate has been promoted to GA",
+    "markdown": "The LegacyServiceAccountTokenNoAutoGeneration feature gate has been promoted to GA ([#112838](https://github.com/kubernetes/kubernetes/pull/112838), [@zshihang](https://github.com/zshihang)) [SIG API Machinery, Apps, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2799-reduction-of-secret-based-service-account-token",
+        "type": "KEP"
+      }
+    ],
+    "author": "zshihang",
+    "author_url": "https://github.com/zshihang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112838",
+    "pr_number": 112838,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112855": {
+    "commit": "d0e86111ef91615f3a17f860a2e9e6aa0c6a259a",
+    "text": "Add kubelet metrics to track the cpumanager cpu allocation and pinning",
+    "markdown": "Add kubelet metrics to track the cpumanager cpu allocation and pinning ([#112855](https://github.com/kubernetes/kubernetes/pull/112855), [@fromanirh](https://github.com/fromanirh)) [SIG Instrumentation, Node and Testing]",
+    "author": "fromanirh",
+    "author_url": "https://github.com/fromanirh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112855",
+    "pr_number": 112855,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112924": {
+    "commit": "b60176972182bc2a459e019bc039dfcffa2ff868",
+    "text": "Removing Windows Server, Version 20H2 flavors from various container images",
+    "markdown": "Removing Windows Server, Version 20H2 flavors from various container images ([#112924](https://github.com/kubernetes/kubernetes/pull/112924), [@marosset](https://github.com/marosset)) [SIG Testing and Windows]",
+    "author": "marosset",
+    "author_url": "https://github.com/marosset",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112924",
+    "pr_number": 112924,
+    "areas": ["test", "release-eng"],
+    "kinds": ["cleanup"],
+    "sigs": ["windows", "testing"],
+    "duplicate": true
+  },
+  "112939": {
+    "commit": "040d7aaafa7c0ec8509b2405e70df2c1b7b350af",
+    "text": "Change  `preemption_victims` metric bucket from `LinearBuckets` to `ExponentialBuckets`.",
+    "markdown": "Change  `preemption_victims` metric bucket from `LinearBuckets` to `ExponentialBuckets`. ([#112939](https://github.com/kubernetes/kubernetes/pull/112939), [@lengrongfu](https://github.com/lengrongfu)) [SIG Instrumentation and Scheduling]",
+    "author": "lengrongfu",
+    "author_url": "https://github.com/lengrongfu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112939",
+    "pr_number": 112939,
+    "areas": ["stable-metrics"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112948": {
+    "commit": "9bedff1147837118e1892c262992ccef42ea4041",
+    "text": "Fix the occasional double-counting of the job_finished_total metric",
+    "markdown": "Fix the occasional double-counting of the job_finished_total metric ([#112948](https://github.com/kubernetes/kubernetes/pull/112948), [@mimowo](https://github.com/mimowo)) [SIG Apps, Architecture, Instrumentation and Testing]",
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112948",
+    "pr_number": 112948,
+    "areas": ["test", "e2e-test-framework"],
+    "kinds": ["bug"],
+    "sigs": ["apps", "instrumentation", "testing", "architecture"],
+    "duplicate": true
+  },
+  "112978": {
+    "commit": "bd2417b4355e45e39df426be00743c07605171f9",
+    "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kube-controller-manager, allowing you to scrape health check metrics.",
+    "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kube-controller-manager, allowing you to scrape health check metrics. ([#112978](https://github.com/kubernetes/kubernetes/pull/112978), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery and Cloud Provider]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/3466", "type": "external" }
+    ],
+    "author": "logicalhan",
+    "author_url": "https://github.com/logicalhan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112978",
+    "pr_number": 112978,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112979": {
+    "commit": "859ada198f51a73d2ce48fafdf7ab9153e653f3b",
+    "text": "Fixed an issue where the APIServer would panic on startup if an egress selector without a controlplane configuration is specified when using APIServerTracing",
+    "markdown": "Fixed an issue where the APIServer would panic on startup if an egress selector without a controlplane configuration is specified when using APIServerTracing ([#112979](https://github.com/kubernetes/kubernetes/pull/112979), [@dashpole](https://github.com/dashpole)) [SIG API Machinery, Instrumentation and Testing]",
+    "author": "dashpole",
+    "author_url": "https://github.com/dashpole",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112979",
+    "pr_number": 112979,
+    "areas": ["test", "apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "instrumentation", "testing"],
+    "duplicate": true
+  },
+  "112980": {
+    "commit": "131704e71db6ea1b3e1febb02b23b576fc7a6f16",
+    "text": "Graduate Kubelet Device Manager to GA.",
+    "markdown": "Graduate Kubelet Device Manager to GA. ([#112980](https://github.com/kubernetes/kubernetes/pull/112980), [@swatisehgal](https://github.com/swatisehgal)) [SIG Cloud Provider and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3574",
+        "type": "KEP"
+      }
+    ],
+    "author": "swatisehgal",
+    "author_url": "https://github.com/swatisehgal",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112980",
+    "pr_number": 112980,
+    "areas": ["kubelet", "provider/gcp"],
+    "kinds": ["feature"],
+    "sigs": ["node", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "112989": {
+    "commit": "054d86feb42b67bb13608d9aa9a7c986750da753",
+    "text": "Updates golang.org/x/text to v0.3.8 to fix CVE-2022-32149",
+    "markdown": "Updates golang.org/x/text to v0.3.8 to fix CVE-2022-32149 ([#112989](https://github.com/kubernetes/kubernetes/pull/112989), [@ameukam](https://github.com/ameukam)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node and Storage]",
+    "author": "ameukam",
+    "author_url": "https://github.com/ameukam",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112989",
+    "pr_number": 112989,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["bug"],
+    "sigs": [
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "architecture",
+      "cloud-provider"
+    ],
+    "duplicate": true
+  },
+  "113005": {
+    "commit": "3b8cfefaee7bd10487db8e1a53b372496bb32d95",
+    "text": "kubeadm: command `kubeadm join phase control-plane-prepare certs` is now supporting to run with `dry-run` mode on it's own",
+    "markdown": "Kubeadm: command `kubeadm join phase control-plane-prepare certs` is now supporting to run with `dry-run` mode on it's own ([#113005](https://github.com/kubernetes/kubernetes/pull/113005), [@chendave](https://github.com/chendave)) [SIG Cluster Lifecycle]",
+    "author": "chendave",
+    "author_url": "https://github.com/chendave",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113005",
+    "pr_number": 113005,
+    "areas": ["kubeadm"],
+    "kinds": ["feature"],
+    "sigs": ["cluster-lifecycle"],
+    "feature": true
+  },
+  "113015": {
+    "commit": "52f5816b8b9ed030dd1ebc4baefc6527f74254ed",
+    "text": "kube-apiserver: custom resources can now be specified in the --encryption-provider-config file and can be encrypted in etcd",
+    "markdown": "Kube-apiserver: custom resources can now be specified in the --encryption-provider-config file and can be encrypted in etcd ([#113015](https://github.com/kubernetes/kubernetes/pull/113015), [@ritazh](https://github.com/ritazh)) [SIG API Machinery, Auth and Testing]",
+    "author": "ritazh",
+    "author_url": "https://github.com/ritazh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113015",
+    "pr_number": 113015,
+    "areas": ["test", "apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "duplicate": true
+  },
+  "113021": {
+    "commit": "2514486d80f7364b20da3c6b1e2013ad24d0e404",
+    "text": "kubelet: Fixes a startup crash in devicemanager",
+    "markdown": "Kubelet: Fixes a startup crash in devicemanager ([#113021](https://github.com/kubernetes/kubernetes/pull/113021), [@rphillips](https://github.com/rphillips)) [SIG Node]",
+    "author": "rphillips",
+    "author_url": "https://github.com/rphillips",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113021",
+    "pr_number": 113021,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "113026": {
+    "commit": "52b47dac4fe26644a91f44191ff7052b73c3afd7",
+    "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kube-scheduler, allowing you to scrape health check metrics.",
+    "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kube-scheduler, allowing you to scrape health check metrics. ([#113026](https://github.com/kubernetes/kubernetes/pull/113026), [@Richabanker](https://github.com/Richabanker)) [SIG Scheduling]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/3466", "type": "external" }
+    ],
+    "author": "Richabanker",
+    "author_url": "https://github.com/Richabanker",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113026",
+    "pr_number": 113026,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "113030": {
+    "commit": "047f6a736b1be1eb43d2941fe9d34f7c04684f2b",
+    "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kubelet, allowing you to scrape health check metrics.",
+    "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kubelet, allowing you to scrape health check metrics. ([#113030](https://github.com/kubernetes/kubernetes/pull/113030), [@Richabanker](https://github.com/Richabanker)) [SIG Node]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/3466", "type": "external" }
+    ],
+    "author": "Richabanker",
+    "author_url": "https://github.com/Richabanker",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113030",
+    "pr_number": 113030,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node"],
+    "feature": true
+  },
+  "113041": {
+    "commit": "843ad71cac98bcfff9f367a8ad90246cbc57d71c",
+    "text": "Fixed a bug where the kubelet chooses the wrong container by its name when running `kubectl exec`.",
+    "markdown": "Fixed a bug where the kubelet chooses the wrong container by its name when running `kubectl exec`. ([#113041](https://github.com/kubernetes/kubernetes/pull/113041), [@saschagrunert](https://github.com/saschagrunert)) [SIG Node]",
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113041",
+    "pr_number": 113041,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "113057": {
+    "commit": "b6e8dfec61c4080f9db8667cec11ba6f4a3bf4bf",
+    "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kube-proxy allowing you to scrape health check metrics.",
+    "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on kube-proxy allowing you to scrape health check metrics. ([#113057](https://github.com/kubernetes/kubernetes/pull/113057), [@Richabanker](https://github.com/Richabanker)) [SIG Network]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/3466", "type": "external" }
+    ],
+    "author": "Richabanker",
+    "author_url": "https://github.com/Richabanker",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113057",
+    "pr_number": 113057,
+    "kinds": ["feature"],
+    "sigs": ["network"],
+    "feature": true
+  },
+  "113113": {
+    "commit": "2b6abb1b333737edbd8e44015de4e2867b6118c9",
+    "text": "The metrics(time duration) of a failed or unschedulable scheduling attempt will be longer for\nit will include the duration time of the unreserve operation now.",
+    "markdown": "The metrics(time duration) of a failed or unschedulable scheduling attempt will be longer for\n  it will include the duration time of the unreserve operation now. ([#113113](https://github.com/kubernetes/kubernetes/pull/113113), [@kerthcet](https://github.com/kerthcet)) [SIG Scheduling]",
+    "author": "kerthcet",
+    "author_url": "https://github.com/kerthcet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113113",
+    "pr_number": 113113,
+    "kinds": ["bug"],
+    "sigs": ["scheduling"]
+  },
+  "113133": {
+    "commit": "615929ed889e7bf921798142ecdef9f87832da43",
+    "text": "kube-apiserver: DELETECOLLECTION API requests are now recorded in metrics with the correct verb.",
+    "markdown": "Kube-apiserver: DELETECOLLECTION API requests are now recorded in metrics with the correct verb. ([#113133](https://github.com/kubernetes/kubernetes/pull/113133), [@sxllwx](https://github.com/sxllwx)) [SIG API Machinery]",
+    "author": "sxllwx",
+    "author_url": "https://github.com/sxllwx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113133",
+    "pr_number": 113133,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113160": {
+    "commit": "2e059ff158bfdc209e42de5438eef8b6e0ea0089",
+    "text": "make Azure File CSI migration as GA in 1.26",
+    "markdown": "Make Azure File CSI migration as GA in 1.26 ([#113160](https://github.com/kubernetes/kubernetes/pull/113160), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113160",
+    "pr_number": 113160,
+    "areas": ["provider/azure"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "113172": {
+    "commit": "ae6dc598bd23c29480ce5ec426b75954dbd1b65b",
+    "text": "API Server Tracing now includes a variety of new spans and span events.",
+    "markdown": "API Server Tracing now includes a variety of new spans and span events. ([#113172](https://github.com/kubernetes/kubernetes/pull/113172), [@dashpole](https://github.com/dashpole)) [SIG API Machinery, Architecture, Auth, Instrumentation, Network, Node and Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/1954332075e9df9b51e1b04eecbb22537308f102/keps/sig-instrumentation/647-apiserver-tracing",
+        "type": "KEP"
+      }
+    ],
+    "author": "dashpole",
+    "author_url": "https://github.com/dashpole",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113172",
+    "pr_number": 113172,
+    "areas": ["kubelet", "apiserver"],
+    "kinds": ["feature"],
+    "sigs": [
+      "network",
+      "scheduling",
+      "node",
+      "api-machinery",
+      "auth",
+      "instrumentation",
+      "architecture"
+    ],
+    "feature": true,
+    "duplicate": true
+  },
+  "113176": {
+    "commit": "2313e2b8256000b3012d7bb4df2ecdf5fcf09604",
+    "text": "New metric job_controller_terminated_pods_tracking_finalizer can be used to monitor whether the job controller is removing Pod finalizers from terminated Pods after accounting them in Job status.",
+    "markdown": "New metric job_controller_terminated_pods_tracking_finalizer can be used to monitor whether the job controller is removing Pod finalizers from terminated Pods after accounting them in Job status. ([#113176](https://github.com/kubernetes/kubernetes/pull/113176), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[Usage]",
+        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-tracking-with-finalizers",
+        "type": "official"
+      }
+    ],
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113176",
+    "pr_number": 113176,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113206": {
+    "commit": "2f7b4ca6851aa3d479c9af3c14a168b4974f2fee",
+    "text": "Fix cost estimation of token creation request for service account in Priority and Fairness.",
+    "markdown": "Fix cost estimation of token creation request for service account in Priority and Fairness. ([#113206](https://github.com/kubernetes/kubernetes/pull/113206), [@marseel](https://github.com/marseel)) [SIG API Machinery]",
+    "author": "marseel",
+    "author_url": "https://github.com/marseel",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113206",
+    "pr_number": 113206,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113212": {
+    "commit": "dbb3b4f340d11ccc87a05a70af1c2f327b5f4815",
+    "text": "The e2e.test binary no longer emits JSON structs to document progress.",
+    "markdown": "The e2e.test binary no longer emits JSON structs to document progress. ([#113212](https://github.com/kubernetes/kubernetes/pull/113212), [@pohly](https://github.com/pohly)) [SIG Testing]",
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113212",
+    "pr_number": 113212,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": ["testing"]
+  },
+  "113304": {
+    "commit": "3c9928e4f87c1d023e595292e6139cbd8dfedd5c",
+    "text": "The `kube-scheduler` and `kube-controller-manager` now use server side apply to set conditions related to pod disruption.",
+    "markdown": "The `kube-scheduler` and `kube-controller-manager` now use server side apply to set conditions related to pod disruption. ([#113304](https://github.com/kubernetes/kubernetes/pull/113304), [@mimowo](https://github.com/mimowo)) [SIG API Machinery, Apps and Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures",
+        "type": "KEP"
+      }
+    ],
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113304",
+    "pr_number": 113304,
+    "kinds": ["bug", "cleanup"],
+    "sigs": ["scheduling", "api-machinery", "apps"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113310": {
+    "commit": "19ab5b69108172a1c1725a23fdf4e30eba4ff629",
+    "text": "The metric `etcd_db_total_size_in_bytes` is renamed to `apiserver_storage_db_total_size_in_bytes`.",
+    "markdown": "The metric `etcd_db_total_size_in_bytes` is renamed to `apiserver_storage_db_total_size_in_bytes`. ([#113310](https://github.com/kubernetes/kubernetes/pull/113310), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery]",
+    "author": "logicalhan",
+    "author_url": "https://github.com/logicalhan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113310",
+    "pr_number": 113310,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"]
+  },
+  "113323": {
+    "commit": "ca03736670550056e74b1241790286e1d8a574f2",
+    "text": "Metrics for RetroactiveDefaultStorageClass feature are now available. To see an attempt count for updating PVC retroactively with a default StorageClass see `retroactive_storageclass_total` metric and for total numer of errors see `retroactive_storageclass_errors_total`.",
+    "markdown": "Metrics for RetroactiveDefaultStorageClass feature are now available. To see an attempt count for updating PVC retroactively with a default StorageClass see `retroactive_storageclass_total` metric and for total numer of errors see `retroactive_storageclass_errors_total`. ([#113323](https://github.com/kubernetes/kubernetes/pull/113323), [@RomanBednar](https://github.com/RomanBednar)) [SIG Apps]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3333",
+        "type": "KEP"
+      }
+    ],
+    "author": "RomanBednar",
+    "author_url": "https://github.com/RomanBednar",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113323",
+    "pr_number": 113323,
+    "kinds": ["feature"],
+    "sigs": ["apps"],
+    "feature": true
+  },
+  "113324": {
+    "commit": "3628532311d9e4cd2cf269dd2a7591f5e3387fb0",
+    "text": "Extend the job `job_finished_total metric by new `reason` label and introduce a new job metric to count pod failures\nhandled by pod failure policy with respect to the action applied.",
+    "markdown": "Extend the job `job_finished_total metric by new `reason` label and introduce a new job metric to count pod failures\n  handled by pod failure policy with respect to the action applied. ([#113324](https://github.com/kubernetes/kubernetes/pull/113324), [@mimowo](https://github.com/mimowo)) [SIG Apps and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures",
+        "type": "KEP"
+      }
+    ],
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113324",
+    "pr_number": 113324,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113340": {
+    "commit": "187a340e65f073c86f446355cc0d6be0e60df0c3",
+    "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on cloud-controller-manager allowing you to scrape health check metrics.",
+    "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` becomes available on cloud-controller-manager allowing you to scrape health check metrics. ([#113340](https://github.com/kubernetes/kubernetes/pull/113340), [@Richabanker](https://github.com/Richabanker)) [SIG Cloud Provider]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/3466", "type": "external" }
+    ],
+    "author": "Richabanker",
+    "author_url": "https://github.com/Richabanker",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113340",
+    "pr_number": 113340,
+    "areas": ["cloudprovider"],
+    "kinds": ["feature"],
+    "sigs": ["cloud-provider"],
+    "feature": true
+  },
+  "113363": {
+    "commit": "8c77295db84d8f19c06b5afbfd475cfd11a834ae",
+    "text": "The ProxyTerminatingEndpoints feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is Local and there are only terminating pods remaining on a node.",
+    "markdown": "The ProxyTerminatingEndpoints feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is Local and there are only terminating pods remaining on a node. ([#113363](https://github.com/kubernetes/kubernetes/pull/113363), [@andrewsykim](https://github.com/andrewsykim)) [SIG Network]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113363",
+    "pr_number": 113363,
+    "kinds": ["feature"],
+    "sigs": ["network"],
+    "feature": true
+  },
+  "113369": {
+    "commit": "bbcf5e38776f2b18026539a0fbcf3aa505386c1f",
+    "text": "The resourceVersion returned in objects from delete responses is now consistent with the resourceVersion contained in the delete watch event",
+    "markdown": "The resourceVersion returned in objects from delete responses is now consistent with the resourceVersion contained in the delete watch event ([#113369](https://github.com/kubernetes/kubernetes/pull/113369), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113369",
+    "pr_number": 113369,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "113448": {
+    "commit": "ac59b03214807ef0319c052a02693f077ee88083",
+    "text": "kubeadm: remove the UnversionedKubeletConfigMap feature gate. The feature has been GA and locked to enabled since 1.25.",
+    "markdown": "Kubeadm: remove the UnversionedKubeletConfigMap feature gate. The feature has been GA and locked to enabled since 1.25. ([#113448](https://github.com/kubernetes/kubernetes/pull/113448), [@pacoxu](https://github.com/pacoxu)) [SIG Cluster Lifecycle]",
+    "documentation": [
+      { "description": "[KEP]", "url": "https://kep.k8s.io/2915", "type": "external" }
+    ],
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113448",
+    "pr_number": 113448,
+    "areas": ["kubeadm"],
+    "kinds": ["cleanup"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "113491": {
+    "commit": "0574a8181de2438affef15e9dc7c42a49b10198c",
+    "text": "Pod Security admission: the pod-security `warn` level will now default to the `enforce` level.",
+    "markdown": "Pod Security admission: the pod-security `warn` level will now default to the `enforce` level. ([#113491](https://github.com/kubernetes/kubernetes/pull/113491), [@tallclair](https://github.com/tallclair)) [SIG Auth and Security]",
+    "author": "tallclair",
+    "author_url": "https://github.com/tallclair",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113491",
+    "pr_number": 113491,
+    "kinds": ["feature"],
+    "sigs": ["auth", "security"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113500": {
+    "commit": "8d78b37d842a53f39f416675d5c638b90539619d",
+    "text": "NodeInclusionPolicy in podTopologySpread plugin is enabled by default.",
+    "markdown": "NodeInclusionPolicy in podTopologySpread plugin is enabled by default. ([#113500](https://github.com/kubernetes/kubernetes/pull/113500), [@kerthcet](https://github.com/kerthcet)) [SIG API Machinery, Apps, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/issues/3094",
+        "type": "KEP"
+      }
+    ],
+    "author": "kerthcet",
+    "author_url": "https://github.com/kerthcet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113500",
+    "pr_number": 113500,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113521": {
+    "commit": "dc2fc1045da1d270dc5f1131b584bd2c095fae04",
+    "text": "Resolves an issue that causes winkernel proxier to treat stale VIPs as valid",
+    "markdown": "Resolves an issue that causes winkernel proxier to treat stale VIPs as valid ([#113521](https://github.com/kubernetes/kubernetes/pull/113521), [@daschott](https://github.com/daschott)) [SIG Network and Windows]",
+    "author": "daschott",
+    "author_url": "https://github.com/daschott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113521",
+    "pr_number": 113521,
+    "kinds": ["bug"],
+    "sigs": ["network", "windows"],
+    "duplicate": true
+  },
+  "86139": {
+    "commit": "ad26b315f230ab0b1ce0ed3afed3f9569bff8457",
+    "text": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#86139](https://github.com/kubernetes/kubernetes/pull/86139), [@jasimmons](https://github.com/jasimmons)) [SIG API Machinery, Apps, Architecture, Auth, Autoscaling, CLI, Contributor Experience, Instrumentation, Network, Node, Release, Scheduling, Storage and Testing]",
+    "author": "jasimmons",
+    "author_url": "https://github.com/jasimmons",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/86139",
+    "pr_number": 86139,
+    "areas": [
+      "test",
+      "kubelet",
+      "apiserver",
+      "kubectl",
+      "cloudprovider",
+      "provider/gcp",
+      "release-eng",
+      "conformance",
+      "ipvs",
+      "e2e-test-framework",
+      "dependency"
+    ],
+    "kinds": ["bug", "api-change"],
+    "sigs": [
+      "network",
+      "scheduling",
+      "storage",
+      "node",
+      "api-machinery",
+      "autoscaling",
+      "contributor-experience",
+      "auth",
+      "apps",
+      "cli",
+      "instrumentation",
+      "testing",
+      "release",
+      "architecture"
+    ],
+    "duplicate": true,
+    "duplicate_kind": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.26.0-alpha.3.json',
   'assets/release-notes-1.26.0-beta.0.json',
   'assets/release-notes-1.26.0-alpha.2.json',
   'assets/release-notes-1.24.0.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.26.0-alpha.3` 