### PR TITLE
Patch relnotes.k8s.io to release v1.27.0-beta.0

### DIFF
--- a/src/assets/release-notes-1.27.0-beta.0.json
+++ b/src/assets/release-notes-1.27.0-beta.0.json
@@ -1,0 +1,2451 @@
+{
+  "107124": {
+    "commit": "8c97443b7b5269e3e96ce31e82e0744219917252",
+    "text": "The change affects the following CLI command:\n\nkubectl create rolebinding -h",
+    "markdown": "The change affects the following CLI command:\n  \n  kubectl create rolebinding -h ([#107124](https://github.com/kubernetes/kubernetes/pull/107124), [@ptux](https://github.com/ptux)) [SIG CLI]",
+    "author": "ptux",
+    "author_url": "https://github.com/ptux",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107124",
+    "pr_number": 107124,
+    "areas": ["kubectl"],
+    "kinds": ["documentation"],
+    "sigs": ["cli"]
+  },
+  "107826": {
+    "commit": "5469b170fe8717cb9fae8f12498cd1afd5586891",
+    "text": "The `wait.Poll*` and `wait.ExponentialBackoff*` functions have been deprecated and will be removed in a future release.  Callers should switch to using `wait.PollUntilContextCancel`, `wait.PollUntilContextTimeout`, or `wait.ExponentialBackoffWithContext` as appropriate.\n\n`PollWithContext(Cancel|Deadline)` will no longer return `ErrWaitTimeout` - use the `Interrupted(error) bool` helper to replace checks for `err == ErrWaitTimeout`, or compare specifically to context errors as needed. A future release will make the `ErrWaitTimeout` error private and callers must use `Interrupted()` instead. If you are returning `ErrWaitTimeout` from your own methods, switch to creating a location specific `cause err` and pass it to the new method `wait.ErrorInterrupted(cause) error` which will ensure `Interrupted()` returns true for your loop. \n\nThe `wait.NewExponentialBackoffManager` and `wait.NewJitteringBackoffManager` functions have been marked as deprecated.  Callers should switch to using the `Backoff{...}.DelayWithReset(clock, resetInterval)` method and must set the `Steps` field when using `Factor`. As a short term change, callers may use the `Timer()` method on the `BackoffManager` until the backoff managers are deprecated and removed. Please see the godoc of the deprecated functions for examples of how to replace usage of this function.",
+    "markdown": "The `wait.Poll*` and `wait.ExponentialBackoff*` functions have been deprecated and will be removed in a future release.  Callers should switch to using `wait.PollUntilContextCancel`, `wait.PollUntilContextTimeout`, or `wait.ExponentialBackoffWithContext` as appropriate.\n  \n  `PollWithContext(Cancel|Deadline)` will no longer return `ErrWaitTimeout` - use the `Interrupted(error) bool` helper to replace checks for `err == ErrWaitTimeout`, or compare specifically to context errors as needed. A future release will make the `ErrWaitTimeout` error private and callers must use `Interrupted()` instead. If you are returning `ErrWaitTimeout` from your own methods, switch to creating a location specific `cause err` and pass it to the new method `wait.ErrorInterrupted(cause) error` which will ensure `Interrupted()` returns true for your loop. \n  \n  The `wait.NewExponentialBackoffManager` and `wait.NewJitteringBackoffManager` functions have been marked as deprecated.  Callers should switch to using the `Backoff{...}.DelayWithReset(clock, resetInterval)` method and must set the `Steps` field when using `Factor`. As a short term change, callers may use the `Timer()` method on the `BackoffManager` until the backoff managers are deprecated and removed. Please see the godoc of the deprecated functions for examples of how to replace usage of this function. ([#107826](https://github.com/kubernetes/kubernetes/pull/107826), [@smarterclayton](https://github.com/smarterclayton)) [SIG API Machinery, Auth, Cloud Provider, Storage and Testing]",
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/107826",
+    "pr_number": 107826,
+    "areas": ["test", "apiserver", "cloudprovider"],
+    "kinds": ["cleanup"],
+    "sigs": ["storage", "api-machinery", "auth", "testing", "cloud-provider"],
+    "duplicate": true
+  },
+  "108838": {
+    "commit": "c072cae4d0a5c4fcee7a8f1ee2bbbabf2f9504e9",
+    "text": "Added the ability to host webhooks in the cloud controller manager.",
+    "markdown": "Added the ability to host webhooks in the cloud controller manager. ([#108838](https://github.com/kubernetes/kubernetes/pull/108838), [@nckturner](https://github.com/nckturner)) [SIG API Machinery, Cloud Provider and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]: [KEP-2699](",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2699-add-webhook-hosting-to-ccm)",
+        "type": "KEP"
+      }
+    ],
+    "author": "nckturner",
+    "author_url": "https://github.com/nckturner",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/108838",
+    "pr_number": 108838,
+    "areas": ["test", "cloudprovider", "code-generation"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "testing", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "110566": {
+    "commit": "37937bb2279092ebff22eee80c64423f1f0923b2",
+    "text": "Setting the Kubelet config option ``--resolv-conf=Host`` on Windows will now result in Kubelet applying the Pod DNS Policies as intended.",
+    "markdown": "Setting the Kubelet config option ``--resolv-conf=Host`` on Windows will now result in Kubelet applying the Pod DNS Policies as intended. ([#110566](https://github.com/kubernetes/kubernetes/pull/110566), [@claudiubelu](https://github.com/claudiubelu)) [SIG Network, Node, Testing and Windows]",
+    "author": "claudiubelu",
+    "author_url": "https://github.com/claudiubelu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110566",
+    "pr_number": 110566,
+    "areas": ["kubelet"],
+    "kinds": ["failing-test"],
+    "sigs": ["network", "node", "windows", "testing"],
+    "duplicate": true
+  },
+  "110772": {
+    "commit": "90c3232de77aa0dd09b948ffdd27c575688fba8a",
+    "text": "Introduces new alpha functionality to the reflector, allowing user to enable API streaming.\n\nTo activate this feature, users can set the `ENABLE_CLIENT_GO_WATCH_LIST_ALPHA` environmental variable.\nIt is important to note that the server must support streaming for this feature to function properly.\nIf streaming is not supported by the server, the reflector will revert to the previous method\nof obtaining data through LIST/WATCH semantics.",
+    "markdown": "Introduces new alpha functionality to the reflector, allowing user to enable API streaming.\n  \n  To activate this feature, users can set the `ENABLE_CLIENT_GO_WATCH_LIST_ALPHA` environmental variable.\n  It is important to note that the server must support streaming for this feature to function properly.\n  If streaming is not supported by the server, the reflector will revert to the previous method\n  of obtaining data through LIST/WATCH semantics. ([#110772](https://github.com/kubernetes/kubernetes/pull/110772), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3157-watch-list",
+        "type": "KEP"
+      }
+    ],
+    "author": "p0lyn0mial",
+    "author_url": "https://github.com/p0lyn0mial",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110772",
+    "pr_number": 110772,
+    "areas": ["apiserver"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery"]
+  },
+  "110864": {
+    "commit": "e3edf134861d203ed8c3b65dbcafaa3c982987c0",
+    "text": "Windows CPU usage node stats are now correctly calculated for nodes with multiple Processor Groups.",
+    "markdown": "Windows CPU usage node stats are now correctly calculated for nodes with multiple Processor Groups. ([#110864](https://github.com/kubernetes/kubernetes/pull/110864), [@claudiubelu](https://github.com/claudiubelu)) [SIG Node, Testing and Windows]",
+    "author": "claudiubelu",
+    "author_url": "https://github.com/claudiubelu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/110864",
+    "pr_number": 110864,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node", "windows", "testing"],
+    "duplicate": true
+  },
+  "111372": {
+    "commit": "7529178924a997708fa1ad93b32d00326cc27fb0",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#111372](https://github.com/kubernetes/kubernetes/pull/111372), [@HeavenTonight](https://github.com/HeavenTonight)) [SIG API Machinery, Apps, Cloud Provider, Testing and Windows]",
+    "author": "HeavenTonight",
+    "author_url": "https://github.com/HeavenTonight",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111372",
+    "pr_number": 111372,
+    "areas": ["test", "apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "apps", "windows", "testing", "cloud-provider"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "111634": {
+    "commit": "33d9543ceb09a9aff54940d639da23c6102d2fcc",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#111634](https://github.com/kubernetes/kubernetes/pull/111634), [@KunWuLuan](https://github.com/KunWuLuan)) [SIG Node]",
+    "author": "KunWuLuan",
+    "author_url": "https://github.com/KunWuLuan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111634",
+    "pr_number": 111634,
+    "areas": ["kubelet"],
+    "kinds": ["bug", "documentation"],
+    "sigs": ["node"],
+    "duplicate_kind": true,
+    "do_not_publish": true
+  },
+  "111658": {
+    "commit": "87a40ae6702b64c4c7b74b873742388882df2a82",
+    "text": "Expands the partial fix for https://github.com/kubernetes/kubernetes/issues/111539 which was already started in https://github.com/kubernetes/kubernetes/pull/109706 Specifically, we will now reduce the amount of syncs for ETP=local services even further in the CCM and avoid re-configuring LBs to an even greater extent.",
+    "markdown": "Expands the partial fix for https://github.com/kubernetes/kubernetes/issues/111539 which was already started in https://github.com/kubernetes/kubernetes/pull/109706 Specifically, we will now reduce the amount of syncs for ETP=local services even further in the CCM and avoid re-configuring LBs to an even greater extent. ([#111658](https://github.com/kubernetes/kubernetes/pull/111658), [@alexanderConstantinescu](https://github.com/alexanderConstantinescu)) [SIG Cloud Provider and Network]",
+    "author": "alexanderConstantinescu",
+    "author_url": "https://github.com/alexanderConstantinescu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111658",
+    "pr_number": 111658,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["network", "cloud-provider"],
+    "duplicate": true
+  },
+  "111661": {
+    "commit": "86bf570711ed1ef6e94f5fbb006b07760683a901",
+    "text": "Fixes #115825. Kube-proxy will now include the `healthz` state in its response to the LB HC as to avoid indicating to the LB that it should use the node in question when Kube-proxy is not healthy.",
+    "markdown": "Fixes #115825. Kube-proxy will now include the `healthz` state in its response to the LB HC as to avoid indicating to the LB that it should use the node in question when Kube-proxy is not healthy. ([#111661](https://github.com/kubernetes/kubernetes/pull/111661), [@alexanderConstantinescu](https://github.com/alexanderConstantinescu)) [SIG Network]",
+    "author": "alexanderConstantinescu",
+    "author_url": "https://github.com/alexanderConstantinescu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/111661",
+    "pr_number": 111661,
+    "areas": ["ipvs"],
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "112334": {
+    "commit": "689fc37dd2f92ca61f4f2405186cb7e097be3ab1",
+    "text": "Update the Event series starting count when emitting isomorphic events from 1 to 2.",
+    "markdown": "Update the Event series starting count when emitting isomorphic events from 1 to 2. ([#112334](https://github.com/kubernetes/kubernetes/pull/112334), [@dgrisonnet](https://github.com/dgrisonnet)) [SIG API Machinery and Testing]",
+    "author": "dgrisonnet",
+    "author_url": "https://github.com/dgrisonnet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112334",
+    "pr_number": 112334,
+    "areas": ["test"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "testing"],
+    "duplicate": true
+  },
+  "112670": {
+    "commit": "37326f7cea750f6b48c61649d59af9183694d4a4",
+    "text": "Migrate `pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go, pkg/controller/nodeipam/ipam/multi_cidr_range_allocator.go pkg/controller/nodeipam/ipam/range_allocator.go pkg/controller/nodelifecycle/node_lifecycle_controller.go` to structured logging",
+    "markdown": "Migrate `pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go, pkg/controller/nodeipam/ipam/multi_cidr_range_allocator.go pkg/controller/nodeipam/ipam/range_allocator.go pkg/controller/nodelifecycle/node_lifecycle_controller.go` to structured logging ([#112670](https://github.com/kubernetes/kubernetes/pull/112670), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG API Machinery, Apps, Architecture, Cloud Provider, Instrumentation, Network and Testing]",
+    "author": "yangjunmyfm192085",
+    "author_url": "https://github.com/yangjunmyfm192085",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/112670",
+    "pr_number": 112670,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": [
+      "network",
+      "api-machinery",
+      "apps",
+      "instrumentation",
+      "testing",
+      "architecture",
+      "cloud-provider"
+    ],
+    "duplicate": true
+  },
+  "113145": {
+    "commit": "c5a1f0188b410e667ba86590e926c685b9ea0735",
+    "text": "Force deleted pods may fail to terminate until the kubelet is restarted when the container runtime returns an error during termination. We have strengthened testing for runtime failures and now perform a more rigorous reconciliation to ensure static pods (especially those that use fixed UIDs) are restarted.  As a side effect of these changes static pods will be restarted with lower latency than before (2s vs 4s, on average) and rapid updates to pod configuration should take effect sooner.\n\nA new metric `kubelet_known_pods` has been added at ALPHA stability to report the number of pods a Kubelet is tracking in a number of internal states.  Operators may use the metrics to track an excess of pods in the orphaned state that may not be completing.",
+    "markdown": "Force deleted pods may fail to terminate until the kubelet is restarted when the container runtime returns an error during termination. We have strengthened testing for runtime failures and now perform a more rigorous reconciliation to ensure static pods (especially those that use fixed UIDs) are restarted.  As a side effect of these changes static pods will be restarted with lower latency than before (2s vs 4s, on average) and rapid updates to pod configuration should take effect sooner.\n  \n  A new metric `kubelet_known_pods` has been added at ALPHA stability to report the number of pods a Kubelet is tracking in a number of internal states.  Operators may use the metrics to track an excess of pods in the orphaned state that may not be completing. ([#113145](https://github.com/kubernetes/kubernetes/pull/113145), [@smarterclayton](https://github.com/smarterclayton)) [SIG API Machinery, Auth, Cloud Provider, Node and Testing]",
+    "author": "smarterclayton",
+    "author_url": "https://github.com/smarterclayton",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113145",
+    "pr_number": 113145,
+    "areas": ["test", "kubelet", "apiserver", "cloudprovider", "e2e-test-framework", "dependency"],
+    "kinds": ["bug"],
+    "sigs": ["node", "api-machinery", "auth", "testing", "cloud-provider"],
+    "duplicate": true
+  },
+  "113218": {
+    "commit": "a34e37c9963af5944435b736882bfcd1e81f7e09",
+    "text": "Added a new alpha API: ClusterTrustBundle (`certificates.k8s.io/v1alpha1`).\nA ClusterTrustBundle may be used to distribute [X.509](https://www.itu.int/rec/T-REC-X.509) trust anchors to workloads within the cluster.",
+    "markdown": "Added a new alpha API: ClusterTrustBundle (`certificates.k8s.io/v1alpha1`).\n  A ClusterTrustBundle may be used to distribute [X.509](https://www.itu.int/rec/T-REC-X.509) trust anchors to workloads within the cluster. ([#113218](https://github.com/kubernetes/kubernetes/pull/113218), [@ahmedtd](https://github.com/ahmedtd)) [SIG API Machinery, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/bddca24910fb349e2eb0ac1c822c77f0f32fe9c6/keps/sig-auth/3257-trust-anchor-sets",
+        "type": "KEP"
+      }
+    ],
+    "author": "ahmedtd",
+    "author_url": "https://github.com/ahmedtd",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113218",
+    "pr_number": 113218,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113270": {
+    "commit": "9f0b4919531a87f762a85fd5d04d85bab9557636",
+    "text": "PVCs will automatically be recreated if they are missing for a pending Pod.",
+    "markdown": "PVCs will automatically be recreated if they are missing for a pending Pod. ([#113270](https://github.com/kubernetes/kubernetes/pull/113270), [@rrangith](https://github.com/rrangith)) [SIG Apps and Testing]",
+    "author": "rrangith",
+    "author_url": "https://github.com/rrangith",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113270",
+    "pr_number": 113270,
+    "areas": ["test", "e2e-test-framework"],
+    "kinds": ["bug"],
+    "sigs": ["apps", "testing"],
+    "duplicate": true
+  },
+  "113428": {
+    "commit": "3489796d5cb5e8d90f98443579ff4ff0d741cea9",
+    "text": "#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#113428](https://github.com/kubernetes/kubernetes/pull/113428), [@mengjiao-liu](https://github.com/mengjiao-liu)) [SIG API Machinery, Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "mengjiao-liu",
+    "author_url": "https://github.com/mengjiao-liu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113428",
+    "pr_number": 113428,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113443": {
+    "commit": "185cd95b9cc1d4254c42f11c90adbc97c1f6e26c",
+    "text": "Migrated the namespace controller (within `kube-controller-manager`) to support [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the namespace controller (within `kube-controller-manager`) to support [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113443](https://github.com/kubernetes/kubernetes/pull/113443), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG API Machinery, Apps, Instrumentation, Node and Testing]",
+    "author": "yangjunmyfm192085",
+    "author_url": "https://github.com/yangjunmyfm192085",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113443",
+    "pr_number": 113443,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["node", "api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113464": {
+    "commit": "e56f3e078163845e0fa5359446aeccac261db4e6",
+    "text": "Migrated the bootstrap signer controller and the token cleaner controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the bootstrap signer controller and the token cleaner controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113464](https://github.com/kubernetes/kubernetes/pull/113464), [@mengjiao-liu](https://github.com/mengjiao-liu)) [SIG API Machinery, Apps and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "mengjiao-liu",
+    "author_url": "https://github.com/mengjiao-liu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113464",
+    "pr_number": 113464,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113471": {
+    "commit": "cbf7d96a854084f268436848e35ea90fbaf00a7b",
+    "text": "Migrated the Kubernetes object garbage collector (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the Kubernetes object garbage collector (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113471](https://github.com/kubernetes/kubernetes/pull/113471), [@ncdc](https://github.com/ncdc)) [SIG API Machinery, Apps and Testing]",
+    "author": "ncdc",
+    "author_url": "https://github.com/ncdc",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113471",
+    "pr_number": 113471,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "apps", "testing"],
+    "duplicate": true
+  },
+  "113525": {
+    "commit": "66bda6c0920798e1b6377db1332a83080c99b909",
+    "text": "Migrated the Deployment controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging)",
+    "markdown": "Migrated the Deployment controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging) ([#113525](https://github.com/kubernetes/kubernetes/pull/113525), [@249043822](https://github.com/249043822)) [SIG API Machinery, Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "249043822",
+    "author_url": "https://github.com/249043822",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113525",
+    "pr_number": 113525,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113584": {
+    "commit": "49649c89ea8fa0c7f81103f735b089ed5537aa37",
+    "text": "Migrated the volume attach/detach controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).\nMigrated the PersistentVolumeClaim protection controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).\nMigrated the PersistentVolume protection controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the volume attach/detach controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).\n  Migrated the PersistentVolumeClaim protection controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).\n  Migrated the PersistentVolume protection controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113584](https://github.com/kubernetes/kubernetes/pull/113584), [@yangjunmyfm192085](https://github.com/yangjunmyfm192085)) [SIG API Machinery, Apps, Instrumentation, Node, Scheduling, Storage and Testing]",
+    "author": "yangjunmyfm192085",
+    "author_url": "https://github.com/yangjunmyfm192085",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113584",
+    "pr_number": 113584,
+    "areas": ["test", "kubelet"],
+    "kinds": ["feature"],
+    "sigs": [
+      "scheduling",
+      "storage",
+      "node",
+      "api-machinery",
+      "apps",
+      "instrumentation",
+      "testing"
+    ],
+    "feature": true,
+    "duplicate": true
+  },
+  "113622": {
+    "commit": "f769c66aa84e94eb425677c439f7b0e66809d3c4",
+    "text": "Migrated the DaemonSet controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging)",
+    "markdown": "Migrated the DaemonSet controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging) ([#113622](https://github.com/kubernetes/kubernetes/pull/113622), [@249043822](https://github.com/249043822)) [SIG API Machinery, Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "249043822",
+    "author_url": "https://github.com/249043822",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113622",
+    "pr_number": 113622,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "113840": {
+    "commit": "a239b9986b00e968196860cf9e885b89961c9bb2",
+    "text": "Migrated the StatefulSet controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging)",
+    "markdown": "Migrated the StatefulSet controller (within `kube-controller-manager) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging) ([#113840](https://github.com/kubernetes/kubernetes/pull/113840), [@249043822](https://github.com/249043822)) [SIG API Machinery, Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "249043822",
+    "author_url": "https://github.com/249043822",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113840",
+    "pr_number": 113840,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113879": {
+    "commit": "1af56548af167d836eff33a5f57552fa417cbc0b",
+    "text": "Migrated the “sample-controller” controller to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the “sample-controller” controller to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113879](https://github.com/kubernetes/kubernetes/pull/113879), [@pchan](https://github.com/pchan)) [SIG API Machinery and Instrumentation]",
+    "author": "pchan",
+    "author_url": "https://github.com/pchan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113879",
+    "pr_number": 113879,
+    "areas": ["logging"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery", "instrumentation"],
+    "duplicate": true
+  },
+  "113910": {
+    "commit": "c88b61f5536466d3826c96b9f9f38970572143b5",
+    "text": "Migrated the ClusterRole aggregation controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the ClusterRole aggregation controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113910](https://github.com/kubernetes/kubernetes/pull/113910), [@mengjiao-liu](https://github.com/mengjiao-liu)) [SIG API Machinery, Apps and Instrumentation]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "mengjiao-liu",
+    "author_url": "https://github.com/mengjiao-liu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113910",
+    "pr_number": 113910,
+    "areas": ["logging"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113916": {
+    "commit": "471b392f43e8fdcbbff14f4494ac278af2d0194c",
+    "text": "Migrated the “TTL after finished” controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the “TTL after finished” controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113916](https://github.com/kubernetes/kubernetes/pull/113916), [@songxiao-wang87](https://github.com/songxiao-wang87)) [SIG API Machinery, Apps, Instrumentation and Testing]",
+    "author": "songxiao-wang87",
+    "author_url": "https://github.com/songxiao-wang87",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113916",
+    "pr_number": 113916,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "113986": {
+    "commit": "4aaa4df840949fa533555bfa7c1b01e3463255ba",
+    "text": "StorageVersionGC (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "StorageVersionGC (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#113986](https://github.com/kubernetes/kubernetes/pull/113986), [@songxiao-wang87](https://github.com/songxiao-wang87)) [SIG API Machinery, Apps and Testing]",
+    "author": "songxiao-wang87",
+    "author_url": "https://github.com/songxiao-wang87",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/113986",
+    "pr_number": 113986,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114017": {
+    "commit": "0ffac50126b53a9c06070022b811c2d033a091af",
+    "text": "kubelet: remove deprecated flag `--container-runtime`",
+    "markdown": "Kubelet: remove deprecated flag `--container-runtime` ([#114017](https://github.com/kubernetes/kubernetes/pull/114017), [@calvin0327](https://github.com/calvin0327)) [SIG Cloud Provider and Node]",
+    "author": "calvin0327",
+    "author_url": "https://github.com/calvin0327",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114017",
+    "pr_number": 114017,
+    "areas": ["kubelet", "provider/gcp"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "cloud-provider"],
+    "duplicate": true
+  },
+  "114226": {
+    "commit": "06619135e0668a059b06b8bd588def5aa9c12e03",
+    "text": "Make `apiextensions-apiserver` binary linking static (also affects the deb and rpm packages).",
+    "markdown": "Make `apiextensions-apiserver` binary linking static (also affects the deb and rpm packages). ([#114226](https://github.com/kubernetes/kubernetes/pull/114226), [@saschagrunert](https://github.com/saschagrunert)) [SIG API Machinery and Release]",
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114226",
+    "pr_number": 114226,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "release"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114227": {
+    "commit": "5452109c9d9eaa62907e1476811c383fe80b1129",
+    "text": "Make `kube-aggregator` binary linking static (also affects the deb and rpm packages).",
+    "markdown": "Make `kube-aggregator` binary linking static (also affects the deb and rpm packages). ([#114227](https://github.com/kubernetes/kubernetes/pull/114227), [@saschagrunert](https://github.com/saschagrunert)) [SIG API Machinery and Release]",
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114227",
+    "pr_number": 114227,
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "release"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114357": {
+    "commit": "f6564d33ba5d3125024275dac8e702d2ed97b615",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#114357](https://github.com/kubernetes/kubernetes/pull/114357), [@dengyufeng2206](https://github.com/dengyufeng2206)) [SIG Auth, Node and Scalability]",
+    "author": "dengyufeng2206",
+    "author_url": "https://github.com/dengyufeng2206",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114357",
+    "pr_number": 114357,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["scalability", "node", "auth"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "114397": {
+    "commit": "8745423a7abb8f648cd73462b70928c4da560309",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#114397](https://github.com/kubernetes/kubernetes/pull/114397), [@my-git9](https://github.com/my-git9)) [SIG Node]",
+    "author": "my-git9",
+    "author_url": "https://github.com/my-git9",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114397",
+    "pr_number": 114397,
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "114426": {
+    "commit": "78fe7c0dbc418e8692b08da055beb13302ef2efb",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#114426](https://github.com/kubernetes/kubernetes/pull/114426), [@my-git9](https://github.com/my-git9)) [SIG Node]",
+    "author": "my-git9",
+    "author_url": "https://github.com/my-git9",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114426",
+    "pr_number": 114426,
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "114497": {
+    "commit": "94e30facdbe4d21234a07da0b7998b4b8a3b1414",
+    "text": "Introduce new metrics removing the redundant subsystem in kube-apiserver pod logs metrics and deprecate the original ones:\n- kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total becomes kube_apiserver_pod_logs_backend_tls_failure_total\n- kube_apiserver_pod_logs_pods_logs_insecure_backend_total becomes kube_apiserver_pod_logs_insecure_backend_total",
+    "markdown": "Introduce new metrics removing the redundant subsystem in kube-apiserver pod logs metrics and deprecate the original ones:\n  - kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total becomes kube_apiserver_pod_logs_backend_tls_failure_total\n  - kube_apiserver_pod_logs_pods_logs_insecure_backend_total becomes kube_apiserver_pod_logs_insecure_backend_total ([#114497](https://github.com/kubernetes/kubernetes/pull/114497), [@dgrisonnet](https://github.com/dgrisonnet)) [SIG API Machinery]",
+    "author": "dgrisonnet",
+    "author_url": "https://github.com/dgrisonnet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114497",
+    "pr_number": 114497,
+    "areas": ["apiserver"],
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"]
+  },
+  "114498": {
+    "commit": "10802e9be1ae76d837254dcde43747151a2833bb",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#114498](https://github.com/kubernetes/kubernetes/pull/114498), [@runzhliu](https://github.com/runzhliu)) [SIG Node]",
+    "author": "runzhliu",
+    "author_url": "https://github.com/runzhliu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114498",
+    "pr_number": 114498,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "114572": {
+    "commit": "68eea2468c58b7bd24ec871686795983b7a41ffd",
+    "text": "Dec 16 09:28:34 n198-252-054 kubelet[2509137]: fatal error: concurrent map iteration and map write\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: goroutine 207 [running]:\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).generateDeviceTopologyHints.func1({0x52e4410, 0xc00363f620})\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/devicemanager/topology_hints.go:163 +0xe7\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask.IterateBitMasks.func1({0xc000a4b858?, 0x77f0930?, 0xc00025d800?}, {0xc00363f618?, 0x0?, 0x416d57?}, 0xc001919158?)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/bitmask/bitmask.go:211 +0xa3\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask.IterateBitMasks.func1({0xc000a4b850, 0x2, 0x2}, {0x77f0930?, 0x0, 0x0}, 0x1)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/bitmask/bitmask.go:215 +0xcc\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask.IterateBitMasks({0xc000a4b850, 0x2, 0x2}, 0x41232a0?)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/bitmask/bitmask.go:220 +0x90\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).generateDeviceTopologyHints(0x4126d20?, {0xc001493f80?, 0xc001493f80?}, 0x14?, 0xa?, 0xc001493f80?)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/devicemanager/topology_hints.go:160 +0xdc\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).GetTopologyHints(0xc000180f00, 0xc001229680, 0xc0023471e0)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/devicemanager/topology_hints.go:80 +0xb36\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*containerScope).accumulateProvidersHints(0xc00025d800?, 0xc002347340?, 0xc0023471e0)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/scope_container.go:75 +0xcd\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*containerScope).calculateAffinity(0xc000a45630, 0xc002347340?, 0xc00025d800?)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/scope_container.go:83 +0x33\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*containerScope).Admit(0xc000a45630, 0xc001229680)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/scope_container.go:53 +0x33b\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*manager).Admit(0xc000227340, 0xc0030ed5c0)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/topology_manager.go:213 +0xaa\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).canAdmitPod(0xc0002ca400, {0xc001287080, 0xc, 0x16}, 0xc001229680)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2085 +0x143\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).HandlePodAdditions(0xc0002ca400, {0xc0013a8710?, 0x1, 0x1})\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2363 +0x1e5\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncLoopIteration(0xc0002ca400, {0x52c7f28, 0xc000132000}, 0xc000fccc00, {0x52d1660, 0xc0002ca400?}, 0xc000f6f8c0, 0xc000f6f920, 0xc000fcd680)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2204 +0xb73\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncLoop(0xc0002ca400, {0x52c7f28, 0xc000132000}, 0xc000ff6790?, {0x52d1660, 0xc0002ca400})\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2147 +0x312\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).Run(0xc0002ca400, 0x0?)\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:1558 +0x729\nDec 16 09:28:34 n198-252-054 kubelet[2509137]: created by k8s.io/kubernetes/cmd/kubelet/app.startKubelet\nDec 16 09:28:34 n198-252-054 kubelet[2509137]:         cmd/kubelet/app/server.go:1193 +0xb8",
+    "markdown": "Dec 16 09:28:34 n198-252-054 kubelet[2509137]: fatal error: concurrent map iteration and map write\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: goroutine 207 [running]:\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).generateDeviceTopologyHints.func1({0x52e4410, 0xc00363f620})\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/devicemanager/topology_hints.go:163 +0xe7\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask.IterateBitMasks.func1({0xc000a4b858?, 0x77f0930?, 0xc00025d800?}, {0xc00363f618?, 0x0?, 0x416d57?}, 0xc001919158?)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/bitmask/bitmask.go:211 +0xa3\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask.IterateBitMasks.func1({0xc000a4b850, 0x2, 0x2}, {0x77f0930?, 0x0, 0x0}, 0x1)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/bitmask/bitmask.go:215 +0xcc\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask.IterateBitMasks({0xc000a4b850, 0x2, 0x2}, 0x41232a0?)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/bitmask/bitmask.go:220 +0x90\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).generateDeviceTopologyHints(0x4126d20?, {0xc001493f80?, 0xc001493f80?}, 0x14?, 0xa?, 0xc001493f80?)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/devicemanager/topology_hints.go:160 +0xdc\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).GetTopologyHints(0xc000180f00, 0xc001229680, 0xc0023471e0)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/devicemanager/topology_hints.go:80 +0xb36\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*containerScope).accumulateProvidersHints(0xc00025d800?, 0xc002347340?, 0xc0023471e0)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/scope_container.go:75 +0xcd\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*containerScope).calculateAffinity(0xc000a45630, 0xc002347340?, 0xc00025d800?)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/scope_container.go:83 +0x33\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*containerScope).Admit(0xc000a45630, 0xc001229680)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/scope_container.go:53 +0x33b\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet/cm/topologymanager.(*manager).Admit(0xc000227340, 0xc0030ed5c0)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/cm/topologymanager/topology_manager.go:213 +0xaa\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).canAdmitPod(0xc0002ca400, {0xc001287080, 0xc, 0x16}, 0xc001229680)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2085 +0x143\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).HandlePodAdditions(0xc0002ca400, {0xc0013a8710?, 0x1, 0x1})\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2363 +0x1e5\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncLoopIteration(0xc0002ca400, {0x52c7f28, 0xc000132000}, 0xc000fccc00, {0x52d1660, 0xc0002ca400?}, 0xc000f6f8c0, 0xc000f6f920, 0xc000fcd680)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2204 +0xb73\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncLoop(0xc0002ca400, {0x52c7f28, 0xc000132000}, 0xc000ff6790?, {0x52d1660, 0xc0002ca400})\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:2147 +0x312\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).Run(0xc0002ca400, 0x0?)\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         pkg/kubelet/kubelet.go:1558 +0x729\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]: created by k8s.io/kubernetes/cmd/kubelet/app.startKubelet\n  Dec 16 09:28:34 n198-252-054 kubelet[2509137]:         cmd/kubelet/app/server.go:1193 +0xb8 ([#114572](https://github.com/kubernetes/kubernetes/pull/114572), [@huyinhou](https://github.com/huyinhou)) [SIG Node]",
+    "author": "huyinhou",
+    "author_url": "https://github.com/huyinhou",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114572",
+    "pr_number": 114572,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "114598": {
+    "commit": "a772691165313bf320fb0c198476132ea65befde",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#114598](https://github.com/kubernetes/kubernetes/pull/114598), [@kunkunhaohao](https://github.com/kunkunhaohao)) [SIG Node]",
+    "author": "kunkunhaohao",
+    "author_url": "https://github.com/kunkunhaohao",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114598",
+    "pr_number": 114598,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "114701": {
+    "commit": "aa49f001bcea0c5e8474aee06e46c2d376843e06",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#114701](https://github.com/kubernetes/kubernetes/pull/114701), [@goushicui](https://github.com/goushicui)) [SIG Node]",
+    "author": "goushicui",
+    "author_url": "https://github.com/goushicui",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114701",
+    "pr_number": 114701,
+    "areas": ["kubelet"],
+    "kinds": ["documentation"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "114768": {
+    "commit": "c84c8add70281c1620819fbc9805d57265bd2ae1",
+    "text": "The job controller back-off logic is now decoupled from workqueue. In case of parallelism \u003e 1, if there are multiple new failures in a reconciliation cycle, all the failures are taken into account to compute the back-off. Previously, the back-off kicked in for all types of failures; with this change, only pod failures are taken into account. If the back-off limits exceeds, the job is marked as failed immediately; before this change, the job is marked as failed in the next back-off.",
+    "markdown": "The job controller back-off logic is now decoupled from workqueue. In case of parallelism \u003e 1, if there are multiple new failures in a reconciliation cycle, all the failures are taken into account to compute the back-off. Previously, the back-off kicked in for all types of failures; with this change, only pod failures are taken into account. If the back-off limits exceeds, the job is marked as failed immediately; before this change, the job is marked as failed in the next back-off. ([#114768](https://github.com/kubernetes/kubernetes/pull/114768), [@sathyanarays](https://github.com/sathyanarays)) [SIG Apps and Testing]",
+    "author": "sathyanarays",
+    "author_url": "https://github.com/sathyanarays",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114768",
+    "pr_number": 114768,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["apps", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114871": {
+    "commit": "8f45b64c93563ef682f24d1f6300679d03d946f1",
+    "text": "Migrated the replicaset controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the replicaset controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#114871](https://github.com/kubernetes/kubernetes/pull/114871), [@Namanl2001](https://github.com/Namanl2001)) [SIG API Machinery, Apps, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "Namanl2001",
+    "author_url": "https://github.com/Namanl2001",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114871",
+    "pr_number": 114871,
+    "areas": ["test", "logging"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114904": {
+    "commit": "898143a96ad6eb1d5dc213b2b3f2e7a8a204652d",
+    "text": "kubelet: fix recording issue when pulling image did finish",
+    "markdown": "Kubelet: fix recording issue when pulling image did finish ([#114904](https://github.com/kubernetes/kubernetes/pull/114904), [@TommyStarK](https://github.com/TommyStarK)) [SIG Node]",
+    "author": "TommyStarK",
+    "author_url": "https://github.com/TommyStarK",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114904",
+    "pr_number": 114904,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node"]
+  },
+  "114918": {
+    "commit": "b6f9a65558f16aa948477ce334830e545a5a2280",
+    "text": "Migrated the service-account controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the service-account controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#114918](https://github.com/kubernetes/kubernetes/pull/114918), [@Namanl2001](https://github.com/Namanl2001)) [SIG API Machinery, Apps, Auth, Instrumentation and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "Namanl2001",
+    "author_url": "https://github.com/Namanl2001",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114918",
+    "pr_number": 114918,
+    "areas": ["test", "logging"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "auth", "apps", "instrumentation", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "114930": {
+    "commit": "f3aebc85b90c7c6ef6b034b3a910cfba27a65951",
+    "text": "Pods owned by a Job will now use the labels `batch.kubernetes.io/job-name` and `batch.kubernetes.io/controller-uid`.\nThe legacy labels `job-name` and `controller-uid` are still added for compatibility.",
+    "markdown": "Pods owned by a Job will now use the labels `batch.kubernetes.io/job-name` and `batch.kubernetes.io/controller-uid`.\n  The legacy labels `job-name` and `controller-uid` are still added for compatibility. ([#114930](https://github.com/kubernetes/kubernetes/pull/114930), [@kannon92](https://github.com/kannon92)) [SIG Apps]",
+    "author": "kannon92",
+    "author_url": "https://github.com/kannon92",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/114930",
+    "pr_number": 114930,
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["apps"],
+    "duplicate_kind": true
+  },
+  "115049": {
+    "commit": "d1aa73312c5e41166f1b92d556c7d0d30af239ab",
+    "text": "Migrated controller helper functions to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated controller helper functions to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#115049](https://github.com/kubernetes/kubernetes/pull/115049), [@fatsheep9146](https://github.com/fatsheep9146)) [SIG Apps]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "fatsheep9146",
+    "author_url": "https://github.com/fatsheep9146",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115049",
+    "pr_number": 115049,
+    "kinds": ["feature"],
+    "sigs": ["apps"],
+    "feature": true
+  },
+  "115075": {
+    "commit": "f44d561c1f8c327bdf2ff3bff175bd10d161454c",
+    "text": "Added a new IPAddress object kind\n- Added a new ClusterIP allocator. The new allocator removes previous Service CIDR block size limitations for IPv4, and limits IPv6 size to a /64",
+    "markdown": "Added a new IPAddress object kind\n  - Added a new ClusterIP allocator. The new allocator removes previous Service CIDR block size limitations for IPv4, and limits IPv6 size to a /64 ([#115075](https://github.com/kubernetes/kubernetes/pull/115075), [@aojea](https://github.com/aojea)) [SIG API Machinery, Apps, Auth, CLI, Cluster Lifecycle, Network and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1880-multiple-service-cidrs",
+        "type": "KEP"
+      }
+    ],
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115075",
+    "pr_number": 115075,
+    "areas": ["test", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["bug", "api-change", "feature"],
+    "sigs": ["network", "api-machinery", "cluster-lifecycle", "auth", "apps", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115082": {
+    "commit": "283c26f91a42b3ae3e2a8bc8d89cf52d8072ed86",
+    "text": "New \"plugin_evaluation_total\" is added to the scheduler. \nThis metric counts how many times the specific plugin affects the scheduling result. The metric doesn't get incremented when the plugin has nothing to do with an incoming Pod.",
+    "markdown": "New \"plugin_evaluation_total\" is added to the scheduler. \n  This metric counts how many times the specific plugin affects the scheduling result. The metric doesn't get incremented when the plugin has nothing to do with an incoming Pod. ([#115082](https://github.com/kubernetes/kubernetes/pull/115082), [@sanposhiho](https://github.com/sanposhiho)) [SIG Instrumentation and Scheduling]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115082",
+    "pr_number": 115082,
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115123": {
+    "commit": "15040e1c860f057c74d6f30b609d52e3ae7a5775",
+    "text": "Update KMSv2 to beta",
+    "markdown": "Update KMSv2 to beta ([#115123](https://github.com/kubernetes/kubernetes/pull/115123), [@aramase](https://github.com/aramase)) [SIG API Machinery, Auth and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements",
+        "type": "KEP"
+      }
+    ],
+    "author": "aramase",
+    "author_url": "https://github.com/aramase",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115123",
+    "pr_number": 115123,
+    "areas": ["test", "apiserver"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115149": {
+    "commit": "30ee6914c54269c5898582c984a3f21f9c6710e9",
+    "text": "The API server's encryption at rest configuration now allows the use of wildcards in the list of resources.  For example, '*.*' can be used to encrypt all resources, including all current and future custom resources.",
+    "markdown": "The API server's encryption at rest configuration now allows the use of wildcards in the list of resources.  For example, '*.*' can be used to encrypt all resources, including all current and future custom resources. ([#115149](https://github.com/kubernetes/kubernetes/pull/115149), [@nilekhc](https://github.com/nilekhc)) [SIG API Machinery, Auth and Testing]",
+    "author": "nilekhc",
+    "author_url": "https://github.com/nilekhc",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115149",
+    "pr_number": 115149,
+    "areas": ["test", "apiserver"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115204": {
+    "commit": "4b7bd457c496897d336bea6e9d65012a124c97ff",
+    "text": "[KCCM - service controller]: enable connection draining for terminating pods upon node downscale by the cluster autoscaler. This is done by not reacting to the taint used by the cluster autoscaler to indicate that the node is going away soon, thus keeping the node referenced by the load balancer until the VM has been completely deleted.",
+    "markdown": "[KCCM - service controller]: enable connection draining for terminating pods upon node downscale by the cluster autoscaler. This is done by not reacting to the taint used by the cluster autoscaler to indicate that the node is going away soon, thus keeping the node referenced by the load balancer until the VM has been completely deleted. ([#115204](https://github.com/kubernetes/kubernetes/pull/115204), [@alexanderConstantinescu](https://github.com/alexanderConstantinescu)) [SIG API Machinery, Cloud Provider, Instrumentation and Network]",
+    "author": "alexanderConstantinescu",
+    "author_url": "https://github.com/alexanderConstantinescu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115204",
+    "pr_number": 115204,
+    "areas": ["cloudprovider", "stable-metrics"],
+    "kinds": ["cleanup"],
+    "sigs": ["network", "api-machinery", "instrumentation", "cloud-provider"],
+    "duplicate": true
+  },
+  "115209": {
+    "commit": "781daea7b24dd855100ddbc5def68e5435797114",
+    "text": "Remove the following deprecated metrics:\n- node_collector_evictions_number replaced by node_collector_evictions_total\n- scheduler_e2e_scheduling_duration_seconds replaced by scheduler_scheduling_attempt_duration_seconds",
+    "markdown": "Remove the following deprecated metrics:\n  - node_collector_evictions_number replaced by node_collector_evictions_total\n  - scheduler_e2e_scheduling_duration_seconds replaced by scheduler_scheduling_attempt_duration_seconds ([#115209](https://github.com/kubernetes/kubernetes/pull/115209), [@dgrisonnet](https://github.com/dgrisonnet)) [SIG Apps and Scheduling]",
+    "author": "dgrisonnet",
+    "author_url": "https://github.com/dgrisonnet",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115209",
+    "pr_number": 115209,
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "apps"],
+    "duplicate": true
+  },
+  "115260": {
+    "commit": "910ce0ed0b417f6c9ef2fc6fd935ead4605ce5c9",
+    "text": "Enable the \"StatefulSetStartOrdinal\" feature gate in beta",
+    "markdown": "Enable the \"StatefulSetStartOrdinal\" feature gate in beta ([#115260](https://github.com/kubernetes/kubernetes/pull/115260), [@pwschuurman](https://github.com/pwschuurman)) [SIG API Machinery and Apps]",
+    "author": "pwschuurman",
+    "author_url": "https://github.com/pwschuurman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115260",
+    "pr_number": 115260,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115268": {
+    "commit": "2c8f63f693d75059f03c5335394883c3349c39ce",
+    "text": "Added NewVolumeManagerReconstruction feature gate and enable it by default to enable updated discovery of mounted volumes during kubelet startup. Please watch for kubelet getting stuck at startup and / or not unmounting volumes from deleted Pods and report any issues in this area.",
+    "markdown": "Added NewVolumeManagerReconstruction feature gate and enable it by default to enable updated discovery of mounted volumes during kubelet startup. Please watch for kubelet getting stuck at startup and / or not unmounting volumes from deleted Pods and report any issues in this area. ([#115268](https://github.com/kubernetes/kubernetes/pull/115268), [@jsafrane](https://github.com/jsafrane)) [SIG Node and Storage]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3763",
+        "type": "KEP"
+      }
+    ],
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115268",
+    "pr_number": 115268,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "node"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115332": {
+    "commit": "637bd6616573a28c9e0610db9ae0807a66fcaab3",
+    "text": "Migrated the ttlafterfinished controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the ttlafterfinished controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#115332](https://github.com/kubernetes/kubernetes/pull/115332), [@obaranov1](https://github.com/obaranov1)) [SIG Apps]",
+    "author": "obaranov1",
+    "author_url": "https://github.com/obaranov1",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115332",
+    "pr_number": 115332,
+    "areas": ["logging"],
+    "kinds": ["cleanup"],
+    "sigs": ["apps"]
+  },
+  "115371": {
+    "commit": "81c5a122c37e5b25ca0880c2edec209896dbd871",
+    "text": "kubelet: change MemoryThrottlingFactor default value to 0.9 and formulas to calculate memory.high",
+    "markdown": "Kubelet: change MemoryThrottlingFactor default value to 0.9 and formulas to calculate memory.high ([#115371](https://github.com/kubernetes/kubernetes/pull/115371), [@pacoxu](https://github.com/pacoxu)) [SIG API Machinery, Apps and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2570-memory-qos",
+        "type": "KEP"
+      }
+    ],
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115371",
+    "pr_number": 115371,
+    "areas": ["kubelet", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115374": {
+    "commit": "715e95708465132b7a8d57d416b9137788eafd3b",
+    "text": "kubelet allows pods to use the `net.ipv4.ip_local_reserved_ports` sysctl by default and the minimal kernel version is 3.16; Pod Security admission allows this sysctl in v1.27+ versions of the baseline and restricted policies.",
+    "markdown": "Kubelet allows pods to use the `net.ipv4.ip_local_reserved_ports` sysctl by default and the minimal kernel version is 3.16; Pod Security admission allows this sysctl in v1.27+ versions of the baseline and restricted policies. ([#115374](https://github.com/kubernetes/kubernetes/pull/115374), [@pacoxu](https://github.com/pacoxu)) [SIG Auth, Network and Node]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115374",
+    "pr_number": 115374,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["network", "node", "auth"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115391": {
+    "commit": "b4305fcf6306828ce99cae19a0b8155aabc2aa93",
+    "text": "PersistentVolume API objects which set NodeAffinities using beta Kubernetes labels for OS, architecture, zone, region, and instance type may now be modified to use the stable Kubernetes labels.",
+    "markdown": "PersistentVolume API objects which set NodeAffinities using beta Kubernetes labels for OS, architecture, zone, region, and instance type may now be modified to use the stable Kubernetes labels. ([#115391](https://github.com/kubernetes/kubernetes/pull/115391), [@haoruan](https://github.com/haoruan)) [SIG Apps and Storage]",
+    "author": "haoruan",
+    "author_url": "https://github.com/haoruan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115391",
+    "pr_number": 115391,
+    "kinds": ["bug"],
+    "sigs": ["storage", "apps"],
+    "duplicate": true
+  },
+  "115433": {
+    "commit": "812d55d230ea02a7bfe3e3b0705fab7503782dfa",
+    "text": "Updated: Redefine AppProtocol field description and add new standard values",
+    "markdown": "Updated: Redefine AppProtocol field description and add new standard values ([#115433](https://github.com/kubernetes/kubernetes/pull/115433), [@LiorLieberman](https://github.com/LiorLieberman)) [SIG API Machinery, Apps and Network]",
+    "author": "LiorLieberman",
+    "author_url": "https://github.com/LiorLieberman",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115433",
+    "pr_number": 115433,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115447": {
+    "commit": "8decaf3ae7f410ab3f3774f3895b9f3124b8a4c6",
+    "text": "Ingress with ingressClass annotation and IngressClassName both set can be created now.",
+    "markdown": "Ingress with ingressClass annotation and IngressClassName both set can be created now. ([#115447](https://github.com/kubernetes/kubernetes/pull/115447), [@AxeZhan](https://github.com/AxeZhan)) [SIG Network]",
+    "author": "AxeZhan",
+    "author_url": "https://github.com/AxeZhan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115447",
+    "pr_number": 115447,
+    "kinds": ["bug"],
+    "sigs": ["network"]
+  },
+  "115451": {
+    "commit": "499a03d88bf416cb7540ff29f7249f5ed0c92ef8",
+    "text": "add e2e test to node expand volume with secret",
+    "markdown": "Add e2e test to node expand volume with secret ([#115451](https://github.com/kubernetes/kubernetes/pull/115451), [@zhucan](https://github.com/zhucan)) [SIG Storage and Testing]",
+    "author": "zhucan",
+    "author_url": "https://github.com/zhucan",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115451",
+    "pr_number": 115451,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115480": {
+    "commit": "beacb8d7afc427eac491c59e9370be7b16b9f318",
+    "text": "Adds --output plaintext-openapiv2 argument to kubectl explain to use old openapiv2 `explain` implementation.",
+    "markdown": "Adds --output plaintext-openapiv2 argument to kubectl explain to use old openapiv2 `explain` implementation. ([#115480](https://github.com/kubernetes/kubernetes/pull/115480), [@alexzielenski](https://github.com/alexzielenski)) [SIG Architecture, Auth, CLI, Cloud Provider and Node]",
+    "documentation": [
+      {
+        "description": "[KEP] 3515 OpenAPI v3 for kubectl explain",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3515-kubectl-explain-openapiv3",
+        "type": "KEP"
+      }
+    ],
+    "author": "alexzielenski",
+    "author_url": "https://github.com/alexzielenski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115480",
+    "pr_number": 115480,
+    "areas": ["apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["node", "auth", "cli", "architecture", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115603": {
+    "commit": "4f76e4a0fd8688a1add065dc9796973dc280fce0",
+    "text": "upgrade coredns to v1.10.1",
+    "markdown": "Upgrade coredns to v1.10.1 ([#115603](https://github.com/kubernetes/kubernetes/pull/115603), [@pacoxu](https://github.com/pacoxu)) [SIG Cloud Provider and Cluster Lifecycle]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115603",
+    "pr_number": 115603,
+    "areas": ["provider/gcp", "kubeadm", "dependency"],
+    "kinds": ["cleanup"],
+    "sigs": ["cluster-lifecycle", "cloud-provider"],
+    "duplicate": true
+  },
+  "115621": {
+    "commit": "da209484929560072bb766afd6103c93a09bd3e6",
+    "text": "Graduates the CSINodeExpandSecret feature to Beta. This feature facilitates passing secrets to CSI driver as part of Node Expansion CSI operation.",
+    "markdown": "Graduates the CSINodeExpandSecret feature to Beta. This feature facilitates passing secrets to CSI driver as part of Node Expansion CSI operation. ([#115621](https://github.com/kubernetes/kubernetes/pull/115621), [@humblec](https://github.com/humblec)) [SIG Storage]",
+    "author": "humblec",
+    "author_url": "https://github.com/humblec",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115621",
+    "pr_number": 115621,
+    "kinds": ["feature"],
+    "sigs": ["storage"],
+    "feature": true
+  },
+  "115630": {
+    "commit": "2e3c5003b96aef29e87ee24c9086ff7f06cb8886",
+    "text": "Changed metrics for aggregated discovery to publish new time series (alpha).",
+    "markdown": "Changed metrics for aggregated discovery to publish new time series (alpha). ([#115630](https://github.com/kubernetes/kubernetes/pull/115630), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery and Testing]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115630",
+    "pr_number": 115630,
+    "areas": ["test", "apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115655": {
+    "commit": "be080584c632b031583310dd090424b06aa4f498",
+    "text": "NodeResourceFit and NodeResourcesBalancedAllocation implement the PreScore extension point for a more performant calculation.",
+    "markdown": "NodeResourceFit and NodeResourcesBalancedAllocation implement the PreScore extension point for a more performant calculation. ([#115655](https://github.com/kubernetes/kubernetes/pull/115655), [@tangwz](https://github.com/tangwz)) [SIG Scheduling]",
+    "author": "tangwz",
+    "author_url": "https://github.com/tangwz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115655",
+    "pr_number": 115655,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "115668": {
+    "commit": "4346c5e5e295f3a3e952bbbc8157228e0e3ff839",
+    "text": "ValidatingAdmissionPolicy now provides a status field that contains results of type checking the validation expression.\nThe type checking is fully informational, and the behavior of the policy is unchanged.",
+    "markdown": "ValidatingAdmissionPolicy now provides a status field that contains results of type checking the validation expression.\n  The type checking is fully informational, and the behavior of the policy is unchanged. ([#115668](https://github.com/kubernetes/kubernetes/pull/115668), [@jiahuif](https://github.com/jiahuif)) [SIG API Machinery, Auth, Cloud Provider and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3488-cel-admission-control",
+        "type": "KEP"
+      }
+    ],
+    "author": "jiahuif",
+    "author_url": "https://github.com/jiahuif",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115668",
+    "pr_number": 115668,
+    "areas": ["test", "apiserver", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing", "cloud-provider"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115693": {
+    "commit": "20c3a007f55b8f05ad31650494f90941ea15370f",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#115693](https://github.com/kubernetes/kubernetes/pull/115693), [@bobbypage](https://github.com/bobbypage)) [SIG Node and Testing]",
+    "author": "bobbypage",
+    "author_url": "https://github.com/bobbypage",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115693",
+    "pr_number": 115693,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "testing"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "115742": {
+    "commit": "bb6c6fad2c19b3e31ef0e00d0b7e05c624fe5d88",
+    "text": "linux/arm will not ship in Kubernetes 1.27 as we are running into issues with building artifacts using golang 1.20.2 (please see issue #116492)",
+    "markdown": "Linux/arm will not ship in Kubernetes 1.27 as we are running into issues with building artifacts using golang 1.20.2 (please see issue #116492) ([#115742](https://github.com/kubernetes/kubernetes/pull/115742), [@dims](https://github.com/dims)) [SIG Architecture, Release and Testing]",
+    "author": "dims",
+    "author_url": "https://github.com/dims",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115742",
+    "pr_number": 115742,
+    "kinds": ["cleanup"],
+    "sigs": ["testing", "release", "architecture"],
+    "duplicate": true
+  },
+  "115747": {
+    "commit": "8c61473f1ce7734bd9399c55d0b057b1f21f97d6",
+    "text": "Added CEL runtime cost calculation into ValidatingAdmissionPolicy, matching the evaluation cost\nrestrictions that already apply to CustomResourceDefinition.\nIf rule evaluation uses more compute than the limit, the API server aborts the evaluation and the\nadmission check that was being performed is aborted; the `failurePolicy` for the ValidatingAdmissionPolicy\ndetermines the outcome.",
+    "markdown": "Added CEL runtime cost calculation into ValidatingAdmissionPolicy, matching the evaluation cost\n  restrictions that already apply to CustomResourceDefinition.\n  If rule evaluation uses more compute than the limit, the API server aborts the evaluation and the\n  admission check that was being performed is aborted; the `failurePolicy` for the ValidatingAdmissionPolicy\n  determines the outcome. ([#115747](https://github.com/kubernetes/kubernetes/pull/115747), [@cici37](https://github.com/cici37)) [SIG API Machinery]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3488",
+        "type": "KEP"
+      }
+    ],
+    "author": "cici37",
+    "author_url": "https://github.com/cici37",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115747",
+    "pr_number": 115747,
+    "areas": ["apiserver"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "115750": {
+    "commit": "1586138519f972a68f597c496d9bace740158681",
+    "text": "Graduate `KubeletTracing` to beta, which means that the feature gate is now enabled by default.",
+    "markdown": "Graduate `KubeletTracing` to beta, which means that the feature gate is now enabled by default. ([#115750](https://github.com/kubernetes/kubernetes/pull/115750), [@saschagrunert](https://github.com/saschagrunert)) [SIG Instrumentation and Node]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/issues/2831",
+        "type": "KEP"
+      }
+    ],
+    "author": "saschagrunert",
+    "author_url": "https://github.com/saschagrunert",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115750",
+    "pr_number": 115750,
+    "areas": ["kubelet", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "instrumentation"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115769": {
+    "commit": "713ded736824d669d9fae9ac4a29b1ec18d66446",
+    "text": "Fix the problem Pod terminating stuck because of trying to umount not actual mounted dir.",
+    "markdown": "Fix the problem Pod terminating stuck because of trying to umount not actual mounted dir. ([#115769](https://github.com/kubernetes/kubernetes/pull/115769), [@mochizuki875](https://github.com/mochizuki875)) [SIG Node and Storage]",
+    "author": "mochizuki875",
+    "author_url": "https://github.com/mochizuki875",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115769",
+    "pr_number": 115769,
+    "kinds": ["bug"],
+    "sigs": ["storage", "node"],
+    "duplicate": true
+  },
+  "115840": {
+    "commit": "cae19f9e851864b03bc0a6cfde301bea77a4fece",
+    "text": "Remove deprecated `--enable-taint-manager` and `--pod-eviction-timeout` CLI flags",
+    "markdown": "Remove deprecated `--enable-taint-manager` and `--pod-eviction-timeout` CLI flags ([#115840](https://github.com/kubernetes/kubernetes/pull/115840), [@atosatto](https://github.com/atosatto)) [SIG API Machinery, Apps, Node and Testing]",
+    "author": "atosatto",
+    "author_url": "https://github.com/atosatto",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115840",
+    "pr_number": 115840,
+    "areas": ["test", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115847": {
+    "commit": "28fa3cbbf180fbd77d364cf845f86d21d54da728",
+    "text": "Extended the kubelet's PodResources API to include resources allocated in `ResourceClaims` via `DynamicResourceAllocation`. Additionally, added a new `Get()` method to query a specific pod for its resources.",
+    "markdown": "Extended the kubelet's PodResources API to include resources allocated in `ResourceClaims` via `DynamicResourceAllocation`. Additionally, added a new `Get()` method to query a specific pod for its resources. ([#115847](https://github.com/kubernetes/kubernetes/pull/115847), [@moshe010](https://github.com/moshe010)) [SIG Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3738",
+        "type": "KEP"
+      }
+    ],
+    "author": "moshe010",
+    "author_url": "https://github.com/moshe010",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115847",
+    "pr_number": 115847,
+    "areas": ["kubelet"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "115856": {
+    "commit": "da87af638f84b0272dcf521fbe7831876cf78900",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#115856](https://github.com/kubernetes/kubernetes/pull/115856), [@lanycrost](https://github.com/lanycrost)) [SIG API Machinery, Apps, Architecture, Auth, Autoscaling, CLI, Node, Release and Testing]",
+    "author": "lanycrost",
+    "author_url": "https://github.com/lanycrost",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115856",
+    "pr_number": 115856,
+    "areas": ["test", "apiserver", "kubectl", "release-eng", "conformance", "dependency"],
+    "kinds": ["cleanup"],
+    "sigs": [
+      "node",
+      "api-machinery",
+      "autoscaling",
+      "auth",
+      "apps",
+      "cli",
+      "testing",
+      "release",
+      "architecture"
+    ],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "115861": {
+    "commit": "6fd488a4e6ac6771916b3c37da6ed8cd9827c303",
+    "text": "When an unsupported PodDisruptionBudget configuration is found, an event and log will be emitted to inform users of the misconfiguration.",
+    "markdown": "When an unsupported PodDisruptionBudget configuration is found, an event and log will be emitted to inform users of the misconfiguration. ([#115861](https://github.com/kubernetes/kubernetes/pull/115861), [@JayKayy](https://github.com/JayKayy)) [SIG Apps]",
+    "author": "JayKayy",
+    "author_url": "https://github.com/JayKayy",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115861",
+    "pr_number": 115861,
+    "kinds": ["feature"],
+    "sigs": ["apps"],
+    "feature": true
+  },
+  "115879": {
+    "commit": "36a215603321a1cd4fb09017dd9c6cc697cb7184",
+    "text": "The SecurityContextDeny admission plugin is going deprecated and will be removed in future versions.",
+    "markdown": "The SecurityContextDeny admission plugin is going deprecated and will be removed in future versions. ([#115879](https://github.com/kubernetes/kubernetes/pull/115879), [@mtardy](https://github.com/mtardy)) [SIG Auth]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3785",
+        "type": "KEP"
+      },
+      {
+        "description": "[Other doc]",
+        "url": "https://k8s.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny",
+        "type": "external"
+      },
+      {
+        "description": "[Issue]",
+        "url": "https://github.com/kubernetes/kubernetes/issues/111516",
+        "type": "external"
+      }
+    ],
+    "author": "mtardy",
+    "author_url": "https://github.com/mtardy",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115879",
+    "pr_number": 115879,
+    "kinds": ["deprecation"],
+    "sigs": ["auth"]
+  },
+  "115904": {
+    "commit": "2225ee5dd307e3a1d4a00b0a7ceae27c0500e005",
+    "text": "Promote CronJobTimeZone feature to GA",
+    "markdown": "Promote CronJobTimeZone feature to GA ([#115904](https://github.com/kubernetes/kubernetes/pull/115904), [@soltysh](https://github.com/soltysh)) [SIG API Machinery and Apps]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3140",
+        "type": "KEP"
+      }
+    ],
+    "author": "soltysh",
+    "author_url": "https://github.com/soltysh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115904",
+    "pr_number": 115904,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115965": {
+    "commit": "44909771d969eeb3948cb377093d0906d6a2f400",
+    "text": "Added metrics for volume reconstruction during kubelet startup.",
+    "markdown": "Added metrics for volume reconstruction during kubelet startup. ([#115965](https://github.com/kubernetes/kubernetes/pull/115965), [@jsafrane](https://github.com/jsafrane)) [SIG Node and Storage]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3756-volume-reconstruction/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115965",
+    "pr_number": 115965,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "node"],
+    "feature": true,
+    "duplicate": true
+  },
+  "115966": {
+    "commit": "4dbb993d928ec352fef0659f3e7288a8563a9951",
+    "text": "GCE does not support LoadBalancer Services with ports with different protocols (TCP and UDP)",
+    "markdown": "GCE does not support LoadBalancer Services with ports with different protocols (TCP and UDP) ([#115966](https://github.com/kubernetes/kubernetes/pull/115966), [@aojea](https://github.com/aojea)) [SIG Apps and Cloud Provider]",
+    "author": "aojea",
+    "author_url": "https://github.com/aojea",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115966",
+    "pr_number": 115966,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug", "cleanup", "api-change"],
+    "sigs": ["apps", "cloud-provider"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115967": {
+    "commit": "c6f3007071d3212417ddab088adc5cc2e388b167",
+    "text": "Graduate CRI Events driven Pod LifeCycle Event Generator (Evented PLEG) to Beta",
+    "markdown": "Graduate CRI Events driven Pod LifeCycle Event Generator (Evented PLEG) to Beta ([#115967](https://github.com/kubernetes/kubernetes/pull/115967), [@harche](https://github.com/harche)) [SIG Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3386",
+        "type": "KEP"
+      }
+    ],
+    "author": "harche",
+    "author_url": "https://github.com/harche",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115967",
+    "pr_number": 115967,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["node"],
+    "feature": true
+  },
+  "115969": {
+    "commit": "16d2d55bc06158124a41f3ee8cf567e63ddd9d21",
+    "text": "Added messageExpression field to ValidationRule. (#115969, @DangerOnTheRanger)",
+    "markdown": "Added messageExpression field to ValidationRule. (#115969, @DangerOnTheRanger) ([#115969](https://github.com/kubernetes/kubernetes/pull/115969), [@DangerOnTheRanger](https://github.com/DangerOnTheRanger)) [SIG API Machinery, Architecture, Auth, CLI, Cloud Provider, Instrumentation, Node and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3747",
+        "type": "KEP"
+      }
+    ],
+    "author": "DangerOnTheRanger",
+    "author_url": "https://github.com/DangerOnTheRanger",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115969",
+    "pr_number": 115969,
+    "areas": ["test", "apiserver", "kubectl", "cloudprovider", "code-generation", "dependency"],
+    "kinds": ["api-change", "feature"],
+    "sigs": [
+      "node",
+      "api-machinery",
+      "auth",
+      "cli",
+      "instrumentation",
+      "testing",
+      "architecture",
+      "cloud-provider"
+    ],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "115973": {
+    "commit": "04675428bbfc9bf7ba4c9e1abfc427b6228069d9",
+    "text": "Adds auditAnnotations to ValidatingAdmissionPolicy, enabling CEL to be used to add audit annotations to request audit events.\nAdds validationActions to ValidatingAdmissionPolicyBinding, enabling validation failures to be handled by any combination of the warn, audit and deny enforcement actions.",
+    "markdown": "Adds auditAnnotations to ValidatingAdmissionPolicy, enabling CEL to be used to add audit annotations to request audit events.\n  Adds validationActions to ValidatingAdmissionPolicyBinding, enabling validation failures to be handled by any combination of the warn, audit and deny enforcement actions. ([#115973](https://github.com/kubernetes/kubernetes/pull/115973), [@jpbetz](https://github.com/jpbetz)) [SIG API Machinery and Testing]",
+    "author": "jpbetz",
+    "author_url": "https://github.com/jpbetz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/115973",
+    "pr_number": 115973,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116010": {
+    "commit": "b49b34c03a2005a490469bc74b52b94248e83a21",
+    "text": "HPA controller starts to expose metrics from the kube-controller-manager.\n- `reconciliations_total`: Number of reconciliation of HPA controller. \n- `reconciliation_duration_seconds`: The time(seconds) that the HPA controller takes to reconcile once.",
+    "markdown": "HPA controller starts to expose metrics from the kube-controller-manager.\n  - `reconciliations_total`: Number of reconciliation of HPA controller. \n  - `reconciliation_duration_seconds`: The time(seconds) that the HPA controller takes to reconcile once. ([#116010](https://github.com/kubernetes/kubernetes/pull/116010), [@sanposhiho](https://github.com/sanposhiho)) [SIG Apps, Autoscaling and Instrumentation]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116010",
+    "pr_number": 116010,
+    "kinds": ["feature"],
+    "sigs": ["autoscaling", "apps", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116015": {
+    "commit": "e57d9683230273c989b9686fe166e55c8eb99fcd",
+    "text": "kubelet: the deprecated `--master-service-namespace` flag is removed in v1.27",
+    "markdown": "Kubelet: the deprecated `--master-service-namespace` flag is removed in v1.27 ([#116015](https://github.com/kubernetes/kubernetes/pull/116015), [@SataQiu](https://github.com/SataQiu)) [SIG Node]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116015",
+    "pr_number": 116015,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"]
+  },
+  "116043": {
+    "commit": "fafbed3b1db4716b9bdd069e9bf5ade6a76e526c",
+    "text": "From now on, the HPA controller will return an error for the container resource metrics when the feature gate \"HPAContainerMetrics\" is disabled. As a result, HPA with a container resource metric performs no scale-down and performs only scale-up based on other metrics.",
+    "markdown": "From now on, the HPA controller will return an error for the container resource metrics when the feature gate \"HPAContainerMetrics\" is disabled. As a result, HPA with a container resource metric performs no scale-down and performs only scale-up based on other metrics. ([#116043](https://github.com/kubernetes/kubernetes/pull/116043), [@sanposhiho](https://github.com/sanposhiho)) [SIG API Machinery, Apps and Autoscaling]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116043",
+    "pr_number": 116043,
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "autoscaling", "apps"],
+    "duplicate": true
+  },
+  "116046": {
+    "commit": "d3a7b5920fc4a443c6e48c98478d1eecf8478246",
+    "text": "graduate the container resource metrics feature on HPA to beta.",
+    "markdown": "Graduate the container resource metrics feature on HPA to beta. ([#116046](https://github.com/kubernetes/kubernetes/pull/116046), [@sanposhiho](https://github.com/sanposhiho)) [SIG Autoscaling]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116046",
+    "pr_number": 116046,
+    "kinds": ["api-change", "feature"],
+    "sigs": ["autoscaling"],
+    "feature": true,
+    "duplicate_kind": true
+  },
+  "116054": {
+    "commit": "64259b43b8e5b7c086bf2b74743dc7e73ebe37e3",
+    "text": "Added authorization check support to the CEL expressions of ValidatingAdmissionPolicy via a `authorizer`\nvariable with expressions. The new variable provides a builder that allows expressions such `authorizer.group('').resource('pods').check('create').allowed()`.",
+    "markdown": "Added authorization check support to the CEL expressions of ValidatingAdmissionPolicy via a `authorizer`\n  variable with expressions. The new variable provides a builder that allows expressions such `authorizer.group('').resource('pods').check('create').allowed()`. ([#116054](https://github.com/kubernetes/kubernetes/pull/116054), [@jpbetz](https://github.com/jpbetz)) [SIG API Machinery and Testing]",
+    "author": "jpbetz",
+    "author_url": "https://github.com/jpbetz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116054",
+    "pr_number": 116054,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116066": {
+    "commit": "9d7db7088263c89410aa9b6ef4c5c2043de4b6b0",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116066](https://github.com/kubernetes/kubernetes/pull/116066), [@yoongon](https://github.com/yoongon)) [SIG Scheduling]",
+    "author": "yoongon",
+    "author_url": "https://github.com/yoongon",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116066",
+    "pr_number": 116066,
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling"],
+    "do_not_publish": true
+  },
+  "116093": {
+    "commit": "bea99ae1ee7b9ebbb4c237d16674795ebbaf2fda",
+    "text": "Graduate Kubelet Topology Manager to GA.",
+    "markdown": "Graduate Kubelet Topology Manager to GA. ([#116093](https://github.com/kubernetes/kubernetes/pull/116093), [@swatisehgal](https://github.com/swatisehgal)) [SIG API Machinery, Node and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/pull/3745",
+        "type": "KEP"
+      }
+    ],
+    "author": "swatisehgal",
+    "author_url": "https://github.com/swatisehgal",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116093",
+    "pr_number": 116093,
+    "areas": ["test", "kubelet", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116108": {
+    "commit": "d8fe8454157cfcc79dba292e67c6919be36b6266",
+    "text": "Promote aggregated discovery endpoint to beta and it will be enabled by default",
+    "markdown": "Promote aggregated discovery endpoint to beta and it will be enabled by default ([#116108](https://github.com/kubernetes/kubernetes/pull/116108), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116108",
+    "pr_number": 116108,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "116119": {
+    "commit": "9053b5dc2c8e0b977e759b9f076d1a52bafabbb7",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116119](https://github.com/kubernetes/kubernetes/pull/116119), [@vinaykul](https://github.com/vinaykul)) [SIG API Machinery, Apps, Node and Testing]",
+    "author": "vinaykul",
+    "author_url": "https://github.com/vinaykul",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116119",
+    "pr_number": 116119,
+    "areas": ["test", "kubelet", "code-generation"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["node", "api-machinery", "apps", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "do_not_publish": true
+  },
+  "116121": {
+    "commit": "fe6a51ed4c013e6b5cdb90f9cced8e1381fc0310",
+    "text": "Bump default API QPS limits for Kubelet.",
+    "markdown": "Bump default API QPS limits for Kubelet. ([#116121](https://github.com/kubernetes/kubernetes/pull/116121), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Node]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116121",
+    "pr_number": 116121,
+    "areas": ["code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116144": {
+    "commit": "548e856b5820bb19a08f48211bad6d010b77de10",
+    "text": "APIServerTracing feature gate is now enabled by default. Tracing in the API Server is still disabled by default, and requires a config file to enable.",
+    "markdown": "APIServerTracing feature gate is now enabled by default. Tracing in the API Server is still disabled by default, and requires a config file to enable. ([#116144](https://github.com/kubernetes/kubernetes/pull/116144), [@dashpole](https://github.com/dashpole)) [SIG API Machinery and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/blob/bddca24910fb349e2eb0ac1c822c77f0f32fe9c6/keps/sig-instrumentation/647-apiserver-tracing/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "dashpole",
+    "author_url": "https://github.com/dashpole",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116144",
+    "pr_number": 116144,
+    "areas": ["test", "apiserver"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116155": {
+    "commit": "4950f519039918c5f247a4cec7cf5b824bb16c92",
+    "text": "The API server now re-uses data encryption keys while the kms v2 plugin's key ID is stable.  Data encryption keys are still randomly generated on server start but an atomic counter is used to prevent nonce collisions.",
+    "markdown": "The API server now re-uses data encryption keys while the kms v2 plugin's key ID is stable.  Data encryption keys are still randomly generated on server start but an atomic counter is used to prevent nonce collisions. ([#116155](https://github.com/kubernetes/kubernetes/pull/116155), [@enj](https://github.com/enj)) [SIG API Machinery, Auth and Testing]",
+    "author": "enj",
+    "author_url": "https://github.com/enj",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116155",
+    "pr_number": 116155,
+    "areas": ["test", "apiserver"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116161": {
+    "commit": "0010333bdd882e50dabfa6caebed805f89554fbb",
+    "text": "Relax API validation to allow pod node selector to be mutable for gated pods (additions only, no deletions or mutations).",
+    "markdown": "Relax API validation to allow pod node selector to be mutable for gated pods (additions only, no deletions or mutations). ([#116161](https://github.com/kubernetes/kubernetes/pull/116161), [@danielvegamyhre](https://github.com/danielvegamyhre)) [SIG Apps, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP](",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3838-pod-mutable-scheduling-directives)",
+        "type": "KEP"
+      }
+    ],
+    "author": "danielvegamyhre",
+    "author_url": "https://github.com/danielvegamyhre",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116161",
+    "pr_number": 116161,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116167": {
+    "commit": "e28b191581195f237d21c0efff19b453f7dc3016",
+    "text": "When GCing pods, kube-controller-manager will delete Evicted pods first.",
+    "markdown": "When GCing pods, kube-controller-manager will delete Evicted pods first. ([#116167](https://github.com/kubernetes/kubernetes/pull/116167), [@borgerli](https://github.com/borgerli)) [SIG Apps]",
+    "author": "borgerli",
+    "author_url": "https://github.com/borgerli",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116167",
+    "pr_number": 116167,
+    "kinds": ["bug"],
+    "sigs": ["apps"]
+  },
+  "116171": {
+    "commit": "d446bebca8008ff8ba8906c76647c0ae40dbb6f0",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116171](https://github.com/kubernetes/kubernetes/pull/116171), [@daman1807](https://github.com/daman1807)) [SIG Network]",
+    "author": "daman1807",
+    "author_url": "https://github.com/daman1807",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116171",
+    "pr_number": 116171,
+    "areas": ["ipvs"],
+    "kinds": ["bug", "cleanup"],
+    "sigs": ["network"],
+    "duplicate_kind": true,
+    "do_not_publish": true
+  },
+  "116172": {
+    "commit": "3277d85604d7d8845f56f670fb83b65982cdddf3",
+    "text": "Fixed a rare race condition in kube-apiserver that could lead to missing events when a watch API request was created at the same time kube-apiserver was re-initializing its internal watch.",
+    "markdown": "Fixed a rare race condition in kube-apiserver that could lead to missing events when a watch API request was created at the same time kube-apiserver was re-initializing its internal watch. ([#116172](https://github.com/kubernetes/kubernetes/pull/116172), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116172",
+    "pr_number": 116172,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "116201": {
+    "commit": "a32050e6cbe600f55854d86dc951479963d6033f",
+    "text": "The scheduler's metric \"plugin_execution_duration_seconds\" now records PreEnqueue plugins execution seconds.",
+    "markdown": "The scheduler's metric \"plugin_execution_duration_seconds\" now records PreEnqueue plugins execution seconds. ([#116201](https://github.com/kubernetes/kubernetes/pull/116201), [@sanposhiho](https://github.com/sanposhiho)) [SIG Scheduling]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116201",
+    "pr_number": 116201,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "116205": {
+    "commit": "4fbfe11b89c3a2151f6b778bf404a668f35a63bb",
+    "text": "Since Kubernetes v1.5, `kubectl apply` has had an alpha-stage `--prune` flag to support deleting previously applied objects that have been removed from the input manifest. This feature has remained in alpha ever since due to performance and correctness issues inherent in its design. This PR exposes a second, independent pruning alpha powered by a new standard named ApplySets. An ApplySet is a server-side object (by default, a Secret; ConfigMaps are also allowed) that kubectl can use to accurately and efficiently track set membership across `apply` operations. The format used for ApplySet is set out in  [KEP 3659](https://github.com/kubernetes/enhancements/issues/3659) as a low-level specification.  Other tools in the ecosystem can also build on this specification for improved interoperability.  To try the ApplySet-based pruning alpha, set `KUBECTL_APPLYSET=true` and use the flags `--prune --applyset=secret-name` with `kubectl apply`.",
+    "markdown": "Since Kubernetes v1.5, `kubectl apply` has had an alpha-stage `--prune` flag to support deleting previously applied objects that have been removed from the input manifest. This feature has remained in alpha ever since due to performance and correctness issues inherent in its design. This PR exposes a second, independent pruning alpha powered by a new standard named ApplySets. An ApplySet is a server-side object (by default, a Secret; ConfigMaps are also allowed) that kubectl can use to accurately and efficiently track set membership across `apply` operations. The format used for ApplySet is set out in  [KEP 3659](https://github.com/kubernetes/enhancements/issues/3659) as a low-level specification.  Other tools in the ecosystem can also build on this specification for improved interoperability.  To try the ApplySet-based pruning alpha, set `KUBECTL_APPLYSET=true` and use the flags `--prune --applyset=secret-name` with `kubectl apply`. ([#116205](https://github.com/kubernetes/kubernetes/pull/116205), [@justinsb](https://github.com/justinsb)) [SIG CLI]",
+    "author": "justinsb",
+    "author_url": "https://github.com/justinsb",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116205",
+    "pr_number": 116205,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "116219": {
+    "commit": "4401af2c3ef213a3b3d9b45e3fc33273f36c6f11",
+    "text": "kube-controller-manager: fix a bug that the \"kubeconfig\" field of \"kubecontrollermanager.config.k8s.io\" configuration is not populated correctly",
+    "markdown": "Kube-controller-manager: fix a bug that the \"kubeconfig\" field of \"kubecontrollermanager.config.k8s.io\" configuration is not populated correctly ([#116219](https://github.com/kubernetes/kubernetes/pull/116219), [@SataQiu](https://github.com/SataQiu)) [SIG API Machinery and Cloud Provider]",
+    "author": "SataQiu",
+    "author_url": "https://github.com/SataQiu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116219",
+    "pr_number": 116219,
+    "areas": ["cloudprovider"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery", "cloud-provider"],
+    "duplicate": true
+  },
+  "116233": {
+    "commit": "e360de48b2dab4bd5669e9101edefd6a18c74992",
+    "text": "gRPC probes are now a GA feature. GRPCContainerProbe feature gate was locked to default value and will be removed in v1.29. If you were setting this feature gate explicitly, please remove it now.",
+    "markdown": "GRPC probes are now a GA feature. GRPCContainerProbe feature gate was locked to default value and will be removed in v1.29. If you were setting this feature gate explicitly, please remove it now. ([#116233](https://github.com/kubernetes/kubernetes/pull/116233), [@SergeyKanzhelev](https://github.com/SergeyKanzhelev)) [SIG API Machinery, Apps and Node]",
+    "author": "SergeyKanzhelev",
+    "author_url": "https://github.com/SergeyKanzhelev",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116233",
+    "pr_number": 116233,
+    "areas": ["kubelet", "code-generation"],
+    "kinds": ["cleanup", "api-change", "feature"],
+    "sigs": ["node", "api-machinery", "apps"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116235": {
+    "commit": "0da57ddc491519f8b97de3fd3e574a1e0d5682cc",
+    "text": "Promoted `OpenAPIV3` to GA",
+    "markdown": "Promoted `OpenAPIV3` to GA ([#116235](https://github.com/kubernetes/kubernetes/pull/116235), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery]",
+    "author": "Jefftree",
+    "author_url": "https://github.com/Jefftree",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116235",
+    "pr_number": 116235,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "116255": {
+    "commit": "ff27ccfabc778b46d42b746466c1004f922ccda4",
+    "text": "The `IPv6DualStack` feature gate for external cloud providers was removed.\n(The feature became GA in 1.23 and the gate was removed for all other\ncomponents several releases ago.) If you were still manually\nenabling it you must stop now.",
+    "markdown": "The `IPv6DualStack` feature gate for external cloud providers was removed.\n  (The feature became GA in 1.23 and the gate was removed for all other\n  components several releases ago.) If you were still manually\n  enabling it you must stop now. ([#116255](https://github.com/kubernetes/kubernetes/pull/116255), [@danwinship](https://github.com/danwinship)) [SIG API Machinery, Cloud Provider and Network]",
+    "author": "danwinship",
+    "author_url": "https://github.com/danwinship",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116255",
+    "pr_number": 116255,
+    "areas": ["cloudprovider"],
+    "kinds": ["cleanup"],
+    "sigs": ["network", "api-machinery", "cloud-provider"],
+    "duplicate": true,
+    "action_required": true
+  },
+  "116261": {
+    "commit": "5e5b3029f3bbfc93c3569f07ad300a5c6057fc58",
+    "text": "Added the `MatchConditions` field to `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` for the v1beta and v1 apis. \n\nThe `AdmissionWebhookMatchConditions` featuregate is now in Alpha",
+    "markdown": "Added the `MatchConditions` field to `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` for the v1beta and v1 apis. \n  \n  The `AdmissionWebhookMatchConditions` featuregate is now in Alpha ([#116261](https://github.com/kubernetes/kubernetes/pull/116261), [@ivelichkovich](https://github.com/ivelichkovich)) [SIG API Machinery and Testing]",
+    "documentation": [
+      {
+        "description": "[\u003clink\u003e](",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions)",
+        "type": "KEP"
+      }
+    ],
+    "author": "ivelichkovich",
+    "author_url": "https://github.com/ivelichkovich",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116261",
+    "pr_number": 116261,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116274": {
+    "commit": "c1431af4f83b2b06a581f23806ee12a0663fed3b",
+    "text": "Promoted `SelfSubjectReview` to Beta",
+    "markdown": "Promoted `SelfSubjectReview` to Beta ([#116274](https://github.com/kubernetes/kubernetes/pull/116274), [@nabokihms](https://github.com/nabokihms)) [SIG API Machinery, Auth, CLI and Testing]",
+    "author": "nabokihms",
+    "author_url": "https://github.com/nabokihms",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116274",
+    "pr_number": 116274,
+    "areas": ["test", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "auth", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116287": {
+    "commit": "89d1a7971ea55c2f495d78edf106dfe43d8ca144",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116287](https://github.com/kubernetes/kubernetes/pull/116287), [@csDengh](https://github.com/csDengh)) [SIG Scheduling]",
+    "author": "csDengh",
+    "author_url": "https://github.com/csDengh",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116287",
+    "pr_number": 116287,
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling"],
+    "do_not_publish": true
+  },
+  "116291": {
+    "commit": "7a4c4eaae7a7295d5969734446bc4077d9fe848f",
+    "text": "Graduated `matchLabelKeys` in `podTopologySpread` to Beta",
+    "markdown": "Graduated `matchLabelKeys` in `podTopologySpread` to Beta ([#116291](https://github.com/kubernetes/kubernetes/pull/116291), [@denkensk](https://github.com/denkensk)) [SIG Scheduling]",
+    "author": "denkensk",
+    "author_url": "https://github.com/denkensk",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116291",
+    "pr_number": 116291,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "116293": {
+    "commit": "a901bb630b5a353898c1b35df582a7faeef160a0",
+    "text": "Enable external plugins can be used as subcommands for kubectl create command if subcommand does not exist as builtin only when KUBECTL_ENABLE_CMD_SHADOW environment variable is exported.",
+    "markdown": "Enable external plugins can be used as subcommands for kubectl create command if subcommand does not exist as builtin only when KUBECTL_ENABLE_CMD_SHADOW environment variable is exported. ([#116293](https://github.com/kubernetes/kubernetes/pull/116293), [@ardaguclu](https://github.com/ardaguclu)) [SIG CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3638-kubectl-plugin-subcommands",
+        "type": "KEP"
+      }
+    ],
+    "author": "ardaguclu",
+    "author_url": "https://github.com/ardaguclu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116293",
+    "pr_number": 116293,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "116299": {
+    "commit": "0e06be57a65792ad5744b5ddf6abe95dd20ac773",
+    "text": "resource.k8s.io/v1alpha1 was replaced with resource.k8s.io/v1alpha2. Before upgrading a cluster, all objects in resource.k8s.io/v1alpha1 (ResourceClaim, ResourceClaimTemplate, ResourceClass, PodScheduling) must be deleted. The changes will be internal, so YAML files which create pods and resource claims don't need changes except for the newer `apiVersion`.",
+    "markdown": "Resource.k8s.io/v1alpha1 was replaced with resource.k8s.io/v1alpha2. Before upgrading a cluster, all objects in resource.k8s.io/v1alpha1 (ResourceClaim, ResourceClaimTemplate, ResourceClass, PodScheduling) must be deleted. The changes will be internal, so YAML files which create pods and resource claims don't need changes except for the newer `apiVersion`. ([#116299](https://github.com/kubernetes/kubernetes/pull/116299), [@pohly](https://github.com/pohly)) [SIG API Machinery, Apps, CLI, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3063",
+        "type": "KEP"
+      }
+    ],
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116299",
+    "pr_number": 116299,
+    "areas": ["test", "kubelet", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "node", "api-machinery", "apps", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "116301": {
+    "commit": "c2b2a7622f0f51d102098119469d49f7544f21cd",
+    "text": "Remove Azure disk in-tree storage plugin",
+    "markdown": "Remove Azure disk in-tree storage plugin ([#116301](https://github.com/kubernetes/kubernetes/pull/116301), [@andyzhangx](https://github.com/andyzhangx)) [SIG API Machinery, Cloud Provider, Node, Scheduling, Storage and Testing]",
+    "author": "andyzhangx",
+    "author_url": "https://github.com/andyzhangx",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116301",
+    "pr_number": 116301,
+    "areas": ["test", "kubelet", "provider/azure", "e2e-test-framework"],
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "storage", "node", "api-machinery", "testing", "cloud-provider"],
+    "duplicate": true
+  },
+  "116305": {
+    "commit": "a4302915c9d4d70b5e8769a125fa2dee946bbdfb",
+    "text": "By enabling the alpha `CloudNodeIPs` feature gate in kubelet and the cloud\nprovider, you can now specify a dual-stack `--node-ip` value (when using an\nexternal cloud provider that supports that functionality).",
+    "markdown": "By enabling the alpha `CloudNodeIPs` feature gate in kubelet and the cloud\n  provider, you can now specify a dual-stack `--node-ip` value (when using an\n  external cloud provider that supports that functionality). ([#116305](https://github.com/kubernetes/kubernetes/pull/116305), [@danwinship](https://github.com/danwinship)) [SIG API Machinery, Cloud Provider, Network and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3705",
+        "type": "KEP"
+      }
+    ],
+    "author": "danwinship",
+    "author_url": "https://github.com/danwinship",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116305",
+    "pr_number": 116305,
+    "areas": ["kubelet", "cloudprovider"],
+    "kinds": ["feature"],
+    "sigs": ["network", "node", "api-machinery", "cloud-provider"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116320": {
+    "commit": "83334ccaa1aebfd0089968c22fca5d9ee5ffb56e",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\nNone\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  None\n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116320](https://github.com/kubernetes/kubernetes/pull/116320), [@wangchen615](https://github.com/wangchen615)) [SIG Node, Scheduling and Testing]",
+    "author": "wangchen615",
+    "author_url": "https://github.com/wangchen615",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116320",
+    "pr_number": 116320,
+    "areas": ["test"],
+    "kinds": ["cleanup"],
+    "sigs": ["scheduling", "node", "testing"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "116326": {
+    "commit": "51471fa350b2db25554663324e140f1b49b6aaaa",
+    "text": "HPA controller exposes the following metrics from the kube-controller-manager.\n- `metric_computation_duration_seconds`: Number of metric computations. \n- `metric_computation_total`: The time(seconds) that the HPA controller takes to calculate one metric.",
+    "markdown": "HPA controller exposes the following metrics from the kube-controller-manager.\n  - `metric_computation_duration_seconds`: Number of metric computations. \n  - `metric_computation_total`: The time(seconds) that the HPA controller takes to calculate one metric. ([#116326](https://github.com/kubernetes/kubernetes/pull/116326), [@sanposhiho](https://github.com/sanposhiho)) [SIG Apps, Autoscaling and Instrumentation]",
+    "author": "sanposhiho",
+    "author_url": "https://github.com/sanposhiho",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116326",
+    "pr_number": 116326,
+    "kinds": ["feature"],
+    "sigs": ["autoscaling", "apps", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116329": {
+    "commit": "03ff890ef47a7dd0d207f09bda963d5d970a7535",
+    "text": "Removed AWS kubelet credential provider. Please use the external kubelet credential provider binary named `ecr-credential-provider` instead.",
+    "markdown": "Removed AWS kubelet credential provider. Please use the external kubelet credential provider binary named `ecr-credential-provider` instead. ([#116329](https://github.com/kubernetes/kubernetes/pull/116329), [@dims](https://github.com/dims)) [SIG Node, Storage and Testing]",
+    "author": "dims",
+    "author_url": "https://github.com/dims",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116329",
+    "pr_number": 116329,
+    "areas": ["test", "kubelet", "dependency"],
+    "kinds": ["cleanup"],
+    "sigs": ["storage", "node", "testing"],
+    "duplicate": true
+  },
+  "116332": {
+    "commit": "ae36991498282514da3fe771b0dd9de66b991c86",
+    "text": "Introduced a breaking change to the `resource.k8s.io` API in its `AllocationResult` struct. This change allows a kubelet plugin for the `DynamicResourceAllocation` feature to service allocations from multiple resource driver controllers.",
+    "markdown": "Introduced a breaking change to the `resource.k8s.io` API in its `AllocationResult` struct. This change allows a kubelet plugin for the `DynamicResourceAllocation` feature to service allocations from multiple resource driver controllers. ([#116332](https://github.com/kubernetes/kubernetes/pull/116332), [@klueska](https://github.com/klueska)) [SIG API Machinery, Apps, CLI, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/pull/3802",
+        "type": "KEP"
+      }
+    ],
+    "author": "klueska",
+    "author_url": "https://github.com/klueska",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116332",
+    "pr_number": 116332,
+    "areas": ["test", "kubelet", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "node", "api-machinery", "apps", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "116342": {
+    "commit": "4c0ed3b52ee286432a151871a2a92392ccf26b7f",
+    "text": "Unlocked the `CSIMigrationvSphere` feature gate.\nThe change allow users to continue using the in-tree vSphere driver,pending a vSphere\nCSI driver release that has with GA support for Windows, XFS, and raw block access.",
+    "markdown": "Unlocked the `CSIMigrationvSphere` feature gate.\n  The change allow users to continue using the in-tree vSphere driver,pending a vSphere\n  CSI driver release that has with GA support for Windows, XFS, and raw block access. ([#116342](https://github.com/kubernetes/kubernetes/pull/116342), [@msau42](https://github.com/msau42)) [SIG Storage]",
+    "author": "msau42",
+    "author_url": "https://github.com/msau42",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116342",
+    "pr_number": 116342,
+    "kinds": ["feature"],
+    "sigs": ["storage"],
+    "feature": true
+  },
+  "116350": {
+    "commit": "e5fd204c33e90a7e8f5a0ee70242f1296a5ec7af",
+    "text": "Added matchConditions field to ValidatingAdmissionPolicy, enabled support for CEL based custom match criteria.",
+    "markdown": "Added matchConditions field to ValidatingAdmissionPolicy, enabled support for CEL based custom match criteria. ([#116350](https://github.com/kubernetes/kubernetes/pull/116350), [@maxsmythe](https://github.com/maxsmythe)) [SIG API Machinery and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/e80ad39a21e6f1be90e2d514fb33df34fd496814/keps/sig-api-machinery/3488-cel-admission-control#match-conditions",
+        "type": "KEP"
+      }
+    ],
+    "author": "maxsmythe",
+    "author_url": "https://github.com/maxsmythe",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116350",
+    "pr_number": 116350,
+    "areas": ["test", "apiserver", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["api-machinery", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116351": {
+    "commit": "2bd69db8d7b71740aee7dd80a173133743b3dd9b",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116351](https://github.com/kubernetes/kubernetes/pull/116351), [@vinaykul](https://github.com/vinaykul)) [SIG Node]",
+    "author": "vinaykul",
+    "author_url": "https://github.com/vinaykul",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116351",
+    "pr_number": 116351,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "116353": {
+    "commit": "480a0c2c3601a54be0679f078c819ba6f887553f",
+    "text": "[alpha: kubectl apply --prune --applyset] Enables certain custom resources (CRs) to be used as ApplySet parent objects. To enable this for a given CR, apply the label `applyset.kubernetes.io/is-parent-type: true` to the CustomResourceDefinition (CRD) that defines it .",
+    "markdown": "[alpha: kubectl apply --prune --applyset] Enables certain custom resources (CRs) to be used as ApplySet parent objects. To enable this for a given CR, apply the label `applyset.kubernetes.io/is-parent-type: true` to the CustomResourceDefinition (CRD) that defines it . ([#116353](https://github.com/kubernetes/kubernetes/pull/116353), [@KnVerey](https://github.com/KnVerey)) [SIG CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/42a4b1c8a18780cf1d5c2460113d59b246002548/keps/sig-cli/3659-kubectl-apply-prune",
+        "type": "KEP"
+      }
+    ],
+    "author": "KnVerey",
+    "author_url": "https://github.com/KnVerey",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116353",
+    "pr_number": 116353,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "116377": {
+    "commit": "6a111bebe2a609589c560ef1ce5431e3f04ac945",
+    "text": "By enabling the `UserNamespacesStatelessPodsSupport` feature gate in kubelet, you can now run a stateless pod in a separate user namespace",
+    "markdown": "By enabling the `UserNamespacesStatelessPodsSupport` feature gate in kubelet, you can now run a stateless pod in a separate user namespace ([#116377](https://github.com/kubernetes/kubernetes/pull/116377), [@giuseppe](https://github.com/giuseppe)) [SIG Apps, Node and Storage]",
+    "author": "giuseppe",
+    "author_url": "https://github.com/giuseppe",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116377",
+    "pr_number": 116377,
+    "areas": ["kubelet"],
+    "kinds": ["feature"],
+    "sigs": ["storage", "node", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116390": {
+    "commit": "900278dd415baf686a4964ce0c9b60782996c95c",
+    "text": "Switched kubectl explain to use OpenAPIV3 information published by the server. OpenAPIV2 backend can  still be used with the `--output plaintext-openapiv2` argument",
+    "markdown": "Switched kubectl explain to use OpenAPIV3 information published by the server. OpenAPIV2 backend can  still be used with the `--output plaintext-openapiv2` argument ([#116390](https://github.com/kubernetes/kubernetes/pull/116390), [@alexzielenski](https://github.com/alexzielenski)) [SIG API Machinery, CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP] 3515 OpenAPI v3 for kubectl explain",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3515-kubectl-explain-openapiv3",
+        "type": "KEP"
+      }
+    ],
+    "author": "alexzielenski",
+    "author_url": "https://github.com/alexzielenski",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116390",
+    "pr_number": 116390,
+    "areas": ["test", "kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery", "cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116395": {
+    "commit": "8b3d529523338b82d6ea8972a9b14f7c3d5339ad",
+    "text": "Fixed data race in `kube-scheduler` when preemption races with a Pod update.",
+    "markdown": "Fixed data race in `kube-scheduler` when preemption races with a Pod update. ([#116395](https://github.com/kubernetes/kubernetes/pull/116395), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116395",
+    "pr_number": 116395,
+    "kinds": ["bug"],
+    "sigs": ["scheduling"]
+  },
+  "116397": {
+    "commit": "e1678f2b645b205b040a267ef6ab319d9696d796",
+    "text": "Added `messageExpression` to `ValidatingAdmissionPolicy`, to set custom failure message via CEL expression.",
+    "markdown": "Added `messageExpression` to `ValidatingAdmissionPolicy`, to set custom failure message via CEL expression. ([#116397](https://github.com/kubernetes/kubernetes/pull/116397), [@jiahuif](https://github.com/jiahuif)) [SIG API Machinery]",
+    "author": "jiahuif",
+    "author_url": "https://github.com/jiahuif",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116397",
+    "pr_number": 116397,
+    "areas": ["apiserver", "code-generation"],
+    "kinds": ["api-change"],
+    "sigs": ["api-machinery"]
+  },
+  "116404": {
+    "commit": "f02da82e3664671ee33658a8699c731e51d47168",
+    "text": "Kubernetes is now built with go 1.20.2",
+    "markdown": "Kubernetes is now built with go 1.20.2 ([#116404](https://github.com/kubernetes/kubernetes/pull/116404), [@cpanato](https://github.com/cpanato)) [SIG Release and Testing]",
+    "author": "cpanato",
+    "author_url": "https://github.com/cpanato",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116404",
+    "pr_number": 116404,
+    "areas": ["test", "release-eng"],
+    "kinds": ["feature"],
+    "sigs": ["testing", "release"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116420": {
+    "commit": "ee18f602523e11a80823a659bed8f70f98a12914",
+    "text": "Update kube-apiserver SLO/SLI latency metrics to exclude priority \u0026 fairness queue wait times",
+    "markdown": "Update kube-apiserver SLO/SLI latency metrics to exclude priority \u0026 fairness queue wait times ([#116420](https://github.com/kubernetes/kubernetes/pull/116420), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery]",
+    "author": "andrewsykim",
+    "author_url": "https://github.com/andrewsykim",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116420",
+    "pr_number": 116420,
+    "areas": ["apiserver"],
+    "kinds": ["feature"],
+    "sigs": ["api-machinery"],
+    "feature": true
+  },
+  "116425": {
+    "commit": "f7bcff44cd7bd1ac71d5607cdd0ceea061051417",
+    "text": "SELinuxMountReadWriteOncePod graduated to Beta.",
+    "markdown": "SELinuxMountReadWriteOncePod graduated to Beta. ([#116425](https://github.com/kubernetes/kubernetes/pull/116425), [@jsafrane](https://github.com/jsafrane)) [SIG Storage and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling",
+        "type": "KEP"
+      }
+    ],
+    "author": "jsafrane",
+    "author_url": "https://github.com/jsafrane",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116425",
+    "pr_number": 116425,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["storage", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116428": {
+    "commit": "c67953a2d0255c8c4f5e315b93f28ab599c428e5",
+    "text": "Fixed performance regression in scheduler caused by frequent metric lookup on critical code path.",
+    "markdown": "Fixed performance regression in scheduler caused by frequent metric lookup on critical code path. ([#116428](https://github.com/kubernetes/kubernetes/pull/116428), [@mborsz](https://github.com/mborsz)) [SIG Scheduling]",
+    "author": "mborsz",
+    "author_url": "https://github.com/mborsz",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116428",
+    "pr_number": 116428,
+    "kinds": ["bug", "regression"],
+    "sigs": ["scheduling"],
+    "duplicate_kind": true
+  },
+  "116436": {
+    "commit": "36b29b38bb3f38db3439bdf568cad1f856998b0a",
+    "text": "Fixed incorrect watch events when a watch is initialized simultanously with a reinitializing watchcache.",
+    "markdown": "Fixed incorrect watch events when a watch is initialized simultanously with a reinitializing watchcache. ([#116436](https://github.com/kubernetes/kubernetes/pull/116436), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery]",
+    "author": "wojtek-t",
+    "author_url": "https://github.com/wojtek-t",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116436",
+    "pr_number": 116436,
+    "areas": ["apiserver"],
+    "kinds": ["bug"],
+    "sigs": ["api-machinery"]
+  },
+  "116450": {
+    "commit": "3c6e419cc3e364e0fce874e6c51ca058f1b9daab",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116450](https://github.com/kubernetes/kubernetes/pull/116450), [@vinaykul](https://github.com/vinaykul)) [SIG API Machinery, Apps, Node, Release, Scheduling and Testing]",
+    "author": "vinaykul",
+    "author_url": "https://github.com/vinaykul",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116450",
+    "pr_number": 116450,
+    "areas": ["test", "kubelet", "release-eng", "code-generation"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["scheduling", "node", "api-machinery", "apps", "testing", "release"],
+    "duplicate": true,
+    "duplicate_kind": true,
+    "do_not_publish": true
+  },
+  "116459": {
+    "commit": "204a9a1f1716bfc9bbeec9335df9055dad1ea0e4",
+    "text": "Added basic Denial Of Service prevention for the the node-local kubelet `podresource` API",
+    "markdown": "Added basic Denial Of Service prevention for the the node-local kubelet `podresource` API ([#116459](https://github.com/kubernetes/kubernetes/pull/116459), [@ffromani](https://github.com/ffromani)) [SIG Node and Testing]",
+    "documentation": [
+      {
+        "description": "KEP",
+        "url": "https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/606-compute-device-assignment/README.md",
+        "type": "KEP"
+      }
+    ],
+    "author": "ffromani",
+    "author_url": "https://github.com/ffromani",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116459",
+    "pr_number": 116459,
+    "areas": ["test", "kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node", "testing"],
+    "duplicate": true
+  },
+  "116500": {
+    "commit": "ead7d66ee12656cfb7c633dd42a87f8d9cfaa469",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116500](https://github.com/kubernetes/kubernetes/pull/116500), [@dims](https://github.com/dims)) [SIG Testing]",
+    "author": "dims",
+    "author_url": "https://github.com/dims",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116500",
+    "pr_number": 116500,
+    "kinds": ["cleanup"],
+    "sigs": ["testing"],
+    "do_not_publish": true
+  },
+  "116501": {
+    "commit": "cd56332d060b8844c8940e2e984e4a82165ae9d2",
+    "text": "StatefulSetAutoDeletePVC feature gate promoted to beta.",
+    "markdown": "StatefulSetAutoDeletePVC feature gate promoted to beta. ([#116501](https://github.com/kubernetes/kubernetes/pull/116501), [@mattcary](https://github.com/mattcary)) [SIG Apps, Auth and Testing]",
+    "author": "mattcary",
+    "author_url": "https://github.com/mattcary",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116501",
+    "pr_number": 116501,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["auth", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116509": {
+    "commit": "609ae513952bb06c36593cbf3d0d89fe1a878959",
+    "text": "Updated distroless iptables to use released image `registry.k8s.io/build-image/distroless-iptables:v0.2.2`\n- Updated setcap to use released image `registry.k8s.io/build-image/setcap:bullseye-v1.4.2`",
+    "markdown": "Updated distroless iptables to use released image `registry.k8s.io/build-image/distroless-iptables:v0.2.2`\n  - Updated setcap to use released image `registry.k8s.io/build-image/setcap:bullseye-v1.4.2` ([#116509](https://github.com/kubernetes/kubernetes/pull/116509), [@cpanato](https://github.com/cpanato)) [SIG Testing]",
+    "author": "cpanato",
+    "author_url": "https://github.com/cpanato",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116509",
+    "pr_number": 116509,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["testing"],
+    "feature": true
+  },
+  "116510": {
+    "commit": "c2cadd2b60424d26678b72506e377dfbf12b9876",
+    "text": "Promote `whoami` kubectl command.",
+    "markdown": "Promote `whoami` kubectl command. ([#116510](https://github.com/kubernetes/kubernetes/pull/116510), [@nabokihms](https://github.com/nabokihms)) [SIG Auth and CLI]",
+    "author": "nabokihms",
+    "author_url": "https://github.com/nabokihms",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116510",
+    "pr_number": 116510,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["auth", "cli"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116522": {
+    "commit": "c0ef73222f96b866138ce3c9e8f910a0a4cbfdfe",
+    "text": "New `service.kubernetes.io/topology-mode` annotation has been introduced as a replacement for the `service.kubernetes.io/topology-aware-hints` annotation.\n- `service.kubernetes.io/topology-aware-hints` annotation has been deprecated.\n- kube-proxy now accepts any value that is not \"disabled\" for these annotations, enabling custom implementation-specific and/or future built-in heuristics to be used.",
+    "markdown": "New `service.kubernetes.io/topology-mode` annotation has been introduced as a replacement for the `service.kubernetes.io/topology-aware-hints` annotation.\n  - `service.kubernetes.io/topology-aware-hints` annotation has been deprecated.\n  - kube-proxy now accepts any value that is not \"disabled\" for these annotations, enabling custom implementation-specific and/or future built-in heuristics to be used. ([#116522](https://github.com/kubernetes/kubernetes/pull/116522), [@robscott](https://github.com/robscott)) [SIG Apps, Network and Testing]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116522",
+    "pr_number": 116522,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116523": {
+    "commit": "49032c394c11cd81c420725fc44b8a979293f2be",
+    "text": "storage.k8s.io/v1beta1 API version of CSIStorageCapacity will no longer be served",
+    "markdown": "Storage.k8s.io/v1beta1 API version of CSIStorageCapacity will no longer be served ([#116523](https://github.com/kubernetes/kubernetes/pull/116523), [@pacoxu](https://github.com/pacoxu)) [SIG API Machinery]",
+    "author": "pacoxu",
+    "author_url": "https://github.com/pacoxu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116523",
+    "pr_number": 116523,
+    "kinds": ["cleanup"],
+    "sigs": ["api-machinery"]
+  },
+  "116529": {
+    "commit": "27e23bad7d595f64519de70f1a82539d14327a28",
+    "text": "Migrated the main kube-controller-manager binary to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the main kube-controller-manager binary to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#116529](https://github.com/kubernetes/kubernetes/pull/116529), [@pohly](https://github.com/pohly)) [SIG API Machinery, Apps, Auth and Node]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116529",
+    "pr_number": 116529,
+    "kinds": ["feature"],
+    "sigs": ["node", "api-machinery", "auth", "apps"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116533": {
+    "commit": "033f4b1772ba3a88080493a32440f96a6337e331",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116533](https://github.com/kubernetes/kubernetes/pull/116533), [@ameukam](https://github.com/ameukam)) [SIG Cloud Provider and K8s Infra]",
+    "author": "ameukam",
+    "author_url": "https://github.com/ameukam",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116533",
+    "pr_number": 116533,
+    "areas": ["provider/gcp"],
+    "kinds": ["cleanup"],
+    "sigs": ["cloud-provider", "k8s-infra"],
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "116535": {
+    "commit": "f2e1a67c05b25c1031fd26eee479001a13bde2c9",
+    "text": "forbid to set matchLabelKeys when labelSelector isn’t set in topologySpreadConstraints",
+    "markdown": "Forbid to set matchLabelKeys when labelSelector isn’t set in topologySpreadConstraints ([#116535](https://github.com/kubernetes/kubernetes/pull/116535), [@denkensk](https://github.com/denkensk)) [SIG API Machinery, Apps and Scheduling]",
+    "author": "denkensk",
+    "author_url": "https://github.com/denkensk",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116535",
+    "pr_number": 116535,
+    "areas": ["code-generation"],
+    "kinds": ["bug", "api-change"],
+    "sigs": ["scheduling", "api-machinery", "apps"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116546": {
+    "commit": "34acfb877ad151918db586245f21e832121675e2",
+    "text": "Potentially breaking change - Updating the polling interval for Windows stats collection from 1 second to 10 seconds",
+    "markdown": "Potentially breaking change - Updating the polling interval for Windows stats collection from 1 second to 10 seconds ([#116546](https://github.com/kubernetes/kubernetes/pull/116546), [@marosset](https://github.com/marosset)) [SIG Node and Windows]",
+    "author": "marosset",
+    "author_url": "https://github.com/marosset",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116546",
+    "pr_number": 116546,
+    "areas": ["kubelet"],
+    "kinds": ["bug"],
+    "sigs": ["node", "windows"],
+    "duplicate": true
+  },
+  "116550": {
+    "commit": "d1dfa899532ae503a81f2ffdd80aa3f734af97e9",
+    "text": "Fixes a regression in the pod binding subresource to honor the `metadata.uid` precondition.\nThis allows kube-scheduler to ensure it is assigns node names to the same instances of pods it made scheduling decisions for.",
+    "markdown": "Fixes a regression in the pod binding subresource to honor the `metadata.uid` precondition.\n  This allows kube-scheduler to ensure it is assigns node names to the same instances of pods it made scheduling decisions for. ([#116550](https://github.com/kubernetes/kubernetes/pull/116550), [@alculquicondor](https://github.com/alculquicondor)) [SIG API Machinery and Testing]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116550",
+    "pr_number": 116550,
+    "areas": ["test", "apiserver"],
+    "kinds": ["bug", "regression"],
+    "sigs": ["api-machinery", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116551": {
+    "commit": "fa5253976c4c03dee6eab03b93cfc3fa2c841e59",
+    "text": "make test-e2e-node PARALLELISM=1 FOCUS=\"StandaloneMode\" \\\nTEST_ARGS='\\\n  --kubelet-flags=\"--fail-swap-on=false\" \\\n  --standalone-mode=true \\\n'",
+    "markdown": "Make test-e2e-node PARALLELISM=1 FOCUS=\"StandaloneMode\" \\\n  TEST_ARGS='\\\n    --kubelet-flags=\"--fail-swap-on=false\" \\\n    --standalone-mode=true \\\n  ' ([#116551](https://github.com/kubernetes/kubernetes/pull/116551), [@SergeyKanzhelev](https://github.com/SergeyKanzhelev)) [SIG Node and Testing]",
+    "author": "SergeyKanzhelev",
+    "author_url": "https://github.com/SergeyKanzhelev",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116551",
+    "pr_number": 116551,
+    "areas": ["test", "e2e-test-framework"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "116556": {
+    "commit": "fbfc887a097b2f7cddd065deacbff03abf0bfef6",
+    "text": "API: resource.k8s.io/v1alpha1.PodScheduling was renamed to resource.k8s.io/v1alpha2.PodSchedulingContext.",
+    "markdown": "API: resource.k8s.io/v1alpha1.PodScheduling was renamed to resource.k8s.io/v1alpha2.PodSchedulingContext. ([#116556](https://github.com/kubernetes/kubernetes/pull/116556), [@pohly](https://github.com/pohly)) [SIG API Machinery, Apps, Auth, CLI, Node, Scheduling and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3063",
+        "type": "KEP"
+      }
+    ],
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116556",
+    "pr_number": 116556,
+    "areas": ["test", "kubelet", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["scheduling", "node", "api-machinery", "auth", "apps", "cli", "testing"],
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116558": {
+    "commit": "815b1bf0d8f9775ff9b180a2faab928814c4ff81",
+    "text": "We have removed support for the v1alpha1 kubeletplugin API of DynamicResourceManagement. All plugins must update to v1alpha2 in order to function properly going forward.",
+    "markdown": "We have removed support for the v1alpha1 kubeletplugin API of DynamicResourceManagement. All plugins must update to v1alpha2 in order to function properly going forward. ([#116558](https://github.com/kubernetes/kubernetes/pull/116558), [@klueska](https://github.com/klueska)) [SIG API Machinery, Apps, CLI, Node, Scheduling and Testing]",
+    "author": "klueska",
+    "author_url": "https://github.com/klueska",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116558",
+    "pr_number": 116558,
+    "areas": ["test", "kubelet", "apiserver", "kubectl", "code-generation"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["scheduling", "node", "api-machinery", "apps", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true,
+    "action_required": true
+  },
+  "116571": {
+    "commit": "e660a1702b4955402d629ce518d66b9de1fb1b09",
+    "text": "Migrated the defaultbinder scheduler plugin to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).",
+    "markdown": "Migrated the defaultbinder scheduler plugin to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). ([#116571](https://github.com/kubernetes/kubernetes/pull/116571), [@mengjiao-liu](https://github.com/mengjiao-liu)) [SIG Instrumentation and Scheduling]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging",
+        "type": "KEP"
+      }
+    ],
+    "author": "mengjiao-liu",
+    "author_url": "https://github.com/mengjiao-liu",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116571",
+    "pr_number": 116571,
+    "areas": ["logging"],
+    "kinds": ["feature"],
+    "sigs": ["scheduling", "instrumentation"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116576": {
+    "commit": "f315a4669a5b7a29328e2e98401ebd559d620b60",
+    "text": "api: validation of a PodSpec now rejects invalid ResourceClaim and ResourceClaimTemplate names. For a pod, the name generated for the ResourceClaim when using a template also must be valid.",
+    "markdown": "Api: validation of a PodSpec now rejects invalid ResourceClaim and ResourceClaimTemplate names. For a pod, the name generated for the ResourceClaim when using a template also must be valid. ([#116576](https://github.com/kubernetes/kubernetes/pull/116576), [@pohly](https://github.com/pohly)) [SIG Apps]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/issues/3063",
+        "type": "KEP"
+      }
+    ],
+    "author": "pohly",
+    "author_url": "https://github.com/pohly",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116576",
+    "pr_number": 116576,
+    "kinds": ["cleanup", "api-change"],
+    "sigs": ["apps"],
+    "duplicate_kind": true
+  },
+  "116590": {
+    "commit": "abb632866172ef68baa983afe678f0a4888d8077",
+    "text": "Adding e2e tests for kubectl --subresource for beta graduation",
+    "markdown": "Adding e2e tests for kubectl --subresource for beta graduation ([#116590](https://github.com/kubernetes/kubernetes/pull/116590), [@MadhavJivrajani](https://github.com/MadhavJivrajani)) [SIG CLI and Testing]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource",
+        "type": "KEP"
+      }
+    ],
+    "author": "MadhavJivrajani",
+    "author_url": "https://github.com/MadhavJivrajani",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116590",
+    "pr_number": 116590,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["cli", "testing"],
+    "feature": true,
+    "duplicate": true
+  },
+  "116595": {
+    "commit": "9c2d28f7d55a5210d02b9a3c7dc6449b9e125340",
+    "text": "Change kubectl --subresource flag to beta",
+    "markdown": "Change kubectl --subresource flag to beta ([#116595](https://github.com/kubernetes/kubernetes/pull/116595), [@MadhavJivrajani](https://github.com/MadhavJivrajani)) [SIG CLI]",
+    "documentation": [
+      {
+        "description": "[KEP]",
+        "url": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource",
+        "type": "KEP"
+      }
+    ],
+    "author": "MadhavJivrajani",
+    "author_url": "https://github.com/MadhavJivrajani",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116595",
+    "pr_number": 116595,
+    "areas": ["kubectl"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "116598": {
+    "commit": "6df64241d03cdf0c26137fceda3c39cb9775178c",
+    "text": "Upgrades functionality of `kubectl kustomize` as described at\nhttps://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0 and https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.1. \n\nThis is a new major release of kustomize, so there are a few backwards-incompatible changes, most of which are rare use cases, bug fixes with side effects, or things that have been deprecated for multiple releases already:\n\n- https://github.com/kubernetes-sigs/kustomize/pull/4911: Drop support for a very old, legacy style of patches. patches used to be allowed to be used as an alias for patchesStrategicMerge in kustomize v3. You now have to use patchesStrategicMerge explicitly, or update to the new syntax supported by patches. See examples in the PR description of https://github.com/kubernetes-sigs/kustomize/pull/4911.\n- https://github.com/kubernetes-sigs/kustomize/issues/4731: Remove a potential build-time side-effect in ConfigMapGenerator and SecretGenerator, which loaded values from the local environment under some circumstances, breaking kustomize build's side-effect-free promise. While this behavior was never intended, we deprecated it and are announcing it as a breaking change since it existed for a long time. See also the Eschewed Features documentation.\n- https://github.com/kubernetes-sigs/kustomize/pull/4985: If you previously included .git in an AWS or Azure URL, we will no longer automatically remove that suffix. You may need to add an extra / to replace the .git for the URL to properly resolve.\n- https://github.com/kubernetes-sigs/kustomize/pull/4954: Drop support for using gh: as a host (e.g. gh:kubernetes-sigs/kustomize). We were unable to find any usage of or basis for this and believe it may have been targeting a custom gitconfig shorthand syntax.",
+    "markdown": "Upgrades functionality of `kubectl kustomize` as described at\n  https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0 and https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.1. \n  \n  This is a new major release of kustomize, so there are a few backwards-incompatible changes, most of which are rare use cases, bug fixes with side effects, or things that have been deprecated for multiple releases already:\n  \n  - https://github.com/kubernetes-sigs/kustomize/pull/4911: Drop support for a very old, legacy style of patches. patches used to be allowed to be used as an alias for patchesStrategicMerge in kustomize v3. You now have to use patchesStrategicMerge explicitly, or update to the new syntax supported by patches. See examples in the PR description of https://github.com/kubernetes-sigs/kustomize/pull/4911.\n  - https://github.com/kubernetes-sigs/kustomize/issues/4731: Remove a potential build-time side-effect in ConfigMapGenerator and SecretGenerator, which loaded values from the local environment under some circumstances, breaking kustomize build's side-effect-free promise. While this behavior was never intended, we deprecated it and are announcing it as a breaking change since it existed for a long time. See also the Eschewed Features documentation.\n  - https://github.com/kubernetes-sigs/kustomize/pull/4985: If you previously included .git in an AWS or Azure URL, we will no longer automatically remove that suffix. You may need to add an extra / to replace the .git for the URL to properly resolve.\n  - https://github.com/kubernetes-sigs/kustomize/pull/4954: Drop support for using gh: as a host (e.g. gh:kubernetes-sigs/kustomize). We were unable to find any usage of or basis for this and believe it may have been targeting a custom gitconfig shorthand syntax. ([#116598](https://github.com/kubernetes/kubernetes/pull/116598), [@natasha41575](https://github.com/natasha41575)) [SIG CLI]",
+    "author": "natasha41575",
+    "author_url": "https://github.com/natasha41575",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116598",
+    "pr_number": 116598,
+    "areas": ["kubectl", "dependency"],
+    "kinds": ["feature"],
+    "sigs": ["cli"],
+    "feature": true
+  },
+  "116607": {
+    "commit": "0e8eae6e35a15c89da85c814b31c7118a49941a4",
+    "text": "kube-scheduler: Optimized implementation of null labelSelector in topology spreading.",
+    "markdown": "Kube-scheduler: Optimized implementation of null labelSelector in topology spreading. ([#116607](https://github.com/kubernetes/kubernetes/pull/116607), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]",
+    "author": "alculquicondor",
+    "author_url": "https://github.com/alculquicondor",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116607",
+    "pr_number": 116607,
+    "kinds": ["feature"],
+    "sigs": ["scheduling"],
+    "feature": true
+  },
+  "116610": {
+    "commit": "e8acfc45ba0d4fcea4615c6af86155092224dac3",
+    "text": "Locks CSIMigrationvSphere feature gate.",
+    "markdown": "Locks CSIMigrationvSphere feature gate. ([#116610](https://github.com/kubernetes/kubernetes/pull/116610), [@xing-yang](https://github.com/xing-yang)) [SIG Storage]",
+    "author": "xing-yang",
+    "author_url": "https://github.com/xing-yang",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116610",
+    "pr_number": 116610,
+    "kinds": ["feature"],
+    "sigs": ["storage"],
+    "feature": true
+  },
+  "116612": {
+    "commit": "39c01ded6a4147998c25e141be802db5cc6ca119",
+    "text": "Added validation to ensure that if `service.kubernetes.io/topology-aware-hints` and `service.kubernetes.io/topology-mode` annotations are both set, they are set to the same value.\n- Added deprecation warning if `service.kubernetes.io/topology-aware-hints` annotation is used.",
+    "markdown": "Added validation to ensure that if `service.kubernetes.io/topology-aware-hints` and `service.kubernetes.io/topology-mode` annotations are both set, they are set to the same value.\n  - Added deprecation warning if `service.kubernetes.io/topology-aware-hints` annotation is used. ([#116612](https://github.com/kubernetes/kubernetes/pull/116612), [@robscott](https://github.com/robscott)) [SIG Apps, Network and Testing]",
+    "author": "robscott",
+    "author_url": "https://github.com/robscott",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116612",
+    "pr_number": 116612,
+    "areas": ["test"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["network", "apps", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  },
+  "116621": {
+    "commit": "74123a734123d7197ce55d061e9422a4f87f7b20",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116621](https://github.com/kubernetes/kubernetes/pull/116621), [@moshe010](https://github.com/moshe010)) [SIG Node]",
+    "author": "moshe010",
+    "author_url": "https://github.com/moshe010",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116621",
+    "pr_number": 116621,
+    "areas": ["kubelet"],
+    "kinds": ["cleanup"],
+    "sigs": ["node"],
+    "do_not_publish": true
+  },
+  "116631": {
+    "commit": "742316ee2136b24b9edb0bb0d5bf69a6bad6f364",
+    "text": "```\n\n#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n\n\u003c!--\nThis section can be blank if this pull request does not require a release note.\n\nWhen adding links which point to resources within git repositories, like\nKEPs or supporting documentation, please reference a specific commit and avoid\nlinking directly to the master branch. This ensures that links reference a\nspecific point in time, rather than a document that may change over time.\n\nSee here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n\nPlease use the following format for linking documentation:\n- [KEP]: \u003clink\u003e\n- [Usage]: \u003clink\u003e\n- [Other doc]: \u003clink\u003e\n--\u003e",
+    "markdown": "```\n  \n  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:\n  \n  \u003c!--\n  This section can be blank if this pull request does not require a release note.\n  \n  When adding links which point to resources within git repositories, like\n  KEPs or supporting documentation, please reference a specific commit and avoid\n  linking directly to the master branch. This ensures that links reference a\n  specific point in time, rather than a document that may change over time.\n  \n  See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files\n  \n  Please use the following format for linking documentation:\n  - [KEP]: \u003clink\u003e\n  - [Usage]: \u003clink\u003e\n  - [Other doc]: \u003clink\u003e\n  --\u003e ([#116631](https://github.com/kubernetes/kubernetes/pull/116631), [@bobbypage](https://github.com/bobbypage)) [SIG Node and Testing]",
+    "author": "bobbypage",
+    "author_url": "https://github.com/bobbypage",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/116631",
+    "pr_number": 116631,
+    "areas": ["test"],
+    "kinds": ["feature"],
+    "sigs": ["node", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "do_not_publish": true
+  },
+  "96120": {
+    "commit": "89a9c0c8bbe2715e597e044cd92f52978d51491b",
+    "text": "Adds feature gate `NodeLogQuery` which provides cluster administrators with a streaming view of logs using kubectl without them having to implement a client side reader or logging into the node.",
+    "markdown": "Adds feature gate `NodeLogQuery` which provides cluster administrators with a streaming view of logs using kubectl without them having to implement a client side reader or logging into the node. ([#96120](https://github.com/kubernetes/kubernetes/pull/96120), [@LorbusChris](https://github.com/LorbusChris)) [SIG API Machinery, Apps, CLI, Node, Testing and Windows]",
+    "author": "LorbusChris",
+    "author_url": "https://github.com/LorbusChris",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/96120",
+    "pr_number": 96120,
+    "areas": ["test", "kubelet", "kubectl", "code-generation", "dependency"],
+    "kinds": ["api-change", "feature"],
+    "sigs": ["node", "api-machinery", "apps", "windows", "cli", "testing"],
+    "feature": true,
+    "duplicate": true,
+    "duplicate_kind": true
+  }
+}

--- a/src/environments/assets.ts
+++ b/src/environments/assets.ts
@@ -1,4 +1,5 @@
 export const assets = [
+  'assets/release-notes-1.27.0-beta.0.json',
   'assets/release-notes-1.27.0-alpha.3.json',
   'assets/release-notes-1.27.0-alpha.2.json',
   'assets/release-notes-1.27.0-alpha.1.json',


### PR DESCRIPTION
Automated patch to update relnotes.k8s.io to k/k version `v1.27.0-beta.0` 