### PR TITLE
Fix markdown regex

### DIFF
--- a/src/app/notes/notes.component.ts
+++ b/src/app/notes/notes.component.ts
@@ -120,8 +120,8 @@ export class NotesComponent implements OnInit {
    * @returns The resulting markdown as string
    */
   public saneMarkdown(markdown: string): string {
-    // remove trailing "(#…, @…) [SIG …]"
-    return markdown.replace(/ \(.*\) \[SIG .*\]$/, '');
+    // remove trailing "([#…](…), [@…](…)) [SIG …]"
+    return markdown.replace(/  \(\[\#\d+\]\(.*\)\) \[SIG .*\]$/, '');
   }
 
   /**


### PR DESCRIPTION
The regular expression is too loose and will match something like:

```
Dynamic Resource Allocation (DRA): Added a feature so the…
```

Which then strips the markdown text down to:

```
Dynamic Resource Allocation
```

We now make the regex more specific to fix that issue.

cc @kubernetes-sigs/release-engineering 

Fixes https://github.com/kubernetes-sigs/release-notes/issues/652


Demo: https://deploy-preview-653--kubernetes-sigs-release-notes.netlify.app/?markdown=120611%20