### PR TITLE
Patch relnotes.k8s.io to release v1.26.0

### DIFF
--- a/src/assets/release-notes-1.26.0.json
+++ b/src/assets/release-notes-1.26.0.json
@@ -1,6 +1,6 @@
 {
   "103177": {
-    "commit": "3cf75a2f760b8093f7c97f26b4b2b059f3777bec",
+    "commit": "86e5d069ecece8591ad693b50bcea49000f6df26",
     "text": "Added a method `StreamWithContext` to `remotecommand.Executor` to support cancelable SPDY executor stream.",
     "markdown": "Added a method `StreamWithContext` to `remotecommand.Executor` to support cancelable SPDY executor stream. ([#103177](https://github.com/kubernetes/kubernetes/pull/103177), [@arkbriar](https://github.com/arkbriar))",
     "author": "arkbriar",
@@ -90,7 +90,7 @@
     "duplicate_kind": true
   },
   "108501": {
-    "commit": "1cefcdea2d6195a794ef122cb7a36614a580d41b",
+    "commit": "85643c0f93064ad9f9bcd9303972d8308734d269",
     "text": "Enabled `kube-controller-manager` to support '--concurrent-horizontal-pod-autoscaler-syncs' flag to set the number of horizontal pod autoscaler controller workers.",
     "markdown": "Enabled `kube-controller-manager` to support '--concurrent-horizontal-pod-autoscaler-syncs' flag to set the number of horizontal pod autoscaler controller workers. ([#108501](https://github.com/kubernetes/kubernetes/pull/108501), [@zroubalik](https://github.com/zroubalik))",
     "author": "zroubalik",
@@ -171,6 +171,20 @@
     "duplicate": true,
     "duplicate_kind": true
   },
+  "109877": {
+    "commit": "380c7f248e4ecc2a104b11652b6171ab65501cba",
+    "text": "scheduler volumebinding: leverage PreFilterResult to reduce down to only eligible node(s) for pod with bound claim(s) to local PersistentVolume(s)",
+    "markdown": "Scheduler volumebinding: leverage PreFilterResult to reduce down to only eligible node(s) for pod with bound claim(s) to local PersistentVolume(s) ([#109877](https://github.com/kubernetes/kubernetes/pull/109877), [@yibozhuang](https://github.com/yibozhuang)) [SIG Scheduling, Storage and Testing]",
+    "author": "yibozhuang",
+    "author_url": "https://github.com/yibozhuang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/109877",
+    "pr_number": 109877,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
   "110268": {
     "commit": "3edbebe3488ccb085826d7a3a6d225101ff11ee6",
     "text": "'The iptables kube-proxy backend now process service/endpoint changes\nmore efficiently in very large clusters.'",
@@ -184,19 +198,6 @@
     "sigs": ["network", "instrumentation"],
     "feature": true,
     "duplicate": true
-  },
-  "110498": {
-    "commit": "cf4d2cc545f62fcfd748a084dff7744f9402bf57",
-    "text": "\"NONE\"",
-    "markdown": "\"NONE\" ([#110498](https://github.com/kubernetes/kubernetes/pull/110498), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG Release]",
-    "author": "yangjunmyfm192085",
-    "author_url": "https://github.com/yangjunmyfm192085",
-    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110498",
-    "pr_number": 110498,
-    "areas": ["release-eng"],
-    "kinds": ["cleanup"],
-    "sigs": ["release"],
-    "do_not_publish": true
   },
   "110559": {
     "commit": "962235c86a1a934fc759be1d3fd3a764fa2efa18",
@@ -224,18 +225,16 @@
     "sigs": ["node", "security"],
     "duplicate": true
   },
-  "110695": {
-    "commit": "5ade6c833fdde89618791b130bd2e9cad9519842",
-    "text": "NONE",
-    "markdown": "NONE ([#110695](https://github.com/kubernetes/kubernetes/pull/110695), [@lokichoggio](https://github.com/lokichoggio)) [SIG Apps and Autoscaling]",
-    "author": "lokichoggio",
-    "author_url": "https://github.com/lokichoggio",
-    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110695",
-    "pr_number": 110695,
+  "110723": {
+    "commit": "856146e67e9343038ab7403d81ad10e8c32869a2",
+    "text": "Fix incorrect log information",
+    "markdown": "Fix incorrect log information ([#110723](https://github.com/kubernetes/kubernetes/pull/110723), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG Network]",
+    "author": "yangjunmyfm192085",
+    "author_url": "https://github.com/yangjunmyfm192085",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110723",
+    "pr_number": 110723,
     "kinds": ["cleanup"],
-    "sigs": ["autoscaling", "apps"],
-    "duplicate": true,
-    "do_not_publish": true
+    "sigs": ["network"]
   },
   "110907": {
     "commit": "20a9f7786aa4ee0b6e1619c7974ea4562d2b2500",
@@ -250,7 +249,7 @@
     "sigs": ["cli"]
   },
   "110972": {
-    "commit": "71ef1ea68df05cafaabd59d8cf486ace5baeebf5",
+    "commit": "891cbede96ab4b64c48edf25f8bbd331d8731622",
     "text": "Kubeadm will cleanup the stale data on best effort basis. Stale data will be removed when each reset phase are executed, default etcd data directory will be cleanup when the `remove-etcd-member` phase are executed.",
     "markdown": "Kubeadm will cleanup the stale data on best effort basis. Stale data will be removed when each reset phase are executed, default etcd data directory will be cleanup when the `remove-etcd-member` phase are executed. ([#110972](https://github.com/kubernetes/kubernetes/pull/110972), [@chendave](https://github.com/chendave)) [SIG Cluster Lifecycle]",
     "author": "chendave",
@@ -337,7 +336,7 @@
     "duplicate_kind": true
   },
   "111277": {
-    "commit": "749256e9c26f21257668694e5b3503e482d3668b",
+    "commit": "2b2be7fa6b69c7591a31475fc4fb1dcff362a128",
     "text": "kubeadm: when a sub command is needed but not provided for a kubeadm command, print a help screen instead of showing a short message.",
     "markdown": "Kubeadm: when a sub command is needed but not provided for a kubeadm command, print a help screen instead of showing a short message. ([#111277](https://github.com/kubernetes/kubernetes/pull/111277), [@chymy](https://github.com/chymy))",
     "author": "chymy",
@@ -350,7 +349,7 @@
     "duplicate_kind": true
   },
   "111333": {
-    "commit": "00dfba473b08528f0a21f7bd3b921f5dd35b013a",
+    "commit": "4e8b11d4411cefbe1a32cf9e54810d9e0bd7378e",
     "text": "Add auth API to get self subject attributes (new selfsubjectreviews API is added). \nThe corresponding command for kubctl is provided - `kubectl auth whoami`.",
     "markdown": "Add auth API to get self subject attributes (new selfsubjectreviews API is added). \n  The corresponding command for kubctl is provided - `kubectl auth whoami`. ([#111333](https://github.com/kubernetes/kubernetes/pull/111333), [@nabokihms](https://github.com/nabokihms)) [SIG API Machinery, Auth, CLI and Testing]",
     "documentation": [
@@ -471,8 +470,21 @@
     "kinds": ["bug"],
     "sigs": ["cli"]
   },
+  "111583": {
+    "commit": "6a57404e280a4156ad3ff940b7f435e049f37918",
+    "text": "NONE",
+    "markdown": "NONE ([#111583](https://github.com/kubernetes/kubernetes/pull/111583), [@arrowfeng](https://github.com/arrowfeng)) [SIG Node]",
+    "author": "arrowfeng",
+    "author_url": "https://github.com/arrowfeng",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111583",
+    "pr_number": 111583,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
   "111616": {
-    "commit": "6f579d3cebe91825dd7dc4c9f9e1474939735bc9",
+    "commit": "875920037a072ec9b34d598795a69f5c3ea8eaa3",
     "text": "Kubelet external Credential Provider feature is moved to GA. Credential Provider Plugin and Credential Provider Config APIs updated from `v1beta1` to `v1` with no API changes.",
     "markdown": "Kubelet external Credential Provider feature is moved to GA. Credential Provider Plugin and Credential Provider Config APIs updated from `v1beta1` to `v1` with no API changes. ([#111616](https://github.com/kubernetes/kubernetes/pull/111616), [@ndixita](https://github.com/ndixita))",
     "documentation": [
@@ -492,7 +504,7 @@
     "duplicate": true
   },
   "111708": {
-    "commit": "2db4dea56544cf1c2aaea4f4af10636f7ae2f8e4",
+    "commit": "f6f44bff9099d8ae8bead38e6ffc1794bded4162",
     "text": "release-note",
     "markdown": "Release-note ([#111708](https://github.com/kubernetes/kubernetes/pull/111708), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG Apps, Instrumentation and Network]",
     "author": "yangjunmyfm192085",
@@ -554,6 +566,17 @@
     "sigs": ["cluster-lifecycle"],
     "feature": true
   },
+  "111802": {
+    "commit": "a7967073969e200ca82eca17ea999de899a66184",
+    "text": "LabelSelectors specified in topologySpreadConstraints are now validated to ensure that pod is scheduled as expected. Existing pods with invalid LabelSelectors can be updated, but new pods are required to specify valid LabelSelectors.",
+    "markdown": "LabelSelectors specified in topologySpreadConstraints are now validated to ensure that pod is scheduled as expected. Existing pods with invalid LabelSelectors can be updated, but new pods are required to specify valid LabelSelectors. ([#111802](https://github.com/kubernetes/kubernetes/pull/111802), [@maaoBit](https://github.com/maaoBit)) [SIG Apps]",
+    "author": "maaoBit",
+    "author_url": "https://github.com/maaoBit",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111802",
+    "pr_number": 111802,
+    "kinds": ["bug"],
+    "sigs": ["apps"]
+  },
   "111806": {
     "commit": "da112dda68b7b323737742fb24844775a1356722",
     "text": "kube-proxy no longer falls back from ipvs mode to iptables mode if you ask it to do ipvs but the system is not correctly configured. Instead, it will just exit with an error.",
@@ -614,8 +637,21 @@
     "kinds": ["bug"],
     "sigs": ["api-machinery"]
   },
+  "111879": {
+    "commit": "886da71e7588c198dcb9a6c7cccfedb478110e57",
+    "text": "\"NONE\"",
+    "markdown": "\"NONE\" ([#111879](https://github.com/kubernetes/kubernetes/pull/111879), [@sanwishe](https://github.com/sanwishe)) [SIG API Machinery]",
+    "author": "sanwishe",
+    "author_url": "https://github.com/sanwishe",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111879",
+    "pr_number": 111879,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"],
+    "do_not_publish": true
+  },
   "111910": {
-    "commit": "ce65b712f896c9a41c1eae39904593af39911805",
+    "commit": "bf2e850b3a90bc941587a74b53a9dd47aca4fb66",
     "text": "Added new Golang runtime-related metrics to Kubernetes components:\n- go_gc_cycles_automatic_gc_cycles_total\n- go_gc_cycles_forced_gc_cycles_total\n- go_gc_cycles_total_gc_cycles_total\n- go_gc_heap_allocs_by_size_bytes\n- go_gc_heap_allocs_bytes_total\n- go_gc_heap_allocs_objects_total\n- go_gc_heap_frees_by_size_bytes\n- go_gc_heap_frees_bytes_total\n- go_gc_heap_frees_objects_total\n- go_gc_heap_goal_bytes\n- go_gc_heap_objects_objects\n- go_gc_heap_tiny_allocs_objects_total\n- go_gc_pauses_seconds\n- go_memory_classes_heap_free_bytes\n- go_memory_classes_heap_objects_bytes\n- go_memory_classes_heap_released_bytes\n- go_memory_classes_heap_stacks_bytes\n- go_memory_classes_heap_unused_bytes\n- go_memory_classes_metadata_mcache_free_bytes\n- go_memory_classes_metadata_mcache_inuse_bytes\n- go_memory_classes_metadata_mspan_free_bytes\n- go_memory_classes_metadata_mspan_inuse_bytes\n- go_memory_classes_metadata_other_bytes\n- go_memory_classes_os_stacks_bytes\n- go_memory_classes_other_bytes\n- go_memory_classes_profiling_buckets_bytes\n- go_memory_classes_total_bytes\n- go_sched_goroutines_goroutines\n- go_sched_latencies_seconds",
     "markdown": "Added new Golang runtime-related metrics to Kubernetes components:\n  - go_gc_cycles_automatic_gc_cycles_total\n  - go_gc_cycles_forced_gc_cycles_total\n  - go_gc_cycles_total_gc_cycles_total\n  - go_gc_heap_allocs_by_size_bytes\n  - go_gc_heap_allocs_bytes_total\n  - go_gc_heap_allocs_objects_total\n  - go_gc_heap_frees_by_size_bytes\n  - go_gc_heap_frees_bytes_total\n  - go_gc_heap_frees_objects_total\n  - go_gc_heap_goal_bytes\n  - go_gc_heap_objects_objects\n  - go_gc_heap_tiny_allocs_objects_total\n  - go_gc_pauses_seconds\n  - go_memory_classes_heap_free_bytes\n  - go_memory_classes_heap_objects_bytes\n  - go_memory_classes_heap_released_bytes\n  - go_memory_classes_heap_stacks_bytes\n  - go_memory_classes_heap_unused_bytes\n  - go_memory_classes_metadata_mcache_free_bytes\n  - go_memory_classes_metadata_mcache_inuse_bytes\n  - go_memory_classes_metadata_mspan_free_bytes\n  - go_memory_classes_metadata_mspan_inuse_bytes\n  - go_memory_classes_metadata_other_bytes\n  - go_memory_classes_os_stacks_bytes\n  - go_memory_classes_other_bytes\n  - go_memory_classes_profiling_buckets_bytes\n  - go_memory_classes_total_bytes\n  - go_sched_goroutines_goroutines\n  - go_sched_latencies_seconds ([#111910](https://github.com/kubernetes/kubernetes/pull/111910), [@tosi3k](https://github.com/tosi3k))",
     "author": "tosi3k",
@@ -629,7 +665,7 @@
     "duplicate": true
   },
   "111930": {
-    "commit": "8a5fbce96e7c255d3cf8d2f15a83f6746c5c1d1a",
+    "commit": "1bf4af4584234741ed7ffeea5eda3ec1127aa335",
     "text": "Added the metric `pod_start_sli_duration_seconds` to kubelet.",
     "markdown": "Added the metric `pod_start_sli_duration_seconds` to kubelet. ([#111930](https://github.com/kubernetes/kubernetes/pull/111930), [@azylinski](https://github.com/azylinski))",
     "author": "azylinski",
@@ -668,7 +704,7 @@
     "action_required": true
   },
   "111998": {
-    "commit": "7eb472246fa225abf690f2ed2792c1c062313884",
+    "commit": "d9f21e55df4cd95f5e6c9ea1d7109a2a767920fb",
     "text": "e2e: tests can now register callbacks with `ginkgo.BeforeEach`, `ginkgo.AfterEach` or `ginkgo.DeferCleanup` directly after creating a framework instance and are guaranteed that their code is called after the framework is initialized and before it gets cleaned up. `ginkgo.DeferCleanup` replaces `f.AddAfterEach` and `AddCleanupAction` which got removed to simplify the framework.",
     "markdown": "E2e: tests can now register callbacks with `ginkgo.BeforeEach`, `ginkgo.AfterEach` or `ginkgo.DeferCleanup` directly after creating a framework instance and are guaranteed that their code is called after the framework is initialized and before it gets cleaned up. `ginkgo.DeferCleanup` replaces `f.AddAfterEach` and `AddCleanupAction` which got removed to simplify the framework. ([#111998](https://github.com/kubernetes/kubernetes/pull/111998), [@pohly](https://github.com/pohly))",
     "author": "pohly",
@@ -681,7 +717,7 @@
     "duplicate": true
   },
   "111999": {
-    "commit": "e61c16cc958f3a832be9071fdc0455c2bc9d9ecf",
+    "commit": "04f8a5c41a0e8716543415238098aa3d3054ab67",
     "text": "Pod failed in scheduling due to expected error will be updated with the reason of `SchedulerError` rather than `Unschedulable`.",
     "markdown": "Pod failed in scheduling due to expected error will be updated with the reason of `SchedulerError` rather than `Unschedulable`. ([#111999](https://github.com/kubernetes/kubernetes/pull/111999), [@kerthcet](https://github.com/kerthcet))",
     "author": "kerthcet",
@@ -719,7 +755,7 @@
     "duplicate": true
   },
   "112008": {
-    "commit": "04e0c6c1609906694ff8803ec99a93158df56fe5",
+    "commit": "50097acf156f8942d01301619603c61765dbf646",
     "text": "kubeadm: removed the toleration for the `node-role.kubernetes.io/master` taint from the CoreDNS deployment of `kubeadm`. With the 1.25 release of kubeadm the taint `node-role.kubernetes.io/master` is no longer applied to control plane nodes and the toleration for it can be removed with the release of 1.26. You can also perform the same toleration removal from your own addon manifests.",
     "markdown": "Kubeadm: removed the toleration for the `node-role.kubernetes.io/master` taint from the CoreDNS deployment of `kubeadm`. With the 1.25 release of kubeadm the taint `node-role.kubernetes.io/master` is no longer applied to control plane nodes and the toleration for it can be removed with the release of 1.26. You can also perform the same toleration removal from your own addon manifests. ([#112008](https://github.com/kubernetes/kubernetes/pull/112008), [@pacoxu](https://github.com/pacoxu))",
     "author": "pacoxu",
@@ -744,7 +780,7 @@
     "duplicate": true
   },
   "112015": {
-    "commit": "ee94dce5b179923e362356a62738fa1de06c62b6",
+    "commit": "d2f11fe7f924f88d123883f73d59e7ca5768372f",
     "text": "`GlusterFS` in-tree storage driver which was deprecated in kubernetes 1.25 release is now removed entirely in 1.26.",
     "markdown": "`GlusterFS` in-tree storage driver which was deprecated in kubernetes 1.25 release is now removed entirely in 1.26. ([#112015](https://github.com/kubernetes/kubernetes/pull/112015), [@humblec](https://github.com/humblec))",
     "author": "humblec",
@@ -774,6 +810,19 @@
     "pr_number": 112017,
     "kinds": ["bug"],
     "sigs": ["api-machinery", "auth"],
+    "duplicate": true
+  },
+  "112021": {
+    "commit": "65e693eccbc97192c7c96b88b4b446a3ed5f5efc",
+    "text": "Fix SELinux label for host path volumes created by host path provisioner",
+    "markdown": "Fix SELinux label for host path volumes created by host path provisioner ([#112021](https://github.com/kubernetes/kubernetes/pull/112021), [@mrunalp](https://github.com/mrunalp)) [SIG Node and Storage]",
+    "author": "mrunalp",
+    "author_url": "https://github.com/mrunalp",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112021",
+    "pr_number": 112021,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["storage", "node"],
     "duplicate": true
   },
   "112026": {
@@ -842,7 +891,7 @@
     "sigs": ["api-machinery"]
   },
   "112058": {
-    "commit": "0ed8dd211af7234b0ed244baa9a65ecb071096be",
+    "commit": "ac868b17d638a427ca3f9510aa5ab9b6731a6e48",
     "text": "Updated `cri-tools` to [v1.25.0(https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.25.0)",
     "markdown": "Updated `cri-tools` to [v1.25.0(https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.25.0) ([#112058](https://github.com/kubernetes/kubernetes/pull/112058), [@saschagrunert](https://github.com/saschagrunert))",
     "author": "saschagrunert",
@@ -894,7 +943,7 @@
     "duplicate_kind": true
   },
   "112123": {
-    "commit": "d0f9e6dc36fb0f6cfff95988e27eb3796c4e6bce",
+    "commit": "74469ca4c5cf30fc15826d6682d31ea2819c9cf2",
     "text": "Clarified the CFS quota as 100ms in the code comments and set the minimum `cpuCFSQuotaPeriod` to 1ms to match Linux kernel expectations.",
     "markdown": "Clarified the CFS quota as 100ms in the code comments and set the minimum `cpuCFSQuotaPeriod` to 1ms to match Linux kernel expectations. ([#112123](https://github.com/kubernetes/kubernetes/pull/112123), [@paskal](https://github.com/paskal))",
     "author": "paskal",
@@ -922,8 +971,8 @@
   },
   "112133": {
     "commit": "6705015101d9572157325ddf237ff65c5efb3cef",
-    "text": "In 'kube-proxy`: The \"userspace\" proxy mode (deprecated for over a year) is no\nlonger supported on either Linux or Windows. Users should use \"iptables\" or \"ipvs\"\non Linux, or \"kernelspace\" on Windows.\n",
-    "markdown": "In 'kube-proxy`: The \"userspace\" proxy mode (deprecated for over a year) is no\n  longer supported on either Linux or Windows. Users should use \"iptables\" or \"ipvs\"\n  on Linux, or \"kernelspace\" on Windows.\n   ([#112133](https://github.com/kubernetes/kubernetes/pull/112133), [@knabben](https://github.com/knabben))",
+    "text": "In `kube-proxy`: The \"userspace\" proxy mode (deprecated for over a year) is no\nlonger supported on either Linux or Windows. Users should use \"iptables\" or \"ipvs\"\non Linux, or \"kernelspace\" on Windows.\n",
+    "markdown": "In `kube-proxy`: The \"userspace\" proxy mode (deprecated for over a year) is no\n  longer supported on either Linux or Windows. Users should use \"iptables\" or \"ipvs\"\n  on Linux, or \"kernelspace\" on Windows.\n   ([#112133](https://github.com/kubernetes/kubernetes/pull/112133), [@knabben](https://github.com/knabben))",
     "author": "knabben",
     "author_url": "https://github.com/knabben",
     "pr_url": "https://github.com/kubernetes/kubernetes/pull/112133",
@@ -1076,7 +1125,7 @@
     "feature": true
   },
   "112243": {
-    "commit": "eae2c424efd9dda8cb0f5ba01ab4c955cdf42cfa",
+    "commit": "67bde9a1023d1805e33d698b28aa6fad991dfb39",
     "text": "Added back unused flags on `kubectl run` command, which did not go through the required deprecation period before being removed.",
     "markdown": "Added back unused flags on `kubectl run` command, which did not go through the required deprecation period before being removed. ([#112243](https://github.com/kubernetes/kubernetes/pull/112243), [@brianpursley](https://github.com/brianpursley))",
     "author": "brianpursley",
@@ -1098,6 +1147,19 @@
     "kinds": ["cleanup"],
     "sigs": ["scheduling"]
   },
+  "112260": {
+    "commit": "b501d6036aa1593ad44e2f1b734307ec76fda6f3",
+    "text": "New metrics `cidrset_cidrs_max_total` and `multicidrset_cidrs_max_total` expose the max number of CIDRs that can be allocated.",
+    "markdown": "New metrics `cidrset_cidrs_max_total` and `multicidrset_cidrs_max_total` expose the max number of CIDRs that can be allocated. ([#112260](https://github.com/kubernetes/kubernetes/pull/112260), [@aryan9600](https://github.com/aryan9600)) [SIG Apps, Instrumentation and Network]",
+    "author": "aryan9600",
+    "author_url": "https://github.com/aryan9600",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112260",
+    "pr_number": 112260,
+    "kinds": ["feature"],
+    "sigs": ["network", "apps", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
   "112261": {
     "commit": "3e8c848cfce00a9ac80a0b2a44dbc671891a33ef",
     "text": "Deprecated the following kubectl run flags, which are ignored if set: `--cascade`, `--filename`, `--force`, `--grace-period`, `--kustomize`, `--recursive`, `--timeout`, `--wait`.",
@@ -1111,7 +1173,7 @@
     "sigs": ["cli"]
   },
   "112267": {
-    "commit": "b3a28d17fd53b694db8a10d7e113807325afd084",
+    "commit": "9cd6331f9584dae9db803e01249c87c7697711de",
     "text": "Updated creation of `LoadBalancer` services, for there to be fewer AWS security group rules in most cases.",
     "markdown": "Updated creation of `LoadBalancer` services, for there to be fewer AWS security group rules in most cases. ([#112267](https://github.com/kubernetes/kubernetes/pull/112267), [@sjenning](https://github.com/sjenning))",
     "author": "sjenning",
@@ -1137,7 +1199,7 @@
     "duplicate": true
   },
   "112299": {
-    "commit": "8287e21228e9b1c945d031581e2fc63920f46d56",
+    "commit": "7cd5e6597e7137aa3b37a7c7ade2bf831cb7aca9",
     "text": "kube-apiserver: `gzip` compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits.",
     "markdown": "Kube-apiserver: `gzip` compression switched from level 4 to level 1 to improve large list call latencies in exchange for higher network bandwidth usage (10-50% higher). This increases the headroom before very large unpaged list calls exceed request timeout limits. ([#112299](https://github.com/kubernetes/kubernetes/pull/112299), [@shyamjvs](https://github.com/shyamjvs))",
     "documentation": [
@@ -1172,7 +1234,7 @@
     "duplicate_kind": true
   },
   "112309": {
-    "commit": "f9c46a0e3361e19de93c02562fedfff7de448dc2",
+    "commit": "ed520f3cac2243cd5f66967e2c590caf1e98b9e2",
     "text": "A new `DisableCompression` field (default = `false`) has been added to kubeconfig under cluster info. When set to `true`, clients using the kubeconfig opt out of response compression for all requests to the apiserver. This can help improve list call latencies significantly when client-server network bandwidth is ample (\u003e30MB/s) or if the server is CPU-constrained.",
     "markdown": "A new `DisableCompression` field (default = `false`) has been added to kubeconfig under cluster info. When set to `true`, clients using the kubeconfig opt out of response compression for all requests to the apiserver. This can help improve list call latencies significantly when client-server network bandwidth is ample (\u003e30MB/s) or if the server is CPU-constrained. ([#112309](https://github.com/kubernetes/kubernetes/pull/112309), [@shyamjvs](https://github.com/shyamjvs))",
     "author": "shyamjvs",
@@ -1212,7 +1274,7 @@
     "duplicate": true
   },
   "112357": {
-    "commit": "3e5e5cc7ee8331c4b8ee41291eef36ff67c3a911",
+    "commit": "bc9c4943193078378aa83912ef9b741e81c7e903",
     "text": "kube-scheduler: added taints filtering logic consistent with `TaintToleration` plugin for `PodTopologySpread` plugin.",
     "markdown": "Kube-scheduler: added taints filtering logic consistent with `TaintToleration` plugin for `PodTopologySpread` plugin. ([#112357](https://github.com/kubernetes/kubernetes/pull/112357), [@SataQiu](https://github.com/SataQiu))",
     "author": "SataQiu",
@@ -1285,7 +1347,7 @@
     "sigs": ["storage"]
   },
   "112414": {
-    "commit": "3bbd025982be4c530b0187485760164921c57da5",
+    "commit": "4276ed36282405d026d8072e0ebed4f1da49070d",
     "text": "kubelet: when there are multi option lines in /etc/resolv.conf, merge all options into one line in a pod with the `Default` DNS policy.",
     "markdown": "Kubelet: when there are multi option lines in /etc/resolv.conf, merge all options into one line in a pod with the `Default` DNS policy. ([#112414](https://github.com/kubernetes/kubernetes/pull/112414), [@pacoxu](https://github.com/pacoxu)) [SIG Network and Node]",
     "author": "pacoxu",
@@ -1298,7 +1360,7 @@
     "duplicate": true
   },
   "112427": {
-    "commit": "148476eff1c9d48d513e725918601a7e85c69792",
+    "commit": "30ac00eeb585feab1bff7452182879bac35f1a91",
     "text": "Allowed `Label` section in vSphere e2e cloud provider configuration.",
     "markdown": "Allowed `Label` section in vSphere e2e cloud provider configuration. ([#112427](https://github.com/kubernetes/kubernetes/pull/112427), [@gnufied](https://github.com/gnufied))",
     "author": "gnufied",
@@ -1311,7 +1373,7 @@
     "duplicate": true
   },
   "112489": {
-    "commit": "0f6b9b883cc4a446035c34ef3bf2c7a4f8693281",
+    "commit": "06fd0a07286faaef2008fd97c888debe0ca1d74a",
     "text": "etcd: Updated to v3.5.5.",
     "markdown": "Etcd: Updated to v3.5.5. ([#112489](https://github.com/kubernetes/kubernetes/pull/112489), [@dims](https://github.com/dims))",
     "author": "dims",
@@ -1348,7 +1410,7 @@
     "sigs": ["cluster-lifecycle"]
   },
   "112518": {
-    "commit": "bb561e0324ecbfc8e3d4ec57e94a386b878eac7e",
+    "commit": "8f269d6df2a57544b73d5ca35e04451373ef334c",
     "text": "fixed code to ensure that pods running on nodes tainted with `NoExecute` continue to run when the `PodDisruptionConditions` feature gate is enabled.",
     "markdown": "Fixed code to ensure that pods running on nodes tainted with `NoExecute` continue to run when the `PodDisruptionConditions` feature gate is enabled. ([#112518](https://github.com/kubernetes/kubernetes/pull/112518), [@mimowo](https://github.com/mimowo))",
     "author": "mimowo",
@@ -1375,7 +1437,7 @@
     "duplicate_kind": true
   },
   "112526": {
-    "commit": "4ff13696417446ffc8e3d42103bc5f7b4f6f56e0",
+    "commit": "a7e079680a9007bed0304ac3b62ae24623ad0bf1",
     "text": "kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors.",
     "markdown": "Kube-apiserver: resolved a regression that treated `304 Not Modified` responses from aggregated API servers as internal errors. ([#112526](https://github.com/kubernetes/kubernetes/pull/112526), [@liggitt](https://github.com/liggitt))",
     "author": "liggitt",
@@ -1493,7 +1555,7 @@
     "duplicate": true
   },
   "112577": {
-    "commit": "7aaacb22a94802c85cd073a5ab0d6b603be49a2c",
+    "commit": "de693b5e2d165081ef52dda83cd3aa3398f263b0",
     "text": "Removed feature gates `ServiceLoadBalancerClass` and `ServiceLBNodePortControl`. These feature gates were enabled (and locked) since `v1.24`.",
     "markdown": "Removed feature gates `ServiceLoadBalancerClass` and `ServiceLBNodePortControl`. These feature gates were enabled (and locked) since `v1.24`. ([#112577](https://github.com/kubernetes/kubernetes/pull/112577), [@andrewsykim](https://github.com/andrewsykim))",
     "author": "andrewsykim",
@@ -1517,7 +1579,7 @@
     "duplicate": true
   },
   "112580": {
-    "commit": "0663a8ff45439cc052dfa227b06e29fa08f2c683",
+    "commit": "b8e740f2e551531b22684e4cf6cd57da11203b3d",
     "text": "Added `--disable-compression` flag to `kubectl` (default = false). When true, it opts out of response compression for all requests to the `apiserver`. This can help improve list call latencies significantly when client-server network bandwidth is ample (\u003e30MB/s) or if the server is CPU-constrained.",
     "markdown": "Added `--disable-compression` flag to `kubectl` (default = false). When true, it opts out of response compression for all requests to the `apiserver`. This can help improve list call latencies significantly when client-server network bandwidth is ample (\u003e30MB/s) or if the server is CPU-constrained. ([#112580](https://github.com/kubernetes/kubernetes/pull/112580), [@shyamjvs](https://github.com/shyamjvs))",
     "author": "shyamjvs",
@@ -1531,7 +1593,7 @@
     "duplicate": true
   },
   "112589": {
-    "commit": "8dba9f782d5283112831ea2ee5c2fbb715f913e8",
+    "commit": "9c9b29032f76e39b0e36200c88fe2f127389a9fe",
     "text": "The `IndexedJob` and `SuspendJob` feature gates that graduated to GA in 1.24 and were unconditionally enabled have been removed in v1.26.",
     "markdown": "The `IndexedJob` and `SuspendJob` feature gates that graduated to GA in 1.24 and were unconditionally enabled have been removed in v1.26. ([#112589](https://github.com/kubernetes/kubernetes/pull/112589), [@SataQiu](https://github.com/SataQiu))",
     "author": "SataQiu",
@@ -1542,7 +1604,7 @@
     "sigs": ["apps"]
   },
   "112607": {
-    "commit": "91a9ce28ac2486c50222aeeec1f76e664155d769",
+    "commit": "3993c23a748b6ff01f116dadb10d07180407021a",
     "text": "volume mount cleanup now considers only plugin directory and not the entire kubelet root",
     "markdown": "Volume mount cleanup now considers only plugin directory and not the entire kubelet root ([#112607](https://github.com/kubernetes/kubernetes/pull/112607), [@mattcary](https://github.com/mattcary))",
     "author": "mattcary",
@@ -1591,7 +1653,7 @@
     "sigs": ["node"]
   },
   "112650": {
-    "commit": "cdbb15c80288947ab670e2419e22992e037f9361",
+    "commit": "205adec698ef41ae8fb59b8ddc175c40c66ca540",
     "text": "kubelet: fixed log spam from kubelet_getters.go `Path does not exist`.",
     "markdown": "Kubelet: fixed log spam from kubelet_getters.go `Path does not exist`. ([#112650](https://github.com/kubernetes/kubernetes/pull/112650), [@rphillips](https://github.com/rphillips))",
     "author": "rphillips",
@@ -1603,7 +1665,7 @@
     "sigs": ["node"]
   },
   "112652": {
-    "commit": "8631b2cdf952f7039f2dadf74a7d4d6e0e3c75b2",
+    "commit": "80024aefcb0d92db7bbb620e71d45b3bae6a3685",
     "text": "Added a `kubernetes_feature_enabled` metric which will tell you if a feature is enabled.",
     "markdown": "Added a `kubernetes_feature_enabled` metric which will tell you if a feature is enabled. ([#112652](https://github.com/kubernetes/kubernetes/pull/112652), [@logicalhan](https://github.com/logicalhan))",
     "author": "logicalhan",
@@ -1651,7 +1713,7 @@
     "duplicate_kind": true
   },
   "112693": {
-    "commit": "78c704d4f60d54996d483d49c23c6aac82f28dc9",
+    "commit": "6cb473b6c4f1239d411e0a50a1cdf9c4c092c42a",
     "text": "Bump `golang.org/x/net` to `v0.1.1-0.20221027164007-c63010009c80`.",
     "markdown": "Bump `golang.org/x/net` to `v0.1.1-0.20221027164007-c63010009c80`. ([#112693](https://github.com/kubernetes/kubernetes/pull/112693), [@aimuz](https://github.com/aimuz))",
     "author": "aimuz",
@@ -1738,7 +1800,7 @@
     "duplicate": true
   },
   "112744": {
-    "commit": "ff19efdf9bd2d1f4abece3229f1e36c1d58b96df",
+    "commit": "9258cb40417d96fdae45b0294adf2bd015b485b0",
     "text": "Added a feature that allows a `StatefulSet` to start numbering replicas from an arbitrary non-negative ordinal, using the `.spec.ordinals.start` field.",
     "markdown": "Added a feature that allows a `StatefulSet` to start numbering replicas from an arbitrary non-negative ordinal, using the `.spec.ordinals.start` field. ([#112744](https://github.com/kubernetes/kubernetes/pull/112744), [@pwschuurman](https://github.com/pwschuurman))",
     "author": "pwschuurman",
@@ -1805,7 +1867,7 @@
     "duplicate": true
   },
   "112792": {
-    "commit": "b4eec3c2ad8d0645a10b4e911738627b7ecb2809",
+    "commit": "9dff2311eacbcde1390ad67233cf0a48f0020eea",
     "text": "Added a new feature gate `CelValidatingAdmissionExtensibility` to enable expression validation for Admission Control.",
     "markdown": "Added a new feature gate `CelValidatingAdmissionExtensibility` to enable expression validation for Admission Control. ([#112792](https://github.com/kubernetes/kubernetes/pull/112792), [@cici37](https://github.com/cici37)) [SIG API Machinery]",
     "documentation": [
@@ -1867,7 +1929,7 @@
     "duplicate": true
   },
   "112837": {
-    "commit": "3ef7784b75e0005d96f1d64d55b822f346f85fb5",
+    "commit": "5bbf4218417c36e827cfda9ce80b4322c4878d21",
     "text": "Fixed an issue in `winkernel` proxier that causes proxy rules to leak anytime service backends are modified.",
     "markdown": "Fixed an issue in `winkernel` proxier that causes proxy rules to leak anytime service backends are modified. ([#112837](https://github.com/kubernetes/kubernetes/pull/112837), [@daschott](https://github.com/daschott))",
     "author": "daschott",
@@ -1880,7 +1942,7 @@
     "duplicate_kind": true
   },
   "112838": {
-    "commit": "32ea818d21c64bc0f9ab65b131d763e0c4401f79",
+    "commit": "af72ea5c07708039823fb28a9d741c647acb376d",
     "text": "The `LegacyServiceAccountTokenNoAutoGeneration` feature gate was promoted to GA.",
     "markdown": "The `LegacyServiceAccountTokenNoAutoGeneration` feature gate was promoted to GA. ([#112838](https://github.com/kubernetes/kubernetes/pull/112838), [@zshihang](https://github.com/zshihang))",
     "documentation": [
@@ -1901,11 +1963,11 @@
     "duplicate": true
   },
   "112855": {
-    "commit": "bdc08eaa4b9ec38fa20573691a27e99862b4729c",
+    "commit": "d0e86111ef91615f3a17f860a2e9e6aa0c6a259a",
     "text": "Added kubelet metrics to track the cpumanager cpu allocation and pinning",
-    "markdown": "Added kubelet metrics to track the cpumanager cpu allocation and pinning ([#112855](https://github.com/kubernetes/kubernetes/pull/112855), [@fromanirh](https://github.com/fromanirh))",
-    "author": "fromanirh",
-    "author_url": "https://github.com/fromanirh",
+    "markdown": "Added kubelet metrics to track the cpumanager cpu allocation and pinning ([#112855](https://github.com/kubernetes/kubernetes/pull/112855), [@ffromani](https://github.com/ffromani))",
+    "author": "ffromani",
+    "author_url": "https://github.com/ffromani",
     "pr_url": "https://github.com/kubernetes/kubernetes/pull/112855",
     "pr_number": 112855,
     "areas": ["test", "kubelet"],
@@ -1927,7 +1989,7 @@
     "sigs": ["api-machinery"]
   },
   "112895": {
-    "commit": "c98aef484d59dd92bb8bfc2cf02d4bc7c10f93c9",
+    "commit": "82ce61afc7bcbddb0f1f3d86145d46811410b33a",
     "text": "Moved `MixedProtocolLBService` from beta to GA.",
     "markdown": "Moved `MixedProtocolLBService` from beta to GA. ([#112895](https://github.com/kubernetes/kubernetes/pull/112895), [@janosi](https://github.com/janosi))",
     "author": "janosi",
@@ -1992,7 +2054,7 @@
     "duplicate": true
   },
   "112914": {
-    "commit": "75bb437a6b3a992e60d2422f8d390280d42bba59",
+    "commit": "243ba086e7f4cb73ea32bdd25d635d06cda26085",
     "text": "Added a `--topology-manager-policy-options` flag to the kubelet to support fine tuning the topology manager policies. The first policy option, `prefer-closest-numa-nodes`, allows these policies to favor sets of NUMA nodes with shorter distance between nodes when making admission decisions.",
     "markdown": "Added a `--topology-manager-policy-options` flag to the kubelet to support fine tuning the topology manager policies. The first policy option, `prefer-closest-numa-nodes`, allows these policies to favor sets of NUMA nodes with shorter distance between nodes when making admission decisions. ([#112914](https://github.com/kubernetes/kubernetes/pull/112914), [@PiotrProkop](https://github.com/PiotrProkop))",
     "author": "PiotrProkop",
@@ -2110,7 +2172,7 @@
     "duplicate": true
   },
   "112980": {
-    "commit": "131704e71db6ea1b3e1febb02b23b576fc7a6f16",
+    "commit": "40741681a24a5acf9361ec74b97e887a9da3e3e4",
     "text": "Graduated Kubelet Device Manager to GA.",
     "markdown": "Graduated Kubelet Device Manager to GA. ([#112980](https://github.com/kubernetes/kubernetes/pull/112980), [@swatisehgal](https://github.com/swatisehgal))",
     "documentation": [
@@ -2187,7 +2249,7 @@
     "duplicate": true
   },
   "113010": {
-    "commit": "39d9981dc2b550ae8f02ebfd039925ede15542e3",
+    "commit": "aef9a37df93b7207d7aac9fe4b8e19b6129f8c7a",
     "text": "'Promoted job-related metrics to stable to follow IndexedJobs GA. The following metrics have their name updated to match metrics API guidelines:\n- `job_sync_total` -\u003e `job_syncs_total`\n- `job_finished_total` -\u003e `jobs_finished_total`'",
     "markdown": "'Promoted job-related metrics to stable to follow IndexedJobs GA. The following metrics have their name updated to match metrics API guidelines:\n  - `job_sync_total` -\u003e `job_syncs_total`\n  - `job_finished_total` -\u003e `jobs_finished_total`' ([#113010](https://github.com/kubernetes/kubernetes/pull/113010), [@soltysh](https://github.com/soltysh))",
     "documentation": [
@@ -2220,9 +2282,9 @@
     "duplicate": true
   },
   "113018": {
-    "commit": "433787d25ba51755bb913eb6a33d1b37e6444aeb",
+    "commit": "a6b928d90c64eba83ede0dc013234188662e1d02",
     "text": "Graduated Kubelet CPU Manager to GA.",
-    "markdown": "Graduated Kubelet CPU Manager to GA. ([#113018](https://github.com/kubernetes/kubernetes/pull/113018), [@fromanirh](https://github.com/fromanirh))",
+    "markdown": "Graduated Kubelet CPU Manager to GA. ([#113018](https://github.com/kubernetes/kubernetes/pull/113018), [@ffromani](https://github.com/ffromani))",
     "documentation": [
       {
         "description": "[KEP]",
@@ -2230,8 +2292,8 @@
         "type": "KEP"
       }
     ],
-    "author": "fromanirh",
-    "author_url": "https://github.com/fromanirh",
+    "author": "ffromani",
+    "author_url": "https://github.com/ffromani",
     "pr_url": "https://github.com/kubernetes/kubernetes/pull/113018",
     "pr_number": 113018,
     "areas": ["test", "kubelet"],
@@ -2284,7 +2346,7 @@
     "feature": true
   },
   "113041": {
-    "commit": "b296f82c69feaab07e93a6db62e52ce8b0991cd0",
+    "commit": "843ad71cac98bcfff9f367a8ad90246cbc57d71c",
     "text": "Fixed a bug where the kubelet choose the wrong container by its name when running `kubectl exec`.",
     "markdown": "Fixed a bug where the kubelet choose the wrong container by its name when running `kubectl exec`. ([#113041](https://github.com/kubernetes/kubernetes/pull/113041), [@saschagrunert](https://github.com/saschagrunert))",
     "author": "saschagrunert",
@@ -2310,8 +2372,20 @@
     "sigs": ["network"],
     "feature": true
   },
+  "113083": {
+    "commit": "a4c6696c456819e58e6215c95b6ece17819a5751",
+    "text": "When describing deployments, `OldReplicaSets` now always shows all replicasets controlled the deployment, not just those that still have replicas available.",
+    "markdown": "When describing deployments, `OldReplicaSets` now always shows all replicasets controlled the deployment, not just those that still have replicas available. ([#113083](https://github.com/kubernetes/kubernetes/pull/113083), [@llorllale](https://github.com/llorllale)) [SIG CLI]",
+    "author": "llorllale",
+    "author_url": "https://github.com/llorllale",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113083",
+    "pr_number": 113083,
+    "areas": ["kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli"]
+  },
   "113113": {
-    "commit": "1582c42e2b0d3afcd7440b30d9f7c6a8ff02db9c",
+    "commit": "2b6abb1b333737edbd8e44015de4e2867b6118c9",
     "text": "The time duration of a failed or unschedulable scheduling attempt will be longer, it \nnow includes the time duration of the unreserve operation.",
     "markdown": "The time duration of a failed or unschedulable scheduling attempt will be longer, it \n  now includes the time duration of the unreserve operation. ([#113113](https://github.com/kubernetes/kubernetes/pull/113113), [@kerthcet](https://github.com/kerthcet))",
     "author": "kerthcet",
@@ -2346,7 +2420,7 @@
     "sigs": ["api-machinery"]
   },
   "113146": {
-    "commit": "a82015b4a245e48db85ce56d14037e7d69a18e90",
+    "commit": "dca025f37c7d40388f6869fc3d04b8f4fab8d122",
     "text": "Adds alpha --output plaintext protected by environment variable `KUBECTL_EXPLAIN_OPENAPIV3`",
     "markdown": "Adds alpha --output plaintext protected by environment variable `KUBECTL_EXPLAIN_OPENAPIV3` ([#113146](https://github.com/kubernetes/kubernetes/pull/113146), [@alexzielenski](https://github.com/alexzielenski)) [SIG CLI]",
     "documentation": [
@@ -2366,7 +2440,7 @@
     "feature": true
   },
   "113160": {
-    "commit": "7cd98dec08cbe3ac1ed7d5238bb179760103795d",
+    "commit": "2e059ff158bfdc209e42de5438eef8b6e0ea0089",
     "text": "Azure File CSI migration is now GA.",
     "markdown": "Azure File CSI migration is now GA. ([#113160](https://github.com/kubernetes/kubernetes/pull/113160), [@andyzhangx](https://github.com/andyzhangx))",
     "author": "andyzhangx",
@@ -2425,7 +2499,7 @@
     "duplicate_kind": true
   },
   "113172": {
-    "commit": "ae6dc598bd23c29480ce5ec426b75954dbd1b65b",
+    "commit": "de26b9023f2872c5cd7e15fad5dd5ab649222c13",
     "text": "API Server Tracing now includes a variety of new spans and span events.",
     "markdown": "API Server Tracing now includes a variety of new spans and span events. ([#113172](https://github.com/kubernetes/kubernetes/pull/113172), [@dashpole](https://github.com/dashpole)) [SIG API Machinery, Architecture, Auth, Instrumentation, Network, Node and Scheduling]",
     "documentation": [
@@ -2521,7 +2595,7 @@
     "sigs": ["testing"]
   },
   "113217": {
-    "commit": "f522df5b49e3165f228fc6e3fd03df76c738bb72",
+    "commit": "ed1610ad15f91b72017c5d69dc4f7d59a17c270f",
     "text": "API Server tracing now includes the latency of authorization, priorityandfairness, impersonation, audit, and authentication filters.",
     "markdown": "API Server tracing now includes the latency of authorization, priorityandfairness, impersonation, audit, and authentication filters. ([#113217](https://github.com/kubernetes/kubernetes/pull/113217), [@dashpole](https://github.com/dashpole))",
     "documentation": [
@@ -2564,8 +2638,21 @@
     "feature": true,
     "duplicate": true
   },
+  "113267": {
+    "commit": "9f2ac979ae12122f6d955ae4bd007fcef73b21ba",
+    "text": "Remove unused rule for `nodes/spec` from `ClusterRole system:kubelet-api-admin`",
+    "markdown": "Remove unused rule for `nodes/spec` from `ClusterRole system:kubelet-api-admin` ([#113267](https://github.com/kubernetes/kubernetes/pull/113267), [@hoskeri](https://github.com/hoskeri)) [SIG Auth and Cloud Provider]",
+    "author": "hoskeri",
+    "author_url": "https://github.com/hoskeri",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113267",
+    "pr_number": 113267,
+    "areas": ["provider/gcp"],
+    "kinds": ["cleanup"],
+    "sigs": ["auth", "cloud-provider"],
+    "duplicate": true
+  },
   "113274": {
-    "commit": "8c77820759cc28a5d82e9a68f3d335d1a27f4466",
+    "commit": "7b6293b6b6a5662fc37f440e839cf5da8b96e935",
     "text": "New Pod API field `.spec.schedulingGates` was introduced to enable users to control when to mark a Pod as scheduling ready.",
     "markdown": "New Pod API field `.spec.schedulingGates` was introduced to enable users to control when to mark a Pod as scheduling ready. ([#113274](https://github.com/kubernetes/kubernetes/pull/113274), [@Huang-Wei](https://github.com/Huang-Wei))",
     "documentation": [
@@ -2608,6 +2695,20 @@
     "duplicate": true,
     "duplicate_kind": true
   },
+  "113284": {
+    "commit": "a4dac224e7ef5d4c1a50b5c6a5f89c39f3115381",
+    "text": "kubectl will display SeccompProfile for pods, containers and ephemeral containers, if values were set.",
+    "markdown": "Kubectl will display SeccompProfile for pods, containers and ephemeral containers, if values were set. ([#113284](https://github.com/kubernetes/kubernetes/pull/113284), [@williamyeh](https://github.com/williamyeh)) [SIG CLI and Security]",
+    "author": "williamyeh",
+    "author_url": "https://github.com/williamyeh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113284",
+    "pr_number": 113284,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "security"],
+    "feature": true,
+    "duplicate": true
+  },
   "113291": {
     "commit": "f328d3dc3d6d7b19045635372f2f7fabd385435e",
     "text": "Fixed the `PodAndContainerStatsFromCRI` feature, instead of supplementing with stats from cAdvisor.",
@@ -2629,7 +2730,7 @@
     "duplicate": true
   },
   "113304": {
-    "commit": "fea883687feafc597591e15773f8c6f491b35d08",
+    "commit": "3c9928e4f87c1d023e595292e6139cbd8dfedd5c",
     "text": "The `kube-scheduler` and `kube-controller-manager` now use server side apply to set conditions related to pod disruption.",
     "markdown": "The `kube-scheduler` and `kube-controller-manager` now use server side apply to set conditions related to pod disruption. ([#113304](https://github.com/kubernetes/kubernetes/pull/113304), [@mimowo](https://github.com/mimowo)) [SIG API Machinery, Apps and Scheduling]",
     "documentation": [
@@ -2649,7 +2750,7 @@
     "duplicate_kind": true
   },
   "113307": {
-    "commit": "c8a3657bde08fde0240cba2e8579b160e95bc459",
+    "commit": "6925bee6d5c15c62cada8b7dab34e0a122cec8ce",
     "text": "Updated the Lease identity naming format for the `APIServerIdentity` feature to use a persistent name.",
     "markdown": "Updated the Lease identity naming format for the `APIServerIdentity` feature to use a persistent name. ([#113307](https://github.com/kubernetes/kubernetes/pull/113307), [@andrewsykim](https://github.com/andrewsykim))",
     "author": "andrewsykim",
@@ -2697,7 +2798,7 @@
     "duplicate_kind": true
   },
   "113323": {
-    "commit": "ca03736670550056e74b1241790286e1d8a574f2",
+    "commit": "42422a1d16e2aba2963e8ca5edecf11862376344",
     "text": "Metrics for `RetroactiveDefaultStorageClass` feature are now available. To see an attempt count for updating PVC retroactively with a default StorageClass see `retroactive_storageclass_total` metric and for total numer of errors see `retroactive_storageclass_errors_total`.",
     "markdown": "Metrics for `RetroactiveDefaultStorageClass` feature are now available. To see an attempt count for updating PVC retroactively with a default StorageClass see `retroactive_storageclass_total` metric and for total numer of errors see `retroactive_storageclass_errors_total`. ([#113323](https://github.com/kubernetes/kubernetes/pull/113323), [@RomanBednar](https://github.com/RomanBednar))",
     "documentation": [
@@ -2770,7 +2871,7 @@
     "feature": true
   },
   "113340": {
-    "commit": "187a340e65f073c86f446355cc0d6be0e60df0c3",
+    "commit": "83fe3aae4b6dbde92c6b130ee059a28814300f52",
     "text": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` now becomes available on cloud-controller-manager allowing you to scrape health check metrics.",
     "markdown": "If `ComponentSLIs` feature gate is enabled, then `/metrics/slis` now becomes available on cloud-controller-manager allowing you to scrape health check metrics. ([#113340](https://github.com/kubernetes/kubernetes/pull/113340), [@Richabanker](https://github.com/Richabanker))",
     "documentation": [
@@ -2786,7 +2887,7 @@
     "feature": true
   },
   "113351": {
-    "commit": "b20ddbd75acf7e917bd1462688ff2f91edaf4052",
+    "commit": "9e24680d0b3970a59588d572fda15001d2c294aa",
     "text": "The `EndpointSliceTerminatingCondition` feature gate was graduated to GA. The gate is now locked and will be removed in v1.28.",
     "markdown": "The `EndpointSliceTerminatingCondition` feature gate was graduated to GA. The gate is now locked and will be removed in v1.28. ([#113351](https://github.com/kubernetes/kubernetes/pull/113351), [@andrewsykim](https://github.com/andrewsykim))",
     "author": "andrewsykim",
@@ -2823,7 +2924,7 @@
     "duplicate_kind": true
   },
   "113363": {
-    "commit": "8c77295db84d8f19c06b5afbfd475cfd11a834ae",
+    "commit": "fccd8b12d0ef817406fde33be8cc1b6b2f5ab718",
     "text": "The `ProxyTerminatingEndpoints` feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is `Local` and there are only terminating pods remaining on a node.",
     "markdown": "The `ProxyTerminatingEndpoints` feature is now Beta and enabled by default. When enabled, kube-proxy will attempt to route traffic to terminating pods when the traffic policy is `Local` and there are only terminating pods remaining on a node. ([#113363](https://github.com/kubernetes/kubernetes/pull/113363), [@andrewsykim](https://github.com/andrewsykim))",
     "author": "andrewsykim",
@@ -2952,7 +3053,7 @@
     "duplicate": true
   },
   "113496": {
-    "commit": "29f4862ed8c114a180f44c215bd200e7f5a4e60f",
+    "commit": "7a465163694131e6d66fe95a7e91f2f8235306bf",
     "text": "Graduated `ServiceInternalTrafficPolicy` feature to GA.",
     "markdown": "Graduated `ServiceInternalTrafficPolicy` feature to GA. ([#113496](https://github.com/kubernetes/kubernetes/pull/113496), [@avoltz](https://github.com/avoltz))",
     "documentation": [
@@ -2996,7 +3097,7 @@
     "duplicate_kind": true
   },
   "113501": {
-    "commit": "70263d55b281878121684337c0a7f205dabba5ec",
+    "commit": "57a3af1f876cfd7125c99b0267ccbe481f1ada00",
     "text": "kubelet: fixed nil pointer in reflector start for standalone mode.",
     "markdown": "Kubelet: fixed nil pointer in reflector start for standalone mode. ([#113501](https://github.com/kubernetes/kubernetes/pull/113501), [@pacoxu](https://github.com/pacoxu))",
     "author": "pacoxu",
@@ -3048,7 +3149,7 @@
     "duplicate": true
   },
   "113519": {
-    "commit": "38bcc0c1537cdd0bf2e26968cf10f34002fc7db1",
+    "commit": "8ce37fde9569064b074f4282d76dcc8c2b21577f",
     "text": "Adds metrics `force_delete_pods_total` and `force_delete_pod_errors_total` in the Pod GC Controller.",
     "markdown": "Adds metrics `force_delete_pods_total` and `force_delete_pod_errors_total` in the Pod GC Controller. ([#113519](https://github.com/kubernetes/kubernetes/pull/113519), [@xing-yang](https://github.com/xing-yang)) [SIG Apps]",
     "author": "xing-yang",
@@ -3060,7 +3161,7 @@
     "feature": true
   },
   "113521": {
-    "commit": "b60b0c74c91a2dc12436503f63d1a3b266eb02d4",
+    "commit": "7b6e4e4d8b12bfa0770f649611c4968b610d2b87",
     "text": "Resolved an issue that caused winkernel proxier to treat stale VIPs as valid.",
     "markdown": "Resolved an issue that caused winkernel proxier to treat stale VIPs as valid. ([#113521](https://github.com/kubernetes/kubernetes/pull/113521), [@daschott](https://github.com/daschott))",
     "author": "daschott",
@@ -3098,7 +3199,7 @@
     "duplicate": true
   },
   "113550": {
-    "commit": "2acad1b8c4b5f9a4991885ef34de1dc771139628",
+    "commit": "b928c535220e54cfe4f5124413536d41f070f906",
     "text": "Kubernetes is now built with Go `1.19.3`.",
     "markdown": "Kubernetes is now built with Go `1.19.3`. ([#113550](https://github.com/kubernetes/kubernetes/pull/113550), [@xmudrii](https://github.com/xmudrii))",
     "author": "xmudrii",
@@ -3112,7 +3213,7 @@
     "duplicate": true
   },
   "113580": {
-    "commit": "6f54848fa06b59c2caf6fe18a3bf85faba66ba73",
+    "commit": "208b2b7ca9f211c0d4a8df903bfb65fd6065d527",
     "text": "Fixed that disruption controller used to change the status of a stale disruption condition after 2 min when the `PodDisruptionConditions` feature gate is enabled.",
     "markdown": "Fixed that disruption controller used to change the status of a stale disruption condition after 2 min when the `PodDisruptionConditions` feature gate is enabled. ([#113580](https://github.com/kubernetes/kubernetes/pull/113580), [@mimowo](https://github.com/mimowo))",
     "author": "mimowo",
@@ -3123,7 +3224,7 @@
     "sigs": ["auth"]
   },
   "113596": {
-    "commit": "cf912a25127c1bbe9c304f457a04d1c2f9c6bf8e",
+    "commit": "167d27a790a5068364befe0fdbf60723d7ae7f51",
     "text": "Added reconstruction of SELinux mount context after kubelet restart. Feature `SELinuxMountReadWriteOncePod` is now fully implemented and kubelet does not lose its cache of SELinux contexts after kubelet process restart.",
     "markdown": "Added reconstruction of SELinux mount context after kubelet restart. Feature `SELinuxMountReadWriteOncePod` is now fully implemented and kubelet does not lose its cache of SELinux contexts after kubelet process restart. ([#113596](https://github.com/kubernetes/kubernetes/pull/113596), [@jsafrane](https://github.com/jsafrane))",
     "documentation": [
@@ -3226,7 +3327,7 @@
     "duplicate_kind": true
   },
   "113710": {
-    "commit": "b6d021b7e375a09d56b75c530ede1781e61a0581",
+    "commit": "e2b9fd760ddb3ab3215e71739b6845629ab533c0",
     "text": "CLI flag `pod-eviction-timeout` is deprecated and will be removed together with `enable-taint-manager` in `v1.27`.",
     "markdown": "CLI flag `pod-eviction-timeout` is deprecated and will be removed together with `enable-taint-manager` in `v1.27`. ([#113710](https://github.com/kubernetes/kubernetes/pull/113710), [@kerthcet](https://github.com/kerthcet))",
     "author": "kerthcet",
@@ -3252,7 +3353,7 @@
     "sigs": ["api-machinery"]
   },
   "113719": {
-    "commit": "ecbafed7c334e62965d1feb5df342a774be91864",
+    "commit": "e21438fca5f5e6988091bf0b39be51fcc19cfd8b",
     "text": "bumped `runc` to `v1.1.4`.",
     "markdown": "Bumped `runc` to `v1.1.4`. ([#113719](https://github.com/kubernetes/kubernetes/pull/113719), [@pacoxu](https://github.com/pacoxu))",
     "author": "pacoxu",
@@ -3264,7 +3365,7 @@
     "sigs": ["node"]
   },
   "113735": {
-    "commit": "29737124860b1414affa07ed6db30fccdbae3b55",
+    "commit": "72a25b17726b3059982dcc740fb8d05ec0c24f95",
     "text": "Renamed the feature gate for CEL in Admission Control to `ValidatingAdmissionPolicy`.",
     "markdown": "Renamed the feature gate for CEL in Admission Control to `ValidatingAdmissionPolicy`. ([#113735](https://github.com/kubernetes/kubernetes/pull/113735), [@cici37](https://github.com/cici37))",
     "documentation": [
@@ -3281,6 +3382,18 @@
     "areas": ["test", "apiserver"],
     "kinds": ["cleanup"],
     "sigs": ["api-machinery", "testing"],
+    "duplicate": true
+  },
+  "113742": {
+    "commit": "afbb21638cfe3dbb7d11adb3d9413d2ca6646594",
+    "text": "Fixing issue in Winkernel Proxier - Unexpected active TCP connection drops while horizontally scaling the endpoints for a LoadBalancer Service with Internal Traffic Policy: Local",
+    "markdown": "Fixing issue in Winkernel Proxier - Unexpected active TCP connection drops while horizontally scaling the endpoints for a LoadBalancer Service with Internal Traffic Policy: Local ([#113742](https://github.com/kubernetes/kubernetes/pull/113742), [@princepereira](https://github.com/princepereira)) [SIG Network and Windows]",
+    "author": "princepereira",
+    "author_url": "https://github.com/princepereira",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113742",
+    "pr_number": 113742,
+    "kinds": ["bug"],
+    "sigs": ["network", "windows"],
     "duplicate": true
   },
   "113749": {
@@ -3342,8 +3455,19 @@
     "feature": true,
     "duplicate": true
   },
+  "113834": {
+    "commit": "ec0b200f3df8835c23c7e5239a4e82d2ca3d601f",
+    "text": "statefulset status will be consistent on API errors",
+    "markdown": "Statefulset status will be consistent on API errors ([#113834](https://github.com/kubernetes/kubernetes/pull/113834), [@atiratree](https://github.com/atiratree)) [SIG Apps]",
+    "author": "atiratree",
+    "author_url": "https://github.com/atiratree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113834",
+    "pr_number": 113834,
+    "kinds": ["bug"],
+    "sigs": ["apps"]
+  },
   "113856": {
-    "commit": "af7cc0a60fa01138d56d9f46eee5cd06d01d20f1",
+    "commit": "bc5afaf580fad21dbc9b09a4fc412cb056058999",
     "text": "Known issue: Job field `.spec.podFailurePolicy.rules[*].onExitCode` might be ignored if the Pod is deleted before it terminates.",
     "markdown": "Known issue: Job field `.spec.podFailurePolicy.rules[*].onExitCode` might be ignored if the Pod is deleted before it terminates. ([#113856](https://github.com/kubernetes/kubernetes/pull/113856), [@alculquicondor](https://github.com/alculquicondor))",
     "documentation": [
@@ -3371,6 +3495,18 @@
     "kinds": ["bug"],
     "sigs": ["apps"]
   },
+  "113933": {
+    "commit": "69fad419a7666ac416307de4c3ee88c7e61b94db",
+    "text": "client-go: fixes potential data races retrying requests using a custom io.Reader body; with this fix, only requests with no body or with string / []byte / runtime.Object bodies can be retried",
+    "markdown": "Client-go: fixes potential data races retrying requests using a custom io.Reader body; with this fix, only requests with no body or with string / []byte / runtime.Object bodies can be retried ([#113933](https://github.com/kubernetes/kubernetes/pull/113933), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113933",
+    "pr_number": 113933,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
   "113955": {
     "commit": "3f823c0daa002158b12bfb2d53bcfe433516659d",
     "text": "Fixed a bug that resulted in \"grpc: the client connection is closing\" errors shortly after the Kubernetes API server automatically reloaded its encryption-at-rest config due to an observed change to the file.  This bug was only encountered when the --encryption-provider-config-automatic-reload flag was set to true.",
@@ -3384,8 +3520,58 @@
     "sigs": ["api-machinery", "auth", "testing"],
     "duplicate": true
   },
+  "113998": {
+    "commit": "21cd660a1f570dce08bc314241d1acd68fe8e74c",
+    "text": "kubeadm: respect user provided kubeconfig during discovery process",
+    "markdown": "Kubeadm: respect user provided kubeconfig during discovery process ([#113998](https://github.com/kubernetes/kubernetes/pull/113998), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113998",
+    "pr_number": 113998,
+    "areas": ["kubeadm"],
+    "kinds": ["bug"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "114055": {
+    "commit": "059acc2f5a6788f9d0b133ac0433944a16b2e986",
+    "text": "Kubernetes components that perform leader election now only support using Leases for this.",
+    "markdown": "Kubernetes components that perform leader election now only support using Leases for this. ([#114055](https://github.com/kubernetes/kubernetes/pull/114055), [@aimuz](https://github.com/aimuz)) [SIG API Machinery, Cloud Provider and Scheduling]",
+    "author": "aimuz",
+    "author_url": "https://github.com/aimuz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114055",
+    "pr_number": 114055,
+    "areas": ["cloudprovider"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["scheduling", "api-machinery", "cloud-provider"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "114086": {
+    "commit": "25e990f738bb98b505142ede7350d591b3fb904c",
+    "text": "If a user attempts to add an ephemeral container to a static pod, they will get a visible validation error.",
+    "markdown": "If a user attempts to add an ephemeral container to a static pod, they will get a visible validation error. ([#114086](https://github.com/kubernetes/kubernetes/pull/114086), [@xmcqueen](https://github.com/xmcqueen)) [SIG Apps and Node]",
+    "author": "xmcqueen",
+    "author_url": "https://github.com/xmcqueen",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114086",
+    "pr_number": 114086,
+    "kinds": ["bug"],
+    "sigs": ["node", "apps"],
+    "duplicate": true
+  },
+  "114116": {
+    "commit": "ebc5b208ae63e33fa5ae2825226fa8eb299fc178",
+    "text": "Fixed StatefulSetAutoDeletePVC feature when OwnerReferencesPermissionEnforcement admission plugin is enabled.",
+    "markdown": "Fixed StatefulSetAutoDeletePVC feature when OwnerReferencesPermissionEnforcement admission plugin is enabled. ([#114116](https://github.com/kubernetes/kubernetes/pull/114116), [@jsafrane](https://github.com/jsafrane)) [SIG Apps, Auth and Storage]",
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114116",
+    "pr_number": 114116,
+    "kinds": ["bug"],
+    "sigs": ["storage", "auth", "apps"],
+    "duplicate": true
+  },
   "114122": {
-    "commit": "4ffca653ff71525852d1a8abc5923156b22f9ced",
+    "commit": "6bdda2da160043c5fcdfd25bbea9e1c1b804c9e5",
     "text": "Fix endpoint reconciler not being able to delete the apiserver lease on shutdown",
     "markdown": "Fix endpoint reconciler not being able to delete the apiserver lease on shutdown ([#114122](https://github.com/kubernetes/kubernetes/pull/114122), [@aojea](https://github.com/aojea)) [SIG API Machinery]",
     "author": "aojea",
@@ -3394,6 +3580,130 @@
     "pr_number": 114122,
     "kinds": ["regression"],
     "sigs": ["api-machinery"]
+  },
+  "114172": {
+    "commit": "f4c1682fb106f6f27121a2163b818acf684d8134",
+    "text": "StatefulSet names must be DNS labels, rather than subdomains.  Any StatefulSet which took advantage of subdomain validation (by having dots in the name) can't possibly have worked, because we eventually set `pod.spec.hostname` from the StatefulSetName, and that is validated as a DNS label.",
+    "markdown": "StatefulSet names must be DNS labels, rather than subdomains.  Any StatefulSet which took advantage of subdomain validation (by having dots in the name) can't possibly have worked, because we eventually set `pod.spec.hostname` from the StatefulSetName, and that is validated as a DNS label. ([#114172](https://github.com/kubernetes/kubernetes/pull/114172), [@thockin](https://github.com/thockin)) [SIG Apps]",
+    "author": "thockin",
+    "author_url": "https://github.com/thockin",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114172",
+    "pr_number": 114172,
+    "kinds": ["bug", "api-change"],
+    "sigs": ["apps"],
+    "duplicate_kind": true
+  },
+  "114176": {
+    "commit": "847a39afc0738771963556fcd819021ca0b0ed88",
+    "text": "kubeadm: improve retries when updating node information, in case kube-apiserver is temporarily unavailable",
+    "markdown": "Kubeadm: improve retries when updating node information, in case kube-apiserver is temporarily unavailable ([#114176](https://github.com/kubernetes/kubernetes/pull/114176), [@QuantumEnergyE](https://github.com/QuantumEnergyE)) [SIG Cluster Lifecycle]",
+    "author": "QuantumEnergyE",
+    "author_url": "https://github.com/QuantumEnergyE",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114176",
+    "pr_number": 114176,
+    "areas": ["kubeadm"],
+    "kinds": ["bug"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "114191": {
+    "commit": "667599b0ddfad8ba760d3bbfe006aae0d8f7dec6",
+    "text": "Profiling can now be served on a unix-domain socket by using the `--profiling-path` option (when profiling is enabled) for security purposes.",
+    "markdown": "Profiling can now be served on a unix-domain socket by using the `--profiling-path` option (when profiling is enabled) for security purposes. ([#114191](https://github.com/kubernetes/kubernetes/pull/114191), [@apelisse](https://github.com/apelisse)) [SIG API Machinery]",
+    "author": "apelisse",
+    "author_url": "https://github.com/apelisse",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114191",
+    "pr_number": 114191,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "114228": {
+    "commit": "8a96ed0d207a16e80b6b217da2c9307b77ec6b82",
+    "text": "Make `kubectl-convert` binary linking static (also affects the deb and rpm packages).",
+    "markdown": "Make `kubectl-convert` binary linking static (also affects the deb and rpm packages). ([#114228](https://github.com/kubernetes/kubernetes/pull/114228), [@saschagrunert](https://github.com/saschagrunert)) [SIG Release]",
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114228",
+    "pr_number": 114228,
+    "kinds": ["feature"],
+    "sigs": ["release"],
+    "feature": true
+  },
+  "114236": {
+    "commit": "55ec09d377274b4a6107fe0b7a061ad408fe05a7",
+    "text": "Fix a data race when emitting similar Events consecutively",
+    "markdown": "Fix a data race when emitting similar Events consecutively ([#114236](https://github.com/kubernetes/kubernetes/pull/114236), [@dgrisonnet](https://github.com/dgrisonnet)) [SIG API Machinery]",
+    "author": "dgrisonnet",
+    "author_url": "https://github.com/dgrisonnet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114236",
+    "pr_number": 114236,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "114237": {
+    "commit": "2f83117bcfe30ad3ada7f1ca66f4b885a1d5df25",
+    "text": "Fix a bug where when emitting similar Events consecutively, some were rejected by the apiserver.",
+    "markdown": "Fix a bug where when emitting similar Events consecutively, some were rejected by the apiserver. ([#114237](https://github.com/kubernetes/kubernetes/pull/114237), [@dgrisonnet](https://github.com/dgrisonnet)) [SIG API Machinery]",
+    "author": "dgrisonnet",
+    "author_url": "https://github.com/dgrisonnet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114237",
+    "pr_number": 114237,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "114246": {
+    "commit": "3c0a78e924e4318de43efbe83d836c336c29ae7b",
+    "text": "Type cannot implement 'mount.Interface' as it has a non-exported method and is defined in a different package",
+    "markdown": "Type cannot implement 'mount.Interface' as it has a non-exported method and is defined in a different package ([#114246](https://github.com/kubernetes/kubernetes/pull/114246), [@mxpv](https://github.com/mxpv)) [SIG Storage]",
+    "author": "mxpv",
+    "author_url": "https://github.com/mxpv",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114246",
+    "pr_number": 114246,
+    "kinds": ["cleanup"],
+    "sigs": ["storage"],
+    "do_not_publish": true
+  },
+  "114249": {
+    "commit": "832644f0b38d536be7a5adce9bc62b0902710091",
+    "text": "change the error message to \"cannot exec into multiple objects at a time\" when file passed to kubectl exec contains multiple resources",
+    "markdown": "Change the error message to \"cannot exec into multiple objects at a time\" when file passed to kubectl exec contains multiple resources ([#114249](https://github.com/kubernetes/kubernetes/pull/114249), [@ardaguclu](https://github.com/ardaguclu)) [SIG CLI and Testing]",
+    "author": "ardaguclu",
+    "author_url": "https://github.com/ardaguclu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114249",
+    "pr_number": 114249,
+    "areas": ["test", "kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli", "testing"],
+    "duplicate": true
+  },
+  "114252": {
+    "commit": "b84f192acc61b5fa9dc438950e6cc57f75889853",
+    "text": "Adding (dry run) and (server dry run) suffixes to kubectl scale command when dry-run is passed",
+    "markdown": "Adding (dry run) and (server dry run) suffixes to kubectl scale command when dry-run is passed ([#114252](https://github.com/kubernetes/kubernetes/pull/114252), [@ardaguclu](https://github.com/ardaguclu)) [SIG CLI and Testing]",
+    "author": "ardaguclu",
+    "author_url": "https://github.com/ardaguclu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114252",
+    "pr_number": 114252,
+    "areas": ["test", "kubectl"],
+    "kinds": ["bug"],
+    "sigs": ["cli", "testing"],
+    "duplicate": true
+  },
+  "114279": {
+    "commit": "34d845502f7e84dae7980007f3ca8c14925f5c56",
+    "text": "kube-up now includes CoreDNS version v1.9.3",
+    "markdown": "Kube-up now includes CoreDNS version v1.9.3 ([#114279](https://github.com/kubernetes/kubernetes/pull/114279), [@pacoxu](https://github.com/pacoxu)) [SIG Cloud Provider and Cluster Lifecycle]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114279",
+    "pr_number": 114279,
+    "areas": ["provider/gcp", "kubeadm", "dependency"],
+    "kinds": ["cleanup", "feature"],
+    "sigs": ["cluster-lifecycle", "cloud-provider"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
   },
   "114284": {
     "commit": "09d7286eb570c8ab89c3008efd6afcf590a94a50",
@@ -3410,7 +3720,7 @@
     "duplicate": true
   },
   "114319": {
-    "commit": "72acaad83924360960e21915aa94cd1db8d0196c",
+    "commit": "afe5378db9d17b1e16ea0028ecfab432475f8e25",
     "text": "Updates golang.org/x/net to fix CVE-2022-41717",
     "markdown": "Updates golang.org/x/net to fix CVE-2022-41717 ([#114319](https://github.com/kubernetes/kubernetes/pull/114319), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node and Storage]",
     "author": "liggitt",
@@ -3431,6 +3741,33 @@
       "cloud-provider"
     ],
     "duplicate": true
+  },
+  "114338": {
+    "commit": "64eef3e9fa4986efcaa22995e0aed17b241e5132",
+    "text": "kubeadm: explicitly set `priority` for static pods with `priorityClassName: system-node-critical`",
+    "markdown": "Kubeadm: explicitly set `priority` for static pods with `priorityClassName: system-node-critical` ([#114338](https://github.com/kubernetes/kubernetes/pull/114338), [@champtar](https://github.com/champtar)) [SIG Cluster Lifecycle]",
+    "author": "champtar",
+    "author_url": "https://github.com/champtar",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114338",
+    "pr_number": 114338,
+    "areas": ["kubeadm"],
+    "kinds": ["bug", "api-change"],
+    "sigs": ["cluster-lifecycle"],
+    "duplicate_kind": true
+  },
+  "114350": {
+    "commit": "a75c0709d091be912b3070acb6e03e0f958c809e",
+    "text": "Deflake a preemption test that may patch Nodes incorrectly.",
+    "markdown": "Deflake a preemption test that may patch Nodes incorrectly. ([#114350](https://github.com/kubernetes/kubernetes/pull/114350), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling and Testing]",
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114350",
+    "pr_number": 114350,
+    "areas": ["test"],
+    "kinds": ["flake", "failing-test"],
+    "sigs": ["scheduling", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
   },
   "67782": {
     "commit": "07bca2d7919c192435949c53f81acff58d6f39eb",


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.26.0` 