### PR TITLE
Remove `as any` type assertions from NgRx reducers

### DIFF
--- a/src/app/app.reducer.ts
+++ b/src/app/app.reducer.ts
@@ -10,7 +10,7 @@ export interface State {
 }
 
 export const reducers: ActionReducerMap<State> = {
-  filter: filterReducer as any,
-  notes: notesReducer as any,
-  settings: settingsReducer as any,
+  filter: filterReducer,
+  notes: notesReducer,
+  settings: settingsReducer,
 };

--- a/src/app/filter/filter.reducer.ts
+++ b/src/app/filter/filter.reducer.ts
@@ -1,5 +1,5 @@
-import { createSelector } from '@ngrx/store';
-import { ActionTypes, FilterAction } from './filter.actions';
+import { Action, createSelector } from '@ngrx/store';
+import { ActionTypes, Failed, UpdateFilterSuccess } from './filter.actions';
 import { Filter } from '@app/shared/model/filter.model';
 import { State as RootState } from '@app/app.reducer';
 
@@ -13,19 +13,19 @@ export const initialState: State = {
   filter: new Filter(),
 };
 
-export function filterReducer(state = initialState, action: FilterAction): State {
+export function filterReducer(state = initialState, action: Action): State {
   switch (action.type) {
     case ActionTypes.UpdateFilterSuccess: {
       return {
         ...state,
-        filter: action.filter,
+        filter: (action as UpdateFilterSuccess).filter,
       };
     }
 
     case ActionTypes.Failed: {
       return {
         ...state,
-        error: action.error,
+        error: (action as Failed).error,
       };
     }
 

--- a/src/app/notes/notes.reducer.ts
+++ b/src/app/notes/notes.reducer.ts
@@ -1,5 +1,5 @@
-import { createSelector } from '@ngrx/store';
-import { ActionTypes, NotesAction } from './notes.actions';
+import { Action, createSelector } from '@ngrx/store';
+import { ActionTypes, DoFilterSuccess, Failed, GetNotesSuccess } from './notes.actions';
 import { Note } from '@app/shared/model/notes.model';
 import { State as RootState } from '@app/app.reducer';
 
@@ -17,7 +17,7 @@ export const initialState: State = {
   notes: [],
 };
 
-export function notesReducer(state = initialState, action: NotesAction): State {
+export function notesReducer(state = initialState, action: Action): State {
   switch (action.type) {
     case ActionTypes.GetNotes: {
       return {
@@ -29,7 +29,7 @@ export function notesReducer(state = initialState, action: NotesAction): State {
     case ActionTypes.GetNotesSuccess: {
       return {
         ...state,
-        notes: action.payload,
+        notes: (action as GetNotesSuccess).payload,
       };
     }
 
@@ -43,14 +43,14 @@ export function notesReducer(state = initialState, action: NotesAction): State {
     case ActionTypes.DoFilterSuccess: {
       return {
         ...state,
-        filteredNotes: action.notes,
+        filteredNotes: (action as DoFilterSuccess).notes,
       };
     }
 
     case ActionTypes.Failed: {
       return {
         ...state,
-        error: action.error,
+        error: (action as Failed).error,
         loading: false,
       };
     }

--- a/src/app/settings/settings.reducer.ts
+++ b/src/app/settings/settings.reducer.ts
@@ -1,5 +1,5 @@
-import { createSelector } from '@ngrx/store';
-import { ActionTypes, SettingsAction } from './settings.actions';
+import { Action, createSelector } from '@ngrx/store';
+import { ActionTypes, Failed, UpdateSettingsSuccess } from './settings.actions';
 import { Settings } from '@app/shared/model/settings.model';
 import { State as RootState } from '@app/app.reducer';
 
@@ -13,19 +13,19 @@ export const initialState: State = {
   settings: new Settings(),
 };
 
-export function settingsReducer(state = initialState, action: SettingsAction): State {
+export function settingsReducer(state = initialState, action: Action): State {
   switch (action.type) {
     case ActionTypes.UpdateSettingsSuccess: {
       return {
         ...state,
-        settings: action.settings,
+        settings: (action as UpdateSettingsSuccess).settings,
       };
     }
 
     case ActionTypes.Failed: {
       return {
         ...state,
-        error: action.error,
+        error: (action as Failed).error,
       };
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,9 +27,9 @@ bootstrapApplication(AppComponent, {
     provideHttpClient(),
     provideStore(
       {
-        filter: filterReducer as any,
-        notes: notesReducer as any,
-        settings: settingsReducer as any,
+        filter: filterReducer,
+        notes: notesReducer,
+        settings: settingsReducer,
       },
       {
         runtimeChecks: {


### PR DESCRIPTION
## Summary
- Widen reducer action parameter types from narrow union types to base `Action`
- Use explicit type casts in switch case branches where action properties are accessed
- Remove all `as any` assertions from `app.reducer.ts` and `main.ts`