### PR TITLE
Drop Google Universal Analytics (UA) code

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,15 +9,5 @@
   </head>
   <body>
     <app-root></app-root>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-98841695-4"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', 'UA-98841695-4');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
- Closes #468
- ⚠️ After this is merged, the **UA site tag will no longer receive events**

/cc @jeefy - since you added the UA site tag in the first place :)
/cc @caniszczyk @nate-double-u @a-mccarthy 