### PR TITLE
Normalize release notes CDN path only if required

### DIFF
--- a/src/app/notes/notes.service.ts
+++ b/src/app/notes/notes.service.ts
@@ -103,10 +103,11 @@ export class NotesService {
    * @returns Transformed URL
    */
   private cdnLinkFromGsPath(path: string): string {
+    // Normalize the link if required
     const regex = /^gs:\/\/[\w-/.]*\.json$/;
-    if (!path.match(regex)) {
-      throw new Error(`Asset path from remote index "${path}" does not match regex ${regex}`);
+    if (path.match(regex)) {
+      return path.replace(/^gs:\/\/[\w-]*\//, 'https://cdn.dl.k8s.io/');
     }
-    return path.replace(/^gs:\/\/[\w-]*\//, 'https://cdn.dl.k8s.io/');
+    return path;
   }
 }


### PR DESCRIPTION
This allows to work on either `gs://` prefixed release notes paths or already resolved URLs.

Refers to https://github.com/kubernetes/release/issues/3720

PTAL @kubernetes-sigs/release-engineering 