### PR TITLE
Patch relnotes.k8s.io to release v1.27.0-alpha.3

### DIFF
--- a/src/assets/release-notes-1.27.0-alpha.3.json
+++ b/src/assets/release-notes-1.27.0-alpha.3.json
@@ -1,0 +1,835 @@
+{
+  "102884": {
+    "commit": "b9fd1802ba0aec68508b4e9eec00819008a79370",
+    "text": "PodSpec.Container.Resources becomes mutable for CPU and memory resource types.\n- PodSpec.Container.ResizePolicy (new object) gives users control over how their containers are resized.\n- PodStatus.Resize status describes the state of a requested Pod resize.\n- PodStatus.ResourcesAllocated describes node resources allocated to Pod.\n- PodStatus.Resources describes node resources applied to running containers by CRI.\n- UpdateContainerResources CRI API now supports both Linux and Windows.\n\nFor details, see KEPs below.",
+    "markdown": "PodSpec.Container.Resources becomes mutable for CPU and memory resource types.\n  - PodSpec.Container.ResizePolicy (new object) gives users control over how their containers are resized.\n  - PodStatus.Resize status describes the state of a requested Pod resize.\n  - PodStatus.ResourcesAllocated describes node resources allocated to Pod.\n  - PodStatus.Resources describes node resources applied to running containers by CRI.\n  - UpdateContainerResources CRI API now supports both Linux and Windows.\n  \n  For details, see KEPs below. ([#102884](https://github.com/kubernetes/kubernetes/pull/102884), [@vinaykul](https://github.com/vinaykul)) [SIG API Machinery, Apps, Instrumentation, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources",
+        "type": "KEP"
+      }
+    ],
+    "author": "vinaykul",
+    "author_url": "https://github.com/vinaykul",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/102884",
+    "pr_number": 102884,
+    "areas": ["test", "kubelet", "apiserver", "code-generation", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "node", "api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "110960": {
+    "commit": "0ad676fca8308fed5bc682cf8315a62b717d6d1d",
+    "text": "Implements API for streaming for the watch-cache\n\nWhen sendInitialEvents ListOption is set together with watch=true, it begins the watch stream with synthetic init events followed by a synthetic \"Bookmark\" after which the server continues streaming events.",
+    "markdown": "Implements API for streaming for the watch-cache\n  \n  When sendInitialEvents ListOption is set together with watch=true, it begins the watch stream with synthetic init events followed by a synthetic \"Bookmark\" after which the server continues streaming events. ([#110960](https://github.com/kubernetes/kubernetes/pull/110960), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3157-watch-list",
+        "type": "KEP"
+      }
+    ],
+    "author": "p0lyn0mial",
+    "author_url": "https://github.com/p0lyn0mial",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110960",
+    "pr_number": 110960,
+    "areas": ["apiserver", "code-generation"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery"]
+  },
+  "112393": {
+    "commit": "e55f2a9b54e0f6bd9ed12e50752d7d2545ab0cab",
+    "text": "Two changes to the /debug/api_priority_and_fairness/dump_priority_levels endpoint of API Priority and Fairness: add total number of dispatched, timed-out, rejected and cancelled requests; output now sorted by PriorityLevelName.",
+    "markdown": "Two changes to the /debug/api_priority_and_fairness/dump_priority_levels endpoint of API Priority and Fairness: add total number of dispatched, timed-out, rejected and cancelled requests; output now sorted by PriorityLevelName. ([#112393](https://github.com/kubernetes/kubernetes/pull/112393), [@borgerli](https://github.com/borgerli)) [SIG API Machinery]",
+    "author": "borgerli",
+    "author_url": "https://github.com/borgerli",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112393",
+    "pr_number": 112393,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "112661": {
+    "commit": "571adf6e84439a5fab1ab09b6e0ceb1c2f8d2153",
+    "text": "Improved FormatMap: Improves performance by about 4x, or nearly 2x in the worst case",
+    "markdown": "Improved FormatMap: Improves performance by about 4x, or nearly 2x in the worst case ([#112661](https://github.com/kubernetes/kubernetes/pull/112661), [@aimuz](https://github.com/aimuz)) [SIG Node]",
+    "author": "aimuz",
+    "author_url": "https://github.com/aimuz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112661",
+    "pr_number": 112661,
+    "kinds": ["cleanup"],
+    "sigs": ["node"]
+  },
+  "112977": {
+    "commit": "2d88d2d993b36c231fdc7537212685544469c517",
+    "text": "Document the reason field in CRI API to ensure it equals OOMKilled for the containers terminated by OOM killer",
+    "markdown": "Document the reason field in CRI API to ensure it equals OOMKilled for the containers terminated by OOM killer ([#112977](https://github.com/kubernetes/kubernetes/pull/112977), [@mimowo](https://github.com/mimowo)) [SIG Node]",
+    "author": "mimowo",
+    "author_url": "https://github.com/mimowo",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112977",
+    "pr_number": 112977,
+    "areas": ["kubelet"],
+    "kinds": ["documentation"],
+    "sigs": ["node"]
+  },
+  "114434": {
+    "commit": "b99fe0d5b9896dd3fe9a2c1bc3b399a18ad080d2",
+    "text": "client-go: metadatainformer and dynamicinformer `SharedInformerFactory`s now supports waiting for goroutines during shutdown",
+    "markdown": "Client-go: metadatainformer and dynamicinformer `SharedInformerFactory`s now supports waiting for goroutines during shutdown ([#114434](https://github.com/kubernetes/kubernetes/pull/114434), [@howardjohn](https://github.com/howardjohn)) [SIG API Machinery]",
+    "author": "howardjohn",
+    "author_url": "https://github.com/howardjohn",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114434",
+    "pr_number": 114434,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "114494": {
+    "commit": "390ddafe9e55ea4082807aaaa95a7d9b06fd3342",
+    "text": "Graduate the `ReadWriteOncePod` feature gate to beta",
+    "markdown": "Graduate the `ReadWriteOncePod` feature gate to beta ([#114494](https://github.com/kubernetes/kubernetes/pull/114494), [@chrishenzie](https://github.com/chrishenzie)) [SIG Scheduling, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/2485",
+        "type": "KEP"
+      }
+    ],
+    "author": "chrishenzie",
+    "author_url": "https://github.com/chrishenzie",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114494",
+    "pr_number": 114494,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114625": {
+    "commit": "a8b1e5724610a5155d556e25da47a134667c051a",
+    "text": "[E2E] Pods spawned by E2E tests can now pull images from the private registry using the new --e2e-docker-config-file flag",
+    "markdown": "[E2E] Pods spawned by E2E tests can now pull images from the private registry using the new --e2e-docker-config-file flag ([#114625](https://github.com/kubernetes/kubernetes/pull/114625), [@Divya063](https://github.com/Divya063)) [SIG Node and Testing]",
+    "author": "Divya063",
+    "author_url": "https://github.com/Divya063",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114625",
+    "pr_number": 114625,
+    "areas": ["test", "e2e-test-framework"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114687": {
+    "commit": "d9ed2ff4b04d0d41b5913d4d93dddf5a6525e83e",
+    "text": "NONE",
+    "markdown": "NONE ([#114687](https://github.com/kubernetes/kubernetes/pull/114687), [@freddie400](https://github.com/freddie400)) [SIG API Machinery, Apps, Autoscaling, Cluster Lifecycle and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "freddie400",
+    "author_url": "https://github.com/freddie400",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114687",
+    "pr_number": 114687,
+    "areas": ["dependency"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "cluster-lifecycle", "autoscaling", "apps", "instrumentation"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "do_not_publish": true
+  },
+  "114872": {
+    "commit": "6e213e7390b60c6db85210f322a213768cefb172",
+    "text": "client-go: fix the wait time for trying to acquire the leader lease",
+    "markdown": "Client-go: fix the wait time for trying to acquire the leader lease ([#114872](https://github.com/kubernetes/kubernetes/pull/114872), [@Iceber](https://github.com/Iceber)) [SIG API Machinery]",
+    "author": "Iceber",
+    "author_url": "https://github.com/Iceber",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114872",
+    "pr_number": 114872,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "115096": {
+    "commit": "70f337c0d5303078a325c63216345ae84475aa69",
+    "text": "cacher: If RV is unset, the watch is now served from the underlying storage as documented.",
+    "markdown": "Cacher: If RV is unset, the watch is now served from the underlying storage as documented. ([#115096](https://github.com/kubernetes/kubernetes/pull/115096), [@MadhavJivrajani](https://github.com/MadhavJivrajani)) [SIG API Machinery]",
+    "author": "MadhavJivrajani",
+    "author_url": "https://github.com/MadhavJivrajani",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115096",
+    "pr_number": 115096,
+    "areas": ["apiserver"],
+    "kinds": ["bug", "cleanup"],
+    "sigs": ["api-machinery"],
+    "duplicate_kind": true
+  },
+  "115220": {
+    "commit": "af9f7a4d90a9562687893b4794c7109d9a05f33e",
+    "text": "kubelet: a \"maxParallelImagePulls\" field can now be specified in the kubelet configuration file to control how many image pulls the kubelet can perform in parallel.",
+    "markdown": "Kubelet: a \"maxParallelImagePulls\" field can now be specified in the kubelet configuration file to control how many image pulls the kubelet can perform in parallel. ([#115220](https://github.com/kubernetes/kubernetes/pull/115220), [@ruiwen-zhao](https://github.com/ruiwen-zhao)) [SIG API Machinery, Node and Scalability]",
+    "author": "ruiwen-zhao",
+    "author_url": "https://github.com/ruiwen-zhao",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115220",
+    "pr_number": 115220,
+    "areas": ["kubelet", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scalability", "node", "api-machinery"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115236": {
+    "commit": "8d31da4599f67e94498217fe43724acd6c8c0ef2",
+    "text": "API validation relaxed allowing Indexed Jobs to be scaled up/down by changing parallelism and completions in tandem, such that parallelism == completions.",
+    "markdown": "API validation relaxed allowing Indexed Jobs to be scaled up/down by changing parallelism and completions in tandem, such that parallelism == completions. ([#115236](https://github.com/kubernetes/kubernetes/pull/115236), [@danielvegamyhre](https://github.com/danielvegamyhre)) [SIG Apps and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3724",
+        "type": "KEP"
+      }
+    ],
+    "author": "danielvegamyhre",
+    "author_url": "https://github.com/danielvegamyhre",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115236",
+    "pr_number": 115236,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115277": {
+    "commit": "51dedff4f3efd407ebf47de11d0db521274471a3",
+    "text": "performance improvements in klog",
+    "markdown": "Performance improvements in klog ([#115277](https://github.com/kubernetes/kubernetes/pull/115277), [@pohly](https://github.com/pohly)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node, Storage and Testing]",
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115277",
+    "pr_number": 115277,
+    "areas": [
+      "test",
+      "kubelet",
+      "apiserver",
+      "kubectl",
+      "cloudprovider",
+      "code-generation",
+      "dependency"
+    ],
+    "kinds": ["feature"],
+    "sigs": [
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "testing",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true
+  },
+  "115363": {
+    "commit": "894cfdfeb4a09083849f9193f7c36360e61509eb",
+    "text": "The PodDisruptionBudget `spec.unhealthyPodEvictionPolicy` field has graduated to beta and is enabled by default. On servers with the feature enabled, this field may be set to `AlwaysAllow` to always allow unhealthy pods covered by the PodDisruptionBudget to be evicted.",
+    "markdown": "The PodDisruptionBudget `spec.unhealthyPodEvictionPolicy` field has graduated to beta and is enabled by default. On servers with the feature enabled, this field may be set to `AlwaysAllow` to always allow unhealthy pods covered by the PodDisruptionBudget to be evicted. ([#115363](https://github.com/kubernetes/kubernetes/pull/115363), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla)) [SIG Apps, Auth and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3017-pod-healthy-policy-for-pdb",
+        "type": "KEP"
+      }
+    ],
+    "author": "ravisantoshgudimetla",
+    "author_url": "https://github.com/ravisantoshgudimetla",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115363",
+    "pr_number": 115363,
+    "areas": ["code-generation"],
+    "kinds": ["api-change"],
+    "sigs": ["node", "auth", "apps"],
+    "duplicate": true
+  },
+  "115394": {
+    "commit": "292450717cb76e0c480fa5883d18fe1245176d63",
+    "text": "apiserver_storage_transformation_operations_total metric has been updated to include labels transformer_prefix and status.",
+    "markdown": "Apiserver_storage_transformation_operations_total metric has been updated to include labels transformer_prefix and status. ([#115394](https://github.com/kubernetes/kubernetes/pull/115394), [@ritazh](https://github.com/ritazh)) [SIG API Machinery, Auth, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements",
+        "type": "KEP"
+      }
+    ],
+    "author": "ritazh",
+    "author_url": "https://github.com/ritazh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115394",
+    "pr_number": 115394,
+    "areas": ["test", "apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115402": {
+    "commit": "762fa1268651206b9262a0c880a884984028bdf4",
+    "text": "Introduce API for streaming.\n\nAdd SendInitialEvents field to the ListOptions. When the new option is set together with watch=true, it begins the watch stream with synthetic init events followed by a synthetic \"Bookmark\" after which the server continues streaming events.",
+    "markdown": "Introduce API for streaming.\n  \n  Add SendInitialEvents field to the ListOptions. When the new option is set together with watch=true, it begins the watch stream with synthetic init events followed by a synthetic \"Bookmark\" after which the server continues streaming events. ([#115402](https://github.com/kubernetes/kubernetes/pull/115402), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3157-watch-list",
+        "type": "KEP"
+      }
+    ],
+    "author": "p0lyn0mial",
+    "author_url": "https://github.com/p0lyn0mial",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115402",
+    "pr_number": 115402,
+    "areas": ["apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "115420": {
+    "commit": "70c129fea52c922f474b9d8524436e9152673506",
+    "text": "File content check for IPV4 is not enabled by default, and the check of IPV4 or IPV6 is done for `kubeadm init` or `kubeadm join` only in case the user intends to create a cluster to support that kind of IP address family",
+    "markdown": "File content check for IPV4 is not enabled by default, and the check of IPV4 or IPV6 is done for `kubeadm init` or `kubeadm join` only in case the user intends to create a cluster to support that kind of IP address family ([#115420](https://github.com/kubernetes/kubernetes/pull/115420), [@chendave](https://github.com/chendave)) [SIG Cluster Lifecycle and Network]",
+    "author": "chendave",
+    "author_url": "https://github.com/chendave",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115420",
+    "pr_number": 115420,
+    "areas": ["kubeadm"],
+    "kinds": ["bug"],
+    "sigs": ["network", "cluster-lifecycle"],
+    "duplicate": true
+  },
+  "115575": {
+    "commit": "8e31885e3649fbf74500383eb399db970b8516fd",
+    "text": "kubeadm: fix a bug where the uploaded kubelet configuration in `kube-system/kubelet-config` ConfigMap does not respect user patch",
+    "markdown": "Kubeadm: fix a bug where the uploaded kubelet configuration in `kube-system/kubelet-config` ConfigMap does not respect user patch ([#115575](https://github.com/kubernetes/kubernetes/pull/115575), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115575",
+    "pr_number": 115575,
+    "areas": ["kubeadm"],
+    "kinds": ["bug"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "115590": {
+    "commit": "e18fa74551bc695014bf9da2d1eb14d2050db181",
+    "text": "Add kubelet Topology Manager metric to measure topology manager admission latency.",
+    "markdown": "Add kubelet Topology Manager metric to measure topology manager admission latency. ([#115590](https://github.com/kubernetes/kubernetes/pull/115590), [@swatisehgal](https://github.com/swatisehgal)) [SIG Node and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/pull/3745",
+        "type": "KEP"
+      }
+    ],
+    "author": "swatisehgal",
+    "author_url": "https://github.com/swatisehgal",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115590",
+    "pr_number": 115590,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115606": {
+    "commit": "aa98f6f4daa0bd6ce3931015069fe525836cbd43",
+    "text": "Pods which have an invalid negative `spec.terminationGracePeriodSeconds` value will be treated as having terminationGracePeriodSeconds of 1",
+    "markdown": "Pods which have an invalid negative `spec.terminationGracePeriodSeconds` value will be treated as having terminationGracePeriodSeconds of 1 ([#115606](https://github.com/kubernetes/kubernetes/pull/115606), [@wzshiming](https://github.com/wzshiming)) [SIG Apps, Node and Testing]",
+    "author": "wzshiming",
+    "author_url": "https://github.com/wzshiming",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115606",
+    "pr_number": 115606,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["node", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115610": {
+    "commit": "f545ff3ba8c963e4a2a384c28d8cb918f2ffd06f",
+    "text": "kubeadm: show a warning message when detecting that the sandbox image of the container runtime is inconsistent with that used by kubeadm",
+    "markdown": "Kubeadm: show a warning message when detecting that the sandbox image of the container runtime is inconsistent with that used by kubeadm ([#115610](https://github.com/kubernetes/kubernetes/pull/115610), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115610",
+    "pr_number": 115610,
+    "areas": ["kubeadm"],
+    "kinds": ["feature"],
+    "sigs": ["cluster-lifecycle"],
+    "feature": true
+  },
+  "115620": {
+    "commit": "814faade7fa3916478df963cfc6e34042e79ce89",
+    "text": "Fix missing delete events on informer re-lists to ensure all delete events are correctly emitted and using the latest known object state, so that all event handlers and stores always reflect the actual apiserver state as best as possible",
+    "markdown": "Fix missing delete events on informer re-lists to ensure all delete events are correctly emitted and using the latest known object state, so that all event handlers and stores always reflect the actual apiserver state as best as possible ([#115620](https://github.com/kubernetes/kubernetes/pull/115620), [@odinuge](https://github.com/odinuge)) [SIG API Machinery]",
+    "author": "odinuge",
+    "author_url": "https://github.com/odinuge",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115620",
+    "pr_number": 115620,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "115634": {
+    "commit": "94424ba808e145140f4ab0a0d508a488480e1b96",
+    "text": "NONE",
+    "markdown": "NONE ([#115634](https://github.com/kubernetes/kubernetes/pull/115634), [@ameukam](https://github.com/ameukam)) [SIG Cloud Provider]",
+    "author": "ameukam",
+    "author_url": "https://github.com/ameukam",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115634",
+    "pr_number": 115634,
+    "areas": ["provider/gcp"],
+    "kinds": ["cleanup"],
+    "sigs": ["cloud-provider"],
+    "do_not_publish": true
+  },
+  "115712": {
+    "commit": "6a5c88b9dd0a0e9ef0115d1bbcb196284777832b",
+    "text": "Added \"netadmin\" debugging profiles for kubectl debug.",
+    "markdown": "Added \"netadmin\" debugging profiles for kubectl debug. ([#115712](https://github.com/kubernetes/kubernetes/pull/115712), [@wedaly](https://github.com/wedaly)) [SIG CLI]",
+    "author": "wedaly",
+    "author_url": "https://github.com/wedaly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115712",
+    "pr_number": 115712,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "115719": {
+    "commit": "9e356a41321cd29fa33f15607317824a697f436c",
+    "text": "Graduated seccomp profile defaulting to GA.\n\nSet the kubelet `--seccomp-default` flag or `seccompDefault` kubelet configuration field to `true` to make pods on that node default to using the `RuntimeDefault` seccomp profile.\n\nEnabling seccomp for your workload can have a negative performance impact depending on the kernel and container runtime version in use.\n\nGuidance for identifying and mitigating those issues is outlined in the Kubernetes [seccomp tutorial](https://k8s.io/docs/tutorials/security/seccomp).",
+    "markdown": "Graduated seccomp profile defaulting to GA.\n  \n  Set the kubelet `--seccomp-default` flag or `seccompDefault` kubelet configuration field to `true` to make pods on that node default to using the `RuntimeDefault` seccomp profile.\n  \n  Enabling seccomp for your workload can have a negative performance impact depending on the kernel and container runtime version in use.\n  \n  Guidance for identifying and mitigating those issues is outlined in the Kubernetes [seccomp tutorial](https://k8s.io/docs/tutorials/security/seccomp). ([#115719](https://github.com/kubernetes/kubernetes/pull/115719), [@saschagrunert](https://github.com/saschagrunert)) [SIG API Machinery, Node, Storage and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/tree/05f81b8/keps/sig-node/2413-seccomp-by-default",
+        "type": "KEP"
+      }
+    ],
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115719",
+    "pr_number": 115719,
+    "areas": ["test", "kubelet", "code-generation", "e2e-test-framework"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["storage", "node", "api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115721": {
+    "commit": "07e7e72c071a33ad38755a5d20c3f4b88f78d722",
+    "text": "The `DownwardAPIHugePages` kubelet feature graduated to stable / GA.",
+    "markdown": "The `DownwardAPIHugePages` kubelet feature graduated to stable / GA. ([#115721](https://github.com/kubernetes/kubernetes/pull/115721), [@saschagrunert](https://github.com/saschagrunert)) [SIG Apps and Node]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/blob/b5b3585/keps/sig-node/2053-downward-api-hugepages/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115721",
+    "pr_number": 115721,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115739": {
+    "commit": "731238fb416a2ae73b39063acdf0c6326555a045",
+    "text": "None",
+    "markdown": "None ([#115739](https://github.com/kubernetes/kubernetes/pull/115739), [@heyste](https://github.com/heyste))",
+    "author": "heyste",
+    "author_url": "https://github.com/heyste",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115739",
+    "pr_number": 115739,
+    "areas": ["conformance"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "architecture"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "115758": {
+    "commit": "b8688048f8d3cca513ae36b2eb6e15f457a18df3",
+    "text": "NONE",
+    "markdown": "NONE ([#115758](https://github.com/kubernetes/kubernetes/pull/115758), [@sourcelliu](https://github.com/sourcelliu)) [SIG API Machinery]",
+    "author": "sourcelliu",
+    "author_url": "https://github.com/sourcelliu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115758",
+    "pr_number": 115758,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"],
+    "do_not_publish": true
+  },
+  "115770": {
+    "commit": "1bafca3099bc5c0aa0711de175bcd32167ad2147",
+    "text": "Yes, discovery document will correctly return the resources for aggregated apiservers that do not implement aggregated disovery",
+    "markdown": "Yes, discovery document will correctly return the resources for aggregated apiservers that do not implement aggregated disovery ([#115770](https://github.com/kubernetes/kubernetes/pull/115770), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115770",
+    "pr_number": 115770,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "115786": {
+    "commit": "b3d8ac8496a23d65a907f9333d906bcd5463764e",
+    "text": "golang.org/x/net updates to v0.7.0 to fix CVE-2022-41723",
+    "markdown": "Golang.org/x/net updates to v0.7.0 to fix CVE-2022-41723 ([#115786](https://github.com/kubernetes/kubernetes/pull/115786), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node and Storage]",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115786",
+    "pr_number": 115786,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["bug"],
+    "sigs": [
+      "storage",
+      "node",
+      "api-machinery",
+      "cluster-lifecycle",
+      "auth",
+      "cli",
+      "instrumentation",
+      "architecture",
+      "cloud-provider"
+    ],
+    "duplicate": true
+  },
+  "115800": {
+    "commit": "d6fe718e19881399fbb65f693c0c0f29f8f63861",
+    "text": "No",
+    "markdown": "No ([#115800](https://github.com/kubernetes/kubernetes/pull/115800), [@shogohida](https://github.com/shogohida)) [SIG Node and Testing]",
+    "author": "shogohida",
+    "author_url": "https://github.com/shogohida",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115800",
+    "pr_number": 115800,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "115802": {
+    "commit": "7b823002f3ee850b53cc0523ca271bc18661e5ef",
+    "text": "`apiserver_admission_webhook_admission_duration_seconds` buckets have been expanded, 25s is now the largest bucket size to match the webhook default timeout.",
+    "markdown": "`apiserver_admission_webhook_admission_duration_seconds` buckets have been expanded, 25s is now the largest bucket size to match the webhook default timeout. ([#115802](https://github.com/kubernetes/kubernetes/pull/115802), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery and Instrumentation]",
+    "author": "logicalhan",
+    "author_url": "https://github.com/logicalhan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115802",
+    "pr_number": 115802,
+    "areas": ["apiserver", "stable-metrics"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "duplicate": true
+  },
+  "115815": {
+    "commit": "06b6644fcf49661d55f7df0311e2692b8d449ab4",
+    "text": "PodSchedulingReadiness is graduated to beta.",
+    "markdown": "PodSchedulingReadiness is graduated to beta. ([#115815](https://github.com/kubernetes/kubernetes/pull/115815), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG API Machinery, Apps, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness",
+        "type": "KEP"
+      }
+    ],
+    "author": "Huang-Wei",
+    "author_url": "https://github.com/Huang-Wei",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115815",
+    "pr_number": 115815,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115821": {
+    "commit": "bce513a2b824e595c4414a05bc8ee60fa7afe0a0",
+    "text": "The Pod API field `.spec.schedulingGates[*].name` now requires qualified names (like `example.com/mygate`), matching validation for names of `.spec.readinessGates[*].name`. Any uses of the alpha scheduling gate feature prior to 1.27 that do not match that validation must be renamed or deleted before upgrading to 1.27.",
+    "markdown": "The Pod API field `.spec.schedulingGates[*].name` now requires qualified names (like `example.com/mygate`), matching validation for names of `.spec.readinessGates[*].name`. Any uses of the alpha scheduling gate feature prior to 1.27 that do not match that validation must be renamed or deleted before upgrading to 1.27. ([#115821](https://github.com/kubernetes/kubernetes/pull/115821), [@lianghao208](https://github.com/lianghao208)) [SIG Apps and Scheduling]",
+    "author": "lianghao208",
+    "author_url": "https://github.com/lianghao208",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115821",
+    "pr_number": 115821,
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115828": {
+    "commit": "5c09c9de297558fdd092c009a4eccc96dffcb713",
+    "text": "Kubernetes is now built with go 1.20.1",
+    "markdown": "Kubernetes is now built with go 1.20.1 ([#115828](https://github.com/kubernetes/kubernetes/pull/115828), [@cpanato](https://github.com/cpanato)) [SIG Release and Testing]",
+    "author": "cpanato",
+    "author_url": "https://github.com/cpanato",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115828",
+    "pr_number": 115828,
+    "areas": ["test", "release-eng"],
+    "kinds": ["feature"],
+    "sigs": ["testing", "release"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115846": {
+    "commit": "33c1a542fbfeeeceb5d2e7a862d1b76f4bfe047d",
+    "text": "Added apiserver_envelope_encryption_invalid_key_id_from_status_total to measure number of times an invalid keyID is returned by the Status RPC call.",
+    "markdown": "Added apiserver_envelope_encryption_invalid_key_id_from_status_total to measure number of times an invalid keyID is returned by the Status RPC call. ([#115846](https://github.com/kubernetes/kubernetes/pull/115846), [@ritazh](https://github.com/ritazh)) [SIG API Machinery and Auth]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements",
+        "type": "KEP"
+      }
+    ],
+    "author": "ritazh",
+    "author_url": "https://github.com/ritazh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115846",
+    "pr_number": 115846,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115861": {
+    "commit": "1f42ebc013066fe1a11e0b48155837f1dccf95df",
+    "text": "When an unsupported PodDisruptionBudget configuration is found, an event and log will be emitted to inform users of the misconfiguration.",
+    "markdown": "When an unsupported PodDisruptionBudget configuration is found, an event and log will be emitted to inform users of the misconfiguration. ([#115861](https://github.com/kubernetes/kubernetes/pull/115861), [@JayKayy](https://github.com/JayKayy)) [SIG Apps]",
+    "author": "JayKayy",
+    "author_url": "https://github.com/JayKayy",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115861",
+    "pr_number": 115861,
+    "kinds": ["feature"],
+    "sigs": ["apps"],
+    "feature": true
+  },
+  "115863": {
+    "commit": "b6582ffcd5ad83c0195afc0959976ea2eb1936a4",
+    "text": "Fixed panic in vSphere e2e tests.",
+    "markdown": "Fixed panic in vSphere e2e tests. ([#115863](https://github.com/kubernetes/kubernetes/pull/115863), [@jsafrane](https://github.com/jsafrane)) [SIG Storage and Testing]",
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115863",
+    "pr_number": 115863,
+    "areas": ["test"],
+    "kinds": ["bug", "failing-test"],
+    "sigs": ["storage", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115893": {
+    "commit": "d788d436c98e26cde800b5dee3c7aa492bc18550",
+    "text": "upgrade go-jose to v2.6.0",
+    "markdown": "Upgrade go-jose to v2.6.0 ([#115893](https://github.com/kubernetes/kubernetes/pull/115893), [@mgoltzsche](https://github.com/mgoltzsche)) [SIG API Machinery, Auth, Cluster Lifecycle and Testing]",
+    "author": "mgoltzsche",
+    "author_url": "https://github.com/mgoltzsche",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115893",
+    "pr_number": 115893,
+    "areas": ["test", "apiserver", "dependency"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "cluster-lifecycle", "auth", "testing"],
+    "duplicate": true
+  },
+  "115905": {
+    "commit": "a2c5863adcb48ce591ed5adafcba94f281732d4d",
+    "text": "Updated distroless iptables to use released image `registry.k8s.io/distroless-iptables:v0.2.1`",
+    "markdown": "Updated distroless iptables to use released image `registry.k8s.io/distroless-iptables:v0.2.1` ([#115905](https://github.com/kubernetes/kubernetes/pull/115905), [@cpanato](https://github.com/cpanato)) [SIG Testing]",
+    "author": "cpanato",
+    "author_url": "https://github.com/cpanato",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115905",
+    "pr_number": 115905,
+    "areas": ["test"],
+    "kinds": ["cleanup", "feature"],
+    "sigs": ["testing"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "115907": {
+    "commit": "697ea476e27f4fb47cc3b009b3d4a840824d20df",
+    "text": "Fixed an EndpointSlice Controller hashing bug that could cause EndpointSlices to incorrectly handle Pods with duplicate IP addresses. For example this could happen when a new Pod reused an IP that was also assigned to a Pod in a completed state.",
+    "markdown": "Fixed an EndpointSlice Controller hashing bug that could cause EndpointSlices to incorrectly handle Pods with duplicate IP addresses. For example this could happen when a new Pod reused an IP that was also assigned to a Pod in a completed state. ([#115907](https://github.com/kubernetes/kubernetes/pull/115907), [@qinqon](https://github.com/qinqon)) [SIG Apps and Network]",
+    "author": "qinqon",
+    "author_url": "https://github.com/qinqon",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115907",
+    "pr_number": 115907,
+    "kinds": ["bug"],
+    "sigs": ["network", "apps"],
+    "duplicate": true
+  },
+  "115919": {
+    "commit": "39a99710bcd784a89d423c27ce6371109e37c7ea",
+    "text": "Fixing issue with Winkernel Proxier - ClusterIP Loadbalancers are missing if the ExternalTrafficPolicy is set to Local and the available endpoints are all remoteEndpoints.",
+    "markdown": "Fixing issue with Winkernel Proxier - ClusterIP Loadbalancers are missing if the ExternalTrafficPolicy is set to Local and the available endpoints are all remoteEndpoints. ([#115919](https://github.com/kubernetes/kubernetes/pull/115919), [@princepereira](https://github.com/princepereira)) [SIG Network and Windows]",
+    "author": "princepereira",
+    "author_url": "https://github.com/princepereira",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115919",
+    "pr_number": 115919,
+    "kinds": ["bug"],
+    "sigs": ["network", "windows"],
+    "duplicate": true
+  },
+  "115928": {
+    "commit": "f32302e744e294cd3b61af4f7b5fe1529e42e330",
+    "text": "volumes: `resource.claims` gets cleared for PVC specs during create or update of a pod spec with inline PVC template or of a PVC because it has no effect.",
+    "markdown": "Volumes: `resource.claims` gets cleared for PVC specs during create or update of a pod spec with inline PVC template or of a PVC because it has no effect. ([#115928](https://github.com/kubernetes/kubernetes/pull/115928), [@pohly](https://github.com/pohly)) [SIG API Machinery, Apps and Storage]",
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115928",
+    "pr_number": 115928,
+    "areas": ["code-generation"],
+    "kinds": ["bug", "api-change"],
+    "sigs": ["storage", "api-machinery", "apps"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115940": {
+    "commit": "e519921666b760b782b46a29179997ab97671068",
+    "text": "Pod template `schedulingGates` are now mutable for Jobs that are suspended and have never been started",
+    "markdown": "Pod template `schedulingGates` are now mutable for Jobs that are suspended and have never been started ([#115940](https://github.com/kubernetes/kubernetes/pull/115940), [@ahg-g](https://github.com/ahg-g)) [SIG Apps]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/2926-job-mutable-scheduling-directives",
+        "type": "KEP"
+      }
+    ],
+    "author": "ahg-g",
+    "author_url": "https://github.com/ahg-g",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115940",
+    "pr_number": 115940,
+    "kinds": ["feature"],
+    "sigs": ["apps"],
+    "feature": true
+  },
+  "115944": {
+    "commit": "0753f0285150d0dcee8a4ea0a4a601ba1e76859e",
+    "text": "Added a [warning](https://k8s.io/blog/2020/09/03/warnings/) response when handling requests that set the deprecated `spec.externalID` field for a Node.",
+    "markdown": "Added a [warning](https://k8s.io/blog/2020/09/03/warnings/) response when handling requests that set the deprecated `spec.externalID` field for a Node. ([#115944](https://github.com/kubernetes/kubernetes/pull/115944), [@SataQiu](https://github.com/SataQiu)) [SIG Node]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115944",
+    "pr_number": 115944,
+    "kinds": ["deprecation"],
+    "sigs": ["node"]
+  },
+  "116018": {
+    "commit": "ad523879944879449275669bfc13b06aadc06e94",
+    "text": "Fix log line in scheduler that inaccurately implies that volume binding has finalized",
+    "markdown": "Fix log line in scheduler that inaccurately implies that volume binding has finalized ([#116018](https://github.com/kubernetes/kubernetes/pull/116018), [@TommyStarK](https://github.com/TommyStarK)) [SIG Scheduling and Storage]",
+    "author": "TommyStarK",
+    "author_url": "https://github.com/TommyStarK",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116018",
+    "pr_number": 116018,
+    "kinds": ["bug"],
+    "sigs": ["scheduling", "storage"],
+    "duplicate": true
+  },
+  "116033": {
+    "commit": "8cd421163050d6416357d9f6cf860495b067682d",
+    "text": "NONE",
+    "markdown": "NONE ([#116033](https://github.com/kubernetes/kubernetes/pull/116033), [@chengjoey](https://github.com/chengjoey)) [SIG API Machinery and Instrumentation]",
+    "author": "chengjoey",
+    "author_url": "https://github.com/chengjoey",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116033",
+    "pr_number": 116033,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "116074": {
+    "commit": "911631a6e030a24aeb526c425f498334e743b32b",
+    "text": "kubeadm: modify '--config' flag from required to optional for 'kubeadm kubeconfig user' command",
+    "markdown": "Kubeadm: modify '--config' flag from required to optional for 'kubeadm kubeconfig user' command ([#116074](https://github.com/kubernetes/kubernetes/pull/116074), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116074",
+    "pr_number": 116074,
+    "areas": ["kubeadm"],
+    "kinds": ["bug"],
+    "sigs": ["cluster-lifecycle"]
+  },
+  "116089": {
+    "commit": "5157158d3d86cbe1c03c28171b2428183ee00009",
+    "text": "Fixed a bug where Kubernetes would apply a default StorageClass to a PersistentVolumeClaim,\neven when the deprecated annotation `volume.beta.kubernetes.io/storage-class` was set.",
+    "markdown": "Fixed a bug where Kubernetes would apply a default StorageClass to a PersistentVolumeClaim,\n  even when the deprecated annotation `volume.beta.kubernetes.io/storage-class` was set. ([#116089](https://github.com/kubernetes/kubernetes/pull/116089), [@cvvz](https://github.com/cvvz)) [SIG Apps and Storage]",
+    "author": "cvvz",
+    "author_url": "https://github.com/cvvz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116089",
+    "pr_number": 116089,
+    "kinds": ["bug", "regression"],
+    "sigs": ["storage", "apps"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116102": {
+    "commit": "aad305051934350e8f51d57a852a0ba390f97757",
+    "text": "NONE",
+    "markdown": "NONE ([#116102](https://github.com/kubernetes/kubernetes/pull/116102), [@danielvegamyhre](https://github.com/danielvegamyhre)) [SIG Apps]",
+    "author": "danielvegamyhre",
+    "author_url": "https://github.com/danielvegamyhre",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116102",
+    "pr_number": 116102,
+    "kinds": ["cleanup"],
+    "sigs": ["apps"],
+    "do_not_publish": true
+  },
+  "116116": {
+    "commit": "6e202d6fdb197ad1fd98b6bb8e6388b2a023a6d4",
+    "text": "The `JobMutableNodeSchedulingDirectives` feature gate has graduated to GA.",
+    "markdown": "The `JobMutableNodeSchedulingDirectives` feature gate has graduated to GA. ([#116116](https://github.com/kubernetes/kubernetes/pull/116116), [@ahg-g](https://github.com/ahg-g)) [SIG Apps, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/2926-job-mutable-scheduling-directives",
+        "type": "KEP"
+      }
+    ],
+    "author": "ahg-g",
+    "author_url": "https://github.com/ahg-g",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116116",
+    "pr_number": 116116,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116171": {
+    "commit": "42a91c29e5903c1f93cc9399635043a14bc99715",
+    "text": "NONE",
+    "markdown": "NONE ([#116171](https://github.com/kubernetes/kubernetes/pull/116171), [@daman1807](https://github.com/daman1807)) [SIG Network]",
+    "author": "daman1807",
+    "author_url": "https://github.com/daman1807",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116171",
+    "pr_number": 116171,
+    "areas": ["ipvs"],
+    "kinds": ["bug", "cleanup"],
+    "sigs": ["network"],
+    "duplicate_kind": true,
+    "do_not_publish": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.27.0-alpha.3.json',
   'assets/release-notes-1.27.0-alpha.2.json',
   'assets/release-notes-1.27.0-alpha.1.json',
   'assets/release-notes-1.26.0.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.27.0-alpha.3` 